### PR TITLE
Make the unit tests compatible with v4.* of Node.js (also backward compatible with v0.10.42)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -16,3 +16,4 @@
 - [FEATURE] Include the possibility to provide a dictionary to map collection names to collection associated data
 - [FEATURE] Include the option to set the number of documents in collections to show the progress of the migration
 - [BUG] Continue the migration process if -f and a not supported migration collection is found
+- [FEATURE] Make the unit tests compatible with v4.* of Node.js (also backward compatible with v0.10.42)

--- a/test/unit/sth_database_test.js
+++ b/test/unit/sth_database_test.js
@@ -1327,7 +1327,7 @@ describe('sth_database tests', function() {
       sthDatabase.connect(INVALID_DATABASE_CONNECTION_PARAMS, function(err, connection) {
         expect(err).to.exist;
         expect(err.name).to.equal('MongoError');
-        expect(err.message).to.equal('getaddrinfo ENOTFOUND');
+        expect(err.message.indexOf('getaddrinfo ENOTFOUND')).to.equal(0);
         expect(connection).to.equal(null);
         done();
       });
@@ -1339,7 +1339,7 @@ describe('sth_database tests', function() {
       sthDatabase.connect(INVALID_DATABASE_CONNECTION_PARAMS, function(err, connection) {
         expect(err).to.exist;
         expect(err.name).to.equal('MongoError');
-        expect(err.message).to.equal('connect ECONNREFUSED');
+        expect(err.message.indexOf('connect ECONNREFUSED')).to.equal(0);
         expect(connection).to.equal(null);
         done();
       });


### PR DESCRIPTION
- No linting issues.
- 100% tests passed.