### PR TITLE
Support to metadata values

### DIFF
--- a/config.js
+++ b/config.js
@@ -48,7 +48,10 @@ config.server = {
   // Default value: "temp".
   temporalDir: 'temp',
   // Max page size returned by a query
-  maxPageSize: '100'
+  maxPageSize: '100',
+  // Enable/disable attribute metadata support
+  attributeMetadataSupport: true,
+  metadataNameSeparator: "___"
 };
 
 // Database configuration

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -696,6 +696,9 @@ if (ENV.PROOF_OF_LIFE_INTERVAL && !isNaN(ENV.PROOF_OF_LIFE_INTERVAL)) {
   );
 }
 
+module.exports.ATTRIBUTE_METADATA_SUPPORT = ENV.ATTRIBUTE_METADATA_SUPPORT || config.server.attributeMetadataSupport || true;
+module.exports.METADATA_NAME_SEPARATOR = ENV.METADATA_NAME_SEPARATOR || config.server.metadataNameSeparator || '___';
+
 sthLogger.info(
   module.exports.LOGGING_CONTEXT.STARTUP,
   'STH component configuration successfully completed'

--- a/lib/server/handlers/sthNotificationHandler.js
+++ b/lib/server/handlers/sthNotificationHandler.js
@@ -42,6 +42,14 @@ function getTotalAttributes(contextResponses) {
       contextResponses[l1].contextElement.attributes &&
       Array.isArray(contextResponses[l1].contextElement.attributes)) {
       totalAttributes += contextResponses[l1].contextElement.attributes.length;
+      if (sthConfig.ATTRIBUTE_METADATA_SUPPORT) {
+        for (var j = 0; j < contextResponses[l1].contextElement.attributes.length; j++) {
+          if (contextResponses[l1].contextElement.attributes[j].metadatas &&
+              Array.isArray(contextResponses[l1].contextElement.attributes[j].metadatas)) {
+            totalAttributes += contextResponses[l1].contextElement.attributes[j].metadatas.length;
+          }
+        }
+      }
     }
   }
   return totalAttributes;
@@ -415,7 +423,7 @@ function processAttribute(data, reply) {
  * @param {Function} reply    The reply function provided by the hapi server
  */
 function processNotification(recvTime, request, reply) {
-  var contextElement, attributes;
+  var contextElement, attributes, metadatas;
 
   // An object is needed since Javascript implements calls-by-sharing
   //  (see http://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing) and the counter is shared between
@@ -461,6 +469,27 @@ function processNotification(recvTime, request, reply) {
           },
           reply
         );
+
+        if (sthConfig.ATTRIBUTE_METADATA_SUPPORT && 
+            attributes[j].metadatas && 
+            Array.isArray(attributes[j].metadatas)) {
+          metadatas = attributes[j].metadatas;
+          for (var k = 0; k < metadatas.length; k++) {
+            metadatas[k].name = attributes[j].name + sthConfig.METADATA_NAME_SEPARATOR + metadatas[k].name;
+            processAttribute(
+              {
+                request: request,
+                contextElement: contextElement,
+                attribute: metadatas[k],
+                recvTime: recvTime,
+                counterObj: counterObj,
+                totalTasks: totalTasks
+              },
+              reply
+            );
+          }
+        }
+
       }
     }
   }


### PR DESCRIPTION
Store metadata values in the same type of structure that attribute values are stored.

On this implementation, metadata values are also stored in Comet. The metadata name is identified by its attribute name, a separator and the metadata name. For example: "attributeName___metadataName".
The separator can be customized in the config.js file.

As example, when the following values (attribute+metadata) are appended to Orion 
`"attributes": [
				{
					"name": "temperature",
					"type": "temperature ",
					"value": "23.00",
					"metadatas": [
						{
							"name": "latitude",
							"type": "integer",
							"value": "46.94242"
						}
					]
				}`

they will be inserted in STH Comet as 
`{
	"_id" : ObjectId("5bf80ebd893d542401afbd77"),
	"recvTime" : ISODate("2018-11-23T14:29:17.451Z"),
	"attrName" : "temperature",
	"attrType" : "temperature ",
	"attrValue" : "23.00"
}
`
`{
	"_id" : ObjectId("5bf80ebd893d542401afbd7a"),
	"recvTime" : ISODate("2018-11-23T14:29:17.451Z"),
	"attrName" : "temperature___latitude",
	"attrType" : "integer",
	"attrValue" : "46.94242"
}
`

We had this metadata support as a requirement on certain scenarios in CPaaS.io project ( https://cpaas.bfh.ch ). 
