### PR TITLE
Dealing with the aggregation of texts including . and $

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - [TASK] Including documentation about the new 'Comet' name
 - [TASK] Including Apiary documentation for the STH component
+- [BUG] Dealing with the aggregation of texts including the '.' and '$' characters

--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ It is important to note that if a valid query is made but it returns no data (fo
 for the specified time frame), a response with code `200` is returned including an empty `values` property array, since it is a valid
 query.
 
+Another very important aspect is that since the strings are used as properties in the generated aggregated data, the [limitations
+to this regard imposed by MongoDB](https://docs.mongodb.org/manual/faq/developers/#dollar-sign-operator-escaping) must be followed. More concretely: "In some cases, you may wish to build a BSON object with a user-provided key. 
+In these situations, keys will need to substitute the reserved $ and . characters. Any character is sufficient, but consider
+using the Unicode full width equivalents: U+FF04 (i.e. “＄”) and U+FF0E (i.e. “．”).". Consequently, take into consideration
+that if the textual values stored in the attributes for which aggregated data is being generated contain the `$` or the `.` characters,
+they will be substituted for their Javascript Unicode full width equivalents, this is: `\uFF04` instead of `$` and `\uFF0E`
+instead of `.`.
+
 [Top](#section0)
 
 ###<a id="section1.4"></a> Updating aggregated time series information

--- a/src/sth_database.js
+++ b/src/sth_database.js
@@ -710,7 +710,8 @@
    */
   function getAggregateUpdate4Update(attrType, attrValue, resolution, recvTime) {
     var aggregateUpdate4Update,
-        attrValueAsNumber;
+        attrValueAsNumber,
+        escapedAttrValue;
     if (!isNaN(attrValue)) {
       attrValueAsNumber = parseFloat(attrValue);
       aggregateUpdate4Update = {
@@ -739,9 +740,11 @@
           'points.$.samples': 1
         }
       };
+      escapedAttrValue = attrValue.replace(/\$/g,'\uFF04').
+        replace(/\./g, '\uFF0E');
       aggregateUpdate4Update['$inc']['points.' +
         (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
-        '.occur.' + attrValue] = 1;
+        '.occur.' + escapedAttrValue] = 1;
     }
     return aggregateUpdate4Update;
   }


### PR DESCRIPTION
Due to https://docs.mongodb.org/manual/faq/developers/#dollar-sign-operator-escaping and the fact that the texts being aggregated are used as properties in the aggregated data stored in MongoDB.

- 100% tests passed
- Assigned to @frbattid 