### PR TITLE
fix/not_logs_to_stdout_init_script

### DIFF
--- a/rpm/SOURCES/etc/init.d/sth
+++ b/rpm/SOURCES/etc/init.d/sth
@@ -103,7 +103,7 @@ component_start()
             continue
         fi
 
-        su ${COMPONENT_USER} -p -c "${NODE_EXEC} ${COMPONENT_DIR}/bin/sth ${instance} 2>&1 | tee -a ${LOG_DIR}/${NAME}.log & echo \$! > ${STH_PID_FILE}"
+        su ${COMPONENT_USER} -p -c "${NODE_EXEC} ${COMPONENT_DIR}/bin/sth ${instance} 2>&1 >> ${LOG_DIR}/${NAME}.log & echo \$! > ${STH_PID_FILE}"
         sleep 2 # some cortesy time to process startup or die
         local PID=$(cat ${STH_PID_FILE})        
         local STH_PID=$(ps -ef | grep -v "grep" | grep "${PID:-not_found}")


### PR DESCRIPTION
After, we need apply these changes to release/0.9.0
We detect if we started STH with append log with tee, Ansible not work correctly and fail
