### PR TITLE
Add code coverage badge to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,6 @@ install:
 
 before_script:
  - npm run lint
+
+after_script: 
+  - npm run test:coveralls

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 [![Docker badge](https://img.shields.io/docker/pulls/fiware/sth-comet.svg)](https://hub.docker.com/r/fiware/sth-comet-ngsi/)
 [![](https://img.shields.io/badge/tag-fiware--sth-comet-orange.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/fiware-sth-comet)
 [![Support badge]( https://img.shields.io/badge/support-askbot-yellowgreen.svg)](https://ask.fiware.org/questions/scope%3Aall/tags%3Asth-comet/)
+[![Join the chat at https://gitter.im/telefonicaid/fiware-sth-comet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/telefonicaid/fiware-sth-comet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 <br/>
 [![Documentation badge](https://readthedocs.org/projects/fiware-sth-comet/badge/?version=latest)](http://fiware-sth-comet.rtfd.io)
 [![Build badge](https://img.shields.io/travis/telefonicaid/fiware-sth-comet.svg)](https://travis-ci.org/telefonicaid/fiware-sth-comet/)
+[![Coverage Status](https://coveralls.io/repos/github/telefonicaid/fiware-sth-comet/badge.svg?branch=master)](https://coveralls.io/github/telefonicaid/fiware-sth-comet?branch=master)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/cygnus.svg)
-[![Join the chat at https://gitter.im/telefonicaid/fiware-sth-comet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/telefonicaid/fiware-sth-comet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 
 The **FIWARE Short Time Historic (STH) - Comet** is in charge of managing (storing and retrieving) historical raw and aggregated time series context information about the evolution in time of context data (i.e., entity attribute values) registered in an [Orion Context Broker](https://github.com/telefonicaid/fiware-orion) instance.
 

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
+    "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "devDependencies": {
     "jshint": "~2.9.6",
     "clear-require": "~1.0.1",
+    "coveralls": "^3.0.2",
     "expect.js": "~0.3.1",
     "istanbul": "~0.4.5",
     "mocha": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "jshint": "~2.9.6",
     "clear-require": "~1.0.1",
-    "coveralls": "^3.0.2",
+    "coveralls": "~3.0.2",
     "expect.js": "~0.3.1",
     "istanbul": "~0.4.5",
     "mocha": "5.2.0",


### PR DESCRIPTION
Expose Code Coverage results to Coveralls. Runs `npm test:coverage` after the unit tests and then sends the results to [coveralls](https://coveralls.io)

the repo needs to be exposed on coveralls as well (obviously) - see https://coveralls.io/repos/new

- SHOULD requirement from TSC