### PR TITLE
Correct test coverage invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
-    "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
+    "test:coverage": "istanbul cover _mocha -- --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },


### PR DESCRIPTION
Enabling code coverage  #481  exposes an error in the `test:coverage` script itself - the parameters should match `test`, but  they don't.

If you run `npm test:coverage` locally the tests will fail, with this fix the tests will (hopefully) complete execution.