### PR TITLE
Deprecated mongodb dependencies #449

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+Upgrade hapi to 16.0.0

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -95,9 +95,7 @@ function connect(params, callback) {
   );
   mongoClient.connect(connectionURL,
     {
-      server: {
-        poolSize: params.poolSize
-      }
+      poolSize: params.poolSize
     },
     function (err, theDB) {
       if (!err) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bytes-counter": "~1.0.0",
     "commander": "~2.9.0",
     "csv-parser": "~1.9.3",
-    "hapi": "~11.1.3",
+    "hapi": "~16.0.0",
     "joi": "~5.1.0",
     "json-csv": "~1.2.0",
     "lodash": "~4.17.5",


### PR DESCRIPTION
The server option is deprecated, It is supported at the top level of the options object.

The following issue https://github.com/telefonicaid/fiware-sth-comet/issues/449 is fixed by removing the server option from mongoClient.connect() method.

The server option falls under the legacy option names and has been deprecated. 
Please refer to the following file [mongo_client.js](https://github.com/mongodb/node-mongodb-native/blob/v2.2.36/lib/mongo_client.js) 

File modified: [sthDatabase.js](https://github.com/telefonicaid/fiware-sth-comet/blob/master/lib/database/sthDatabase.js)

**Before**
`mongoClient.connect(connectionURL,
    {
      server: {
        poolSize: params.poolSize
      }
    },`

**After**
 `  mongoClient.connect(connectionURL,
    {
      poolSize: params.poolSize
    },`



### **Update** 
This request also addresses the following issue: [#455](https://github.com/telefonicaid/fiware-sth-comet/issues/455)

os.tmpdir() returns a string specifying the operating system's default directory for temporary files. It was deprecated after node v7.0.0. 
This method is used by hapi module at /node_modules/hapi/lib/defaults.js. hapi version currently used in sth-comet is 11.1.3
As this version is not present on the branch, we cannot make or propose changes to this file. We’ll have to upgrade the hapi version.
The deprecation issue has been fixed in the new version of hapi. Updating the version of hapi in the package.json file of sth-comet removes the deprecation warning. (v16 or higher is recommended.)

**Note:** 
Please delete the existing folder of hapi under/node_modules directory where sth-comet is installed and then change the version of hapi in package.json file. Run the command `npm install hapi` before running sth-comet

File modified: [package.json](https://github.com/telefonicaid/fiware-sth-comet/blob/master/package.json)

**Before**
`"hapi": "~11.1.3",`

**After**
`"hapi": "~16.0.0",`