### PR TITLE
Slash (/) not allowed in MongoDB connection URLs after the database name when replica set

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [BUG] Slash (/) not allowed in MongoDB connection URLs after the database name when replica set

--- a/lib/sth_database.js
+++ b/lib/sth_database.js
@@ -97,7 +97,7 @@ function getJSONCSVOptions(attrName) {
  */
 function connect(params, callback) {
   connectionURL = 'mongodb://' + params.authentication + '@' + params.dbURI + '/' + params.database +
-    (params.replicaSet ? '/?replicaSet=' + params.replicaSet : '');
+    (params.replicaSet ? '?replicaSet=' + params.replicaSet : '');
 
   mongoClient.connect(connectionURL,
     {


### PR DESCRIPTION
- No linting issues
- 100% tests passed