### PR TITLE
Add prettier code formatting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,7 @@
 	"camelcase": true,
 	"maxlen": 120,
         "esversion": 6,
-	"node": true
+	"node": true,
+	"laxbreak": true,
+	"quotmark": 0
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,6 +4,6 @@
   "singleQuote": true,
   "parser": "flow",
   "printWidth": 120,
-  "trailingComma": "es5",
+  "trailingComma": "none",
   "tabWidth": 4
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "singleQuote": true,
+  "parser": "flow",
+  "printWidth": 120,
+  "trailingComma": "es5",
+  "tabWidth": 4
+}

--- a/config.js
+++ b/config.js
@@ -26,127 +26,127 @@ var config = {};
 // STH server configuration
 //--------------------------
 config.server = {
-  // The host where the STH server will be started.
-  // Default value: "localhost".
-  host: 'localhost',
-  // The port where the STH server will be listening.
-  // Default value: "8666".
-  port: '8666',
-  // The service to be used if not sent by the Orion Context Broker in the notifications.
-  // Default value: "testservice".
-  defaultService: 'testservice',
-  // The service path to be used if not sent by the Orion Context Broker in the notifications.
-  // Default value: "/testservicepath".
-  defaultServicePath: '/testservicepath',
-  // A flag indicating if the empty results should be removed from the response.
-  // Default value: "true".
-  filterOutEmpty: 'true',
-  // Array of resolutions the STH component should aggregate values for.
-  // Valid resolution values are: 'month', 'day', 'hour', 'minute' and 'second'
-  aggregationBy: ['day', 'hour', 'minute'],
-  // Directory where temporary files will be stored, such as the ones generated when CSV files are requested.
-  // Default value: "temp".
-  temporalDir: 'temp',
-  // Max page size returned by a query
-  maxPageSize: '100',
+    // The host where the STH server will be started.
+    // Default value: "localhost".
+    host: 'localhost',
+    // The port where the STH server will be listening.
+    // Default value: "8666".
+    port: '8666',
+    // The service to be used if not sent by the Orion Context Broker in the notifications.
+    // Default value: "testservice".
+    defaultService: 'testservice',
+    // The service path to be used if not sent by the Orion Context Broker in the notifications.
+    // Default value: "/testservicepath".
+    defaultServicePath: '/testservicepath',
+    // A flag indicating if the empty results should be removed from the response.
+    // Default value: "true".
+    filterOutEmpty: 'true',
+    // Array of resolutions the STH component should aggregate values for.
+    // Valid resolution values are: 'month', 'day', 'hour', 'minute' and 'second'
+    aggregationBy: ['day', 'hour', 'minute'],
+    // Directory where temporary files will be stored, such as the ones generated when CSV files are requested.
+    // Default value: "temp".
+    temporalDir: 'temp',
+    // Max page size returned by a query
+    maxPageSize: '100',
 };
 
 // Database configuration
 //------------------------
 config.database = {
-  // The STH component supports 3 alternative models when storing the raw and aggregated data
-  // into the database: 1) one collection per attribute, 2) one collection per entity and
-  // 3) one collection per service path. The possible values are: "collection-per-attribute",
-  // "collection-per-entity" and "collection-per-service-path" respectively. Default value:
-  // "collection-per-entity".
-  dataModel: 'collection-per-entity',
-  // The username to use for the database connection. Default value: "".
-  user: '',
-  // The password to use for the database connection. Default value: "".
-  password: '',
-  // The URI to use for the database connection. It supports replica set URIs. This does not
-  // include the "mongo://" protocol part. Default value: "localhost:27017"
-  URI: 'localhost:27017',
-  // The name of the replica set to connect to, if any. Default value: "".
-  replicaSet: '',
-  // The prefix to be added to the service for the creation of the databases. Default value: "sth".
-  prefix: 'sth_',
-  // The prefix to be added to the collections in the databases. More information below.
-  //  Default value: "sth_".
-  collectionPrefix: 'sth_',
-  // The default MongoDB pool size of database connections. Optional. Default value: "5".
-  poolSize: '5',
-  // The write concern (see http://docs.mongodb.org/manual/core/write-concern/) to apply when
-  // writing data to the MongoDB database. Default value: "1".
-  writeConcern: '1',
-  // Flag indicating if the raw and/or aggregated data should be persisted. Valid values are:
-  // "only-raw", "only-aggregated" and "both". Default value: "both".
-  shouldStore: 'both',
-  truncation: {
-    // Data from the raw and aggregated data collections will be removed if older than the value specified in seconds.
-    // Set the value to 0 or remove the property entry not to apply this time-based truncation policy.
-    // Default value: "0".
-    expireAfterSeconds: '0',
-    // The oldest raw data (according to insertion time) will be removed if the size of the raw data collection
-    // gets bigger than the value specified in bytes. In case of raw data the reference time is the one stored in the
-    // 'recvTime' property whereas in the case of the aggregated data the reference of time is the one stored in the
-    // '_id.origin' property. Set the value to 0 or remove the property entry not to apply this truncation policy.
-    // Default value: "0".
-    // The "size" configuration parameter is mandatory in case size collection truncation is desired as required by
-    // MongoDB.
-    // Notice that this configuration parameter does not affect the aggregated data collections since MongoDB does not
-    // currently support updating documents in capped collections which increase the size of the documents.
-    // Notice also that in case of the raw data, the size-based truncation policy takes precedence over the TTL one.
-    // More concretely, if "size" is set, the value of "exporeAfterSeconds" is ignored for the raw data collections
-    // since currently MongoDB does not support TTL in capped collections.
-    size: '0',
-    // The oldest raw data (according to insertion time) will be removed if the number of documents in the raw data
-    // collections goes beyond the specified value. Set the value to 0 or remove the property entry not to apply this
-    // truncation policy. Default value: "0".
-    // Notice that this configuration parameter does not affect the aggregated data collections since MongoDB does not
-    // currently support updating documents in capped collections which increase the size of the documents.
-    max: '0',
-  },
-  // Attribute values to one or more blank spaces should be ignored and not processed either as raw data or for
-  // the aggregated computations. Default value: "true".
-  ignoreBlankSpaces: 'true',
-  // Database and collection names have to respect the limitations imposed by MongoDB (see
-  // https://docs.mongodb.com/manual/reference/limits/). To it, the STH provides 2 main mechanisms: mappings and
-  // encoding which can be configured using the next 2 configuration parameters.
-  // The mappings mechanism will substitute the original services, service paths, entity and attribute names and types
-  // by the ones defined in the configuration file. If enabled, the mappings mechanism will be the one applied.
-  nameMapping: {
+    // The STH component supports 3 alternative models when storing the raw and aggregated data
+    // into the database: 1) one collection per attribute, 2) one collection per entity and
+    // 3) one collection per service path. The possible values are: "collection-per-attribute",
+    // "collection-per-entity" and "collection-per-service-path" respectively. Default value:
+    // "collection-per-entity".
+    dataModel: 'collection-per-entity',
+    // The username to use for the database connection. Default value: "".
+    user: '',
+    // The password to use for the database connection. Default value: "".
+    password: '',
+    // The URI to use for the database connection. It supports replica set URIs. This does not
+    // include the "mongo://" protocol part. Default value: "localhost:27017"
+    URI: 'localhost:27017',
+    // The name of the replica set to connect to, if any. Default value: "".
+    replicaSet: '',
+    // The prefix to be added to the service for the creation of the databases. Default value: "sth".
+    prefix: 'sth_',
+    // The prefix to be added to the collections in the databases. More information below.
+    //  Default value: "sth_".
+    collectionPrefix: 'sth_',
+    // The default MongoDB pool size of database connections. Optional. Default value: "5".
+    poolSize: '5',
+    // The write concern (see http://docs.mongodb.org/manual/core/write-concern/) to apply when
+    // writing data to the MongoDB database. Default value: "1".
+    writeConcern: '1',
+    // Flag indicating if the raw and/or aggregated data should be persisted. Valid values are:
+    // "only-raw", "only-aggregated" and "both". Default value: "both".
+    shouldStore: 'both',
+    truncation: {
+        // Data from the raw and aggregated data collections will be removed if older than the value specified in seconds.
+        // Set the value to 0 or remove the property entry not to apply this time-based truncation policy.
+        // Default value: "0".
+        expireAfterSeconds: '0',
+        // The oldest raw data (according to insertion time) will be removed if the size of the raw data collection
+        // gets bigger than the value specified in bytes. In case of raw data the reference time is the one stored in the
+        // 'recvTime' property whereas in the case of the aggregated data the reference of time is the one stored in the
+        // '_id.origin' property. Set the value to 0 or remove the property entry not to apply this truncation policy.
+        // Default value: "0".
+        // The "size" configuration parameter is mandatory in case size collection truncation is desired as required by
+        // MongoDB.
+        // Notice that this configuration parameter does not affect the aggregated data collections since MongoDB does not
+        // currently support updating documents in capped collections which increase the size of the documents.
+        // Notice also that in case of the raw data, the size-based truncation policy takes precedence over the TTL one.
+        // More concretely, if "size" is set, the value of "exporeAfterSeconds" is ignored for the raw data collections
+        // since currently MongoDB does not support TTL in capped collections.
+        size: '0',
+        // The oldest raw data (according to insertion time) will be removed if the number of documents in the raw data
+        // collections goes beyond the specified value. Set the value to 0 or remove the property entry not to apply this
+        // truncation policy. Default value: "0".
+        // Notice that this configuration parameter does not affect the aggregated data collections since MongoDB does not
+        // currently support updating documents in capped collections which increase the size of the documents.
+        max: '0',
+    },
+    // Attribute values to one or more blank spaces should be ignored and not processed either as raw data or for
+    // the aggregated computations. Default value: "true".
+    ignoreBlankSpaces: 'true',
+    // Database and collection names have to respect the limitations imposed by MongoDB (see
+    // https://docs.mongodb.com/manual/reference/limits/). To it, the STH provides 2 main mechanisms: mappings and
+    // encoding which can be configured using the next 2 configuration parameters.
+    // The mappings mechanism will substitute the original services, service paths, entity and attribute names and types
+    // by the ones defined in the configuration file. If enabled, the mappings mechanism will be the one applied.
+    nameMapping: {
+        // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
+        enabled: 'false',
+        // The path from the root of the STH component Node application to the mappings configuration file
+        configFile: './name-mapping.json',
+    },
+    // The encoding criteria is the following one:
+    // 1. Encode the forbidden characters using an escaping character (x) and a numerical Unicode code for each character.
+    //    For instance, the / character will be encoded as x002f.
+    // 2. Database and collection names already using the above encoding must be escaped prepending another x,
+    //    for instance, the text x002a will be encoded as xx002a.
+    // 3. The uppercase characters included in database names will be encoded using the mechanism stated in 1.
+    // 4. Collection names starting with 'system.' will be encoded as 'xsystem.'. For instance, system.myData will be
+    //    encoded as xsystem.myData.
     // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
-    enabled: 'false',
-    // The path from the root of the STH component Node application to the mappings configuration file
-    configFile: './name-mapping.json',
-  },
-  // The encoding criteria is the following one:
-  // 1. Encode the forbidden characters using an escaping character (x) and a numerical Unicode code for each character.
-  //    For instance, the / character will be encoded as x002f.
-  // 2. Database and collection names already using the above encoding must be escaped prepending another x,
-  //    for instance, the text x002a will be encoded as xx002a.
-  // 3. The uppercase characters included in database names will be encoded using the mechanism stated in 1.
-  // 4. Collection names starting with 'system.' will be encoded as 'xsystem.'. For instance, system.myData will be
-  //    encoded as xsystem.myData.
-  // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
-  nameEncoding: 'false',
+    nameEncoding: 'false',
 };
 
 // Logging configuration
 //------------------------
 config.logging = {
-  // The logging level of the messages. Messages with a level equal or superior to this will be logged.
-  // Accepted values are: "debug", "info", "warn" and "error". Default value: "info".
-  level: 'info',
-  // The logging format:
-  // - "json": writes logs as JSON.
-  // - "dev": for development. Used as the 'de-facto' value when the NODE_ENV variable is set to 'development'.
-  // - "pipe": writes logs separating the fields with pipes.
-  format: 'pipe',
-  // The time in seconds between proof of life logging messages informing that the server is up and running normally.
-  // Default value: "60"
-  proofOfLifeInterval: '60',
+    // The logging level of the messages. Messages with a level equal or superior to this will be logged.
+    // Accepted values are: "debug", "info", "warn" and "error". Default value: "info".
+    level: 'info',
+    // The logging format:
+    // - "json": writes logs as JSON.
+    // - "dev": for development. Used as the 'de-facto' value when the NODE_ENV variable is set to 'development'.
+    // - "pipe": writes logs separating the fields with pipes.
+    format: 'pipe',
+    // The time in seconds between proof of life logging messages informing that the server is up and running normally.
+    // Default value: "60"
+    proofOfLifeInterval: '60',
 };
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -48,7 +48,7 @@ config.server = {
     // Default value: "temp".
     temporalDir: 'temp',
     // Max page size returned by a query
-    maxPageSize: '100',
+    maxPageSize: '100'
 };
 
 // Database configuration
@@ -105,7 +105,7 @@ config.database = {
         // truncation policy. Default value: "0".
         // Notice that this configuration parameter does not affect the aggregated data collections since MongoDB does not
         // currently support updating documents in capped collections which increase the size of the documents.
-        max: '0',
+        max: '0'
     },
     // Attribute values to one or more blank spaces should be ignored and not processed either as raw data or for
     // the aggregated computations. Default value: "true".
@@ -119,7 +119,7 @@ config.database = {
         // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
         enabled: 'false',
         // The path from the root of the STH component Node application to the mappings configuration file
-        configFile: './name-mapping.json',
+        configFile: './name-mapping.json'
     },
     // The encoding criteria is the following one:
     // 1. Encode the forbidden characters using an escaping character (x) and a numerical Unicode code for each character.
@@ -130,7 +130,7 @@ config.database = {
     // 4. Collection names starting with 'system.' will be encoded as 'xsystem.'. For instance, system.myData will be
     //    encoded as xsystem.myData.
     // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
-    nameEncoding: 'false',
+    nameEncoding: 'false'
 };
 
 // Logging configuration
@@ -146,7 +146,7 @@ config.logging = {
     format: 'pipe',
     // The time in seconds between proof of life logging messages informing that the server is up and running normally.
     // Default value: "60"
-    proofOfLifeInterval: '60',
+    proofOfLifeInterval: '60'
 };
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -48,7 +48,7 @@ config.server = {
   // Default value: "temp".
   temporalDir: 'temp',
   // Max page size returned by a query
-  maxPageSize: '100'
+  maxPageSize: '100',
 };
 
 // Database configuration
@@ -105,7 +105,7 @@ config.database = {
     // truncation policy. Default value: "0".
     // Notice that this configuration parameter does not affect the aggregated data collections since MongoDB does not
     // currently support updating documents in capped collections which increase the size of the documents.
-    max: '0'
+    max: '0',
   },
   // Attribute values to one or more blank spaces should be ignored and not processed either as raw data or for
   // the aggregated computations. Default value: "true".
@@ -119,7 +119,7 @@ config.database = {
     // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
     enabled: 'false',
     // The path from the root of the STH component Node application to the mappings configuration file
-    configFile: './name-mapping.json'
+    configFile: './name-mapping.json',
   },
   // The encoding criteria is the following one:
   // 1. Encode the forbidden characters using an escaping character (x) and a numerical Unicode code for each character.
@@ -130,7 +130,7 @@ config.database = {
   // 4. Collection names starting with 'system.' will be encoded as 'xsystem.'. For instance, system.myData will be
   //    encoded as xsystem.myData.
   // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
-  nameEncoding: 'false'
+  nameEncoding: 'false',
 };
 
 // Logging configuration
@@ -146,7 +146,7 @@ config.logging = {
   format: 'pipe',
   // The time in seconds between proof of life logging messages informing that the server is up and running normally.
   // Default value: "60"
-  proofOfLifeInterval: '60'
+  proofOfLifeInterval: '60',
 };
 
 module.exports = config;

--- a/doc/manuals/contribution-guidelines.md
+++ b/doc/manuals/contribution-guidelines.md
@@ -16,26 +16,26 @@ In order to start contributing:
 
 1. Fork this repository clicking on the "Fork" button on the upper-right area of the page.
 2. Clone your just forked repository:
-    ```
+    ```bash
     git clone https://github.com/your-github-username/fiware-sth-comet.git
     ```
 3. Add the main fiware-sth-comet repository as a remote to your forked repository (use any name for your remote repository, it does not have to be fiware-sth-comet, although we will use it in the next steps):
-    ```
+    ```bash
     git remote add fiware-sth-comet https://github.com/telefonicaid/fiware-sth-comet.git
     ```
 
 Before starting your contribution, remember to synchronize the `master` branch in your forked repository with the `master` branch in the main fiware-sth-comet repository following the next steps:
 
 1. Change to your local `master` branch (in case you are not in it already):
-    ```
+    ```bash
     git checkout master
     ```
 2. Fetch the remote changes:
-    ```
+    ```bash
     git fetch fiware-sth-comet
     ```
 3. Merge them:
-    ```
+    ```bash
     git rebase fiware-sth-comet/master
     ```
 
@@ -119,6 +119,16 @@ Removes `node_modules` and `coverage` folders, and  `package-lock.json` file so 
 ```bash
 # Use git-bash on Windows
 npm run clean
+```
+
+### Prettify Code
+
+Runs the [prettier](https://prettier.io) code formatter to ensure consistent code style (whitespacing, parameter
+placement and breakup of long lines etc.) within the codebase.
+
+```bash
+# Use git-bash on Windows
+npm run prettier
 ```
 
 ## Releasing

--- a/ghpages/javascripts/scale.fix.js
+++ b/ghpages/javascripts/scale.fix.js
@@ -1,17 +1,17 @@
 var metas = document.getElementsByTagName('meta');
 var i;
 if (navigator.userAgent.match(/iPhone/i)) {
-  for (i=0; i<metas.length; i++) {
-    if (metas[i].name == "viewport") {
-      metas[i].content = "width=device-width, minimum-scale=1.0, maximum-scale=1.0";
+    for (i = 0; i < metas.length; i++) {
+        if (metas[i].name == 'viewport') {
+            metas[i].content = 'width=device-width, minimum-scale=1.0, maximum-scale=1.0';
+        }
     }
-  }
-  document.addEventListener("gesturestart", gestureStart, false);
+    document.addEventListener('gesturestart', gestureStart, false);
 }
 function gestureStart() {
-  for (i=0; i<metas.length; i++) {
-    if (metas[i].name == "viewport") {
-      metas[i].content = "width=device-width, minimum-scale=0.25, maximum-scale=1.6";
+    for (i = 0; i < metas.length; i++) {
+        if (metas[i].name == 'viewport') {
+            metas[i].content = 'width=device-width, minimum-scale=0.25, maximum-scale=1.6';
+        }
     }
-  }
 }

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -35,14 +35,14 @@ module.exports = {
         DAY: 'day',
         HOUR: 'hour',
         MINUTE: 'minute',
-        SECOND: 'second',
+        SECOND: 'second'
     },
     HEADER: {
         CORRELATOR: 'fiware-correlator',
         FIWARE_SERVICE: 'fiware-service',
         FIWARE_SERVICE_PATH: 'fiware-servicepath',
         FIWARE_TOTAL_COUNT: 'fiware-total-count',
-        X_REAL_IP: 'x-real-ip',
+        X_REAL_IP: 'x-real-ip'
     },
     OPERATION_TYPE_PREFIX: 'OPER_STH_',
     OPERATION_TYPE: {
@@ -54,22 +54,22 @@ module.exports = {
         DB_CONN_CLOSE: 'OPER_STH_DB_CONN_CLOSE',
         SERVER_START: 'OPER_STH_SERVER_START',
         SERVER_LOG: 'OPER_STH_SERVER_LOG',
-        SERVER_STOP: 'OPER_STH_SERVER_STOP',
+        SERVER_STOP: 'OPER_STH_SERVER_STOP'
     },
     DATA_TO_STORE: {
         ONLY_RAW: 'only-raw',
         ONLY_AGGREGATED: 'only-aggregated',
-        BOTH: 'both',
+        BOTH: 'both'
     },
     DATA_MODELS: {
         COLLECTION_PER_ATTRIBUTE: 'collection-per-attribute',
         COLLECTION_PER_ENTITY: 'collection-per-entity',
-        COLLECTION_PER_SERVICE_PATH: 'collection-per-service-path',
+        COLLECTION_PER_SERVICE_PATH: 'collection-per-service-path'
     },
     AGGREGATIONS: {
         NUMERIC: 'numeric',
-        TEXTUAL: 'textual',
-    },
+        TEXTUAL: 'textual'
+    }
 };
 
 module.exports.LOGGING_CONTEXT = {
@@ -78,57 +78,57 @@ module.exports.LOGGING_CONTEXT = {
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.STARTUP,
+        op: module.exports.OPERATION_TYPE.STARTUP
     },
     SHUTDOWN: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.SHUTDOWN,
+        op: module.exports.OPERATION_TYPE.SHUTDOWN
     },
     SERVER_START: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.SERVER_START,
+        op: module.exports.OPERATION_TYPE.SERVER_START
     },
     SERVER_STOP: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.SERVER_STOP,
+        op: module.exports.OPERATION_TYPE.SERVER_STOP
     },
     SERVER_LOG: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.SERVER_LOG,
+        op: module.exports.OPERATION_TYPE.SERVER_LOG
     },
     DB_CONN_OPEN: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.DB_CONN_OPEN,
+        op: module.exports.OPERATION_TYPE.DB_CONN_OPEN
     },
     DB_CONN_CLOSE: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.DB_CONN_CLOSE,
+        op: module.exports.OPERATION_TYPE.DB_CONN_CLOSE
     },
     DB_LOG: {
         from: 'n/a',
         srv: 'n/a',
         subsrv: 'n/a',
         comp: 'STH',
-        op: module.exports.OPERATION_TYPE.DB_LOG,
-    },
+        op: module.exports.OPERATION_TYPE.DB_LOG
+    }
 };
 
 var invalidLoggingLevel;
@@ -373,7 +373,7 @@ if (!ENV.MAX_PAGE_SIZE && !(config && config.server && config.server.maxPageSize
 var dataModels = [
     module.exports.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
     module.exports.DATA_MODELS.COLLECTION_PER_ENTITY,
-    module.exports.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+    module.exports.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
 ];
 if (dataModels.indexOf(ENV.DATA_MODEL) !== -1) {
     module.exports.DATA_MODEL = ENV.DATA_MODEL;
@@ -526,7 +526,7 @@ if (
     [
         module.exports.DATA_TO_STORE.ONLY_RAW,
         module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
-        module.exports.DATA_TO_STORE.BOTH,
+        module.exports.DATA_TO_STORE.BOTH
     ].indexOf(ENV.SHOULD_STORE) !== -1
 ) {
     module.exports.SHOULD_STORE = ENV.SHOULD_STORE;
@@ -538,7 +538,7 @@ if (
     [
         module.exports.DATA_TO_STORE.ONLY_RAW,
         module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
-        module.exports.DATA_TO_STORE.BOTH,
+        module.exports.DATA_TO_STORE.BOTH
     ].indexOf(config.database.shouldStore) !== -1
 ) {
     module.exports.SHOULD_STORE = config.database.shouldStore;

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -312,11 +312,9 @@ if (ENV.AGGREGATION_BY) {
 }
 if (!isEnvAggregationBy || envAggregationByParseError) {
     if (
-        config &&
-        config.server &&
-        config.server.aggregationBy &&
-        Array.isArray(config.server.aggregationBy) &&
-        config.server.aggregationBy.length
+        // prettier-ignore
+        config && config.server && config.server.aggregationBy && 
+            Array.isArray(config.server.aggregationBy) && config.server.aggregationBy.length
     ) {
         config.server.aggregationBy.forEach(function(entry) {
             if (module.exports.RESOLUTION[entry.toUpperCase()]) {
@@ -494,10 +492,8 @@ try {
             'Database write concern set to value: ' + module.exports.WRITE_CONCERN
         );
     } else if (
-        config &&
-        config.database &&
-        config.database.writeConcern &&
-        (!isNaN(config.database.writeConcern) ||
+        // prettier-ignore
+        config && config.database && config.database.writeConcern && (!isNaN(config.database.writeConcern) ||
             config.database.writeConcern === 'majority' ||
             JSON.parse(config.database.writeConcern))
     ) {
@@ -566,11 +562,9 @@ if (
         'Database truncation expiration time set to value: ' + module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS
     );
 } else if (
-    config &&
-    config.database &&
-    config.database.truncation &&
-    config.database.truncation.expireAfterSeconds &&
-    parseInt(config.database.truncation.expireAfterSeconds, 10) >= 0
+    // prettier-ignore
+    config && config.database && config.database.truncation && config.database.truncation.expireAfterSeconds && 
+        parseInt(config.database.truncation.expireAfterSeconds, 10) >= 0
 ) {
     module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = parseInt(config.database.truncation.expireAfterSeconds, 10);
     sthLogger.info(
@@ -593,11 +587,9 @@ if (ENV.TRUNCATION_SIZE && parseInt(ENV.TRUNCATION_SIZE, 10) >= 0) {
         'Database truncation size set to value: ' + module.exports.TRUNCATION_SIZE
     );
 } else if (
-    config &&
-    config.database &&
-    config.database.truncation &&
-    config.database.truncation.size &&
-    parseInt(config.database.truncation.size, 10) >= 0
+    // prettier-ignore
+    config && config.database && config.database.truncation && config.database.truncation.size && 
+        parseInt(config.database.truncation.size, 10) >= 0
 ) {
     module.exports.TRUNCATION_SIZE = parseInt(config.database.truncation.size, 10);
     sthLogger.info(
@@ -620,11 +612,9 @@ if (ENV.TRUNCATION_MAX && parseInt(ENV.TRUNCATION_MAX, 10) >= 0) {
         'Database truncation document number set to value: ' + module.exports.TRUNCATION_MAX
     );
 } else if (
-    config &&
-    config.database &&
-    config.database.truncation &&
-    config.database.truncation.max &&
-    parseInt(config.database.truncation.max, 10) >= 0
+    // prettier-ignore
+    config && config.database && config.database.truncation && config.database.truncation.max && 
+        parseInt(config.database.truncation.max, 10) >= 0
 ) {
     module.exports.TRUNCATION_MAX = parseInt(config.database.truncation.max, 10);
     sthLogger.info(
@@ -738,10 +728,8 @@ if (ENV.PROOF_OF_LIFE_INTERVAL && !isNaN(ENV.PROOF_OF_LIFE_INTERVAL)) {
         'Proof of life interval set to value: ' + module.exports.PROOF_OF_LIFE_INTERVAL
     );
 } else if (
-    config &&
-    config.logging &&
-    config.logging.proofOfLifeInterval &&
-    !isNaN(config.logging.proofOfLifeInterval)
+    // prettier-ignore
+    config && config.logging && config.logging.proofOfLifeInterval && !isNaN(config.logging.proofOfLifeInterval)
 ) {
     module.exports.PROOF_OF_LIFE_INTERVAL = parseInt(config.logging.proofOfLifeInterval, 10);
     sthLogger.info(

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -136,10 +136,9 @@ var LOGGING_LEVELS = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'];
 if (ENV.LOGOPS_LEVEL && LOGGING_LEVELS.indexOf(ENV.LOGOPS_LEVEL.toUpperCase()) !== -1) {
     module.exports.LOGOPS_LEVEL = ENV.LOGOPS_LEVEL.toUpperCase();
 } else if (
-    config &&
-    config.logging &&
-    config.logging.level &&
-    LOGGING_LEVELS.indexOf(config.logging.level.toUpperCase()) !== -1
+    // prettier-ignore
+    config && config.logging && config.logging.level && 
+        LOGGING_LEVELS.indexOf(config.logging.level.toUpperCase()) !== -1
 ) {
     module.exports.LOGOPS_LEVEL = config.logging.level.toUpperCase();
 } else {
@@ -153,10 +152,9 @@ var LOGGING_FORMATS = ['json', 'dev', 'pipe'];
 if (ENV.LOGOPS_FORMAT && LOGGING_FORMATS.indexOf(ENV.LOGOPS_FORMAT.toLowerCase()) !== -1) {
     module.exports.LOGOPS_FORMAT = ENV.LOGOPS_FORMAT.toLowerCase();
 } else if (
-    config &&
-    config.logging &&
-    config.logging.format &&
-    LOGGING_FORMATS.indexOf(config.logging.format.toLowerCase()) !== -1
+    // prettier-ignore
+    config && config.logging && config.logging.format && 
+        LOGGING_FORMATS.indexOf(config.logging.format.toLowerCase()) !== -1
 ) {
     module.exports.LOGOPS_FORMAT = config.logging.format.toLowerCase();
 } else {
@@ -245,10 +243,8 @@ if (ENV.DEFAULT_SERVICE_PATH && ENV.DEFAULT_SERVICE_PATH.charAt(0) === '/') {
         'Default service path set to value: ' + module.exports.DEFAULT_SERVICE_PATH
     );
 } else if (
-    config &&
-    config.server &&
-    config.server.defaultServicePath &&
-    config.server.defaultServicePath.charAt(0) === '/'
+    // prettier-ignore
+    config && config.server && config.server.defaultServicePath && config.server.defaultServicePath.charAt(0) === '/'
 ) {
     module.exports.DEFAULT_SERVICE_PATH = config.server.defaultServicePath;
     sthLogger.info(

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -30,673 +30,731 @@ var sthLogger = require('logops');
 var ENV = process.env;
 
 module.exports = {
-  RESOLUTION: {
-    MONTH: 'month',
-    DAY: 'day',
-    HOUR: 'hour',
-    MINUTE: 'minute',
-    SECOND: 'second'
-  },
-  HEADER: {
-    CORRELATOR: 'fiware-correlator',
-    FIWARE_SERVICE: 'fiware-service',
-    FIWARE_SERVICE_PATH: 'fiware-servicepath',
-    FIWARE_TOTAL_COUNT: 'fiware-total-count',
-    X_REAL_IP: 'x-real-ip'
-  },
-  OPERATION_TYPE_PREFIX: 'OPER_STH_',
-  OPERATION_TYPE: {
-    NOT_AVAILABLE: 'NA',
-    STARTUP: 'OPER_STH_STARTUP',
-    SHUTDOWN: 'OPER_STH_SHUTDOWN',
-    DB_CONN_OPEN: 'OPER_STH_DB_CONN_OPEN',
-    DB_LOG: 'OPER_STH_DB_LOG',
-    DB_CONN_CLOSE: 'OPER_STH_DB_CONN_CLOSE',
-    SERVER_START: 'OPER_STH_SERVER_START',
-    SERVER_LOG: 'OPER_STH_SERVER_LOG',
-    SERVER_STOP: 'OPER_STH_SERVER_STOP'
-  },
-  DATA_TO_STORE: {
-    ONLY_RAW: 'only-raw',
-    ONLY_AGGREGATED: 'only-aggregated',
-    BOTH: 'both'
-  },
-  DATA_MODELS: {
-    COLLECTION_PER_ATTRIBUTE: 'collection-per-attribute',
-    COLLECTION_PER_ENTITY: 'collection-per-entity',
-    COLLECTION_PER_SERVICE_PATH: 'collection-per-service-path'
-  },
-  AGGREGATIONS: {
-    NUMERIC: 'numeric',
-    TEXTUAL: 'textual'
-  }
+    RESOLUTION: {
+        MONTH: 'month',
+        DAY: 'day',
+        HOUR: 'hour',
+        MINUTE: 'minute',
+        SECOND: 'second',
+    },
+    HEADER: {
+        CORRELATOR: 'fiware-correlator',
+        FIWARE_SERVICE: 'fiware-service',
+        FIWARE_SERVICE_PATH: 'fiware-servicepath',
+        FIWARE_TOTAL_COUNT: 'fiware-total-count',
+        X_REAL_IP: 'x-real-ip',
+    },
+    OPERATION_TYPE_PREFIX: 'OPER_STH_',
+    OPERATION_TYPE: {
+        NOT_AVAILABLE: 'NA',
+        STARTUP: 'OPER_STH_STARTUP',
+        SHUTDOWN: 'OPER_STH_SHUTDOWN',
+        DB_CONN_OPEN: 'OPER_STH_DB_CONN_OPEN',
+        DB_LOG: 'OPER_STH_DB_LOG',
+        DB_CONN_CLOSE: 'OPER_STH_DB_CONN_CLOSE',
+        SERVER_START: 'OPER_STH_SERVER_START',
+        SERVER_LOG: 'OPER_STH_SERVER_LOG',
+        SERVER_STOP: 'OPER_STH_SERVER_STOP',
+    },
+    DATA_TO_STORE: {
+        ONLY_RAW: 'only-raw',
+        ONLY_AGGREGATED: 'only-aggregated',
+        BOTH: 'both',
+    },
+    DATA_MODELS: {
+        COLLECTION_PER_ATTRIBUTE: 'collection-per-attribute',
+        COLLECTION_PER_ENTITY: 'collection-per-entity',
+        COLLECTION_PER_SERVICE_PATH: 'collection-per-service-path',
+    },
+    AGGREGATIONS: {
+        NUMERIC: 'numeric',
+        TEXTUAL: 'textual',
+    },
 };
 
 module.exports.LOGGING_CONTEXT = {
-  STARTUP: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.STARTUP
-  },
-  SHUTDOWN: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.SHUTDOWN
-  },
-  SERVER_START: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.SERVER_START
-  },
-  SERVER_STOP: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.SERVER_STOP
-  },
-  SERVER_LOG: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.SERVER_LOG
-  },
-  DB_CONN_OPEN: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.DB_CONN_OPEN
-  },
-  DB_CONN_CLOSE: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.DB_CONN_CLOSE
-  },
-  DB_LOG: {
-    from: 'n/a',
-    srv: 'n/a',
-    subsrv: 'n/a',
-    comp: 'STH',
-    op: module.exports.OPERATION_TYPE.DB_LOG
-  }
+    STARTUP: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.STARTUP,
+    },
+    SHUTDOWN: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.SHUTDOWN,
+    },
+    SERVER_START: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.SERVER_START,
+    },
+    SERVER_STOP: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.SERVER_STOP,
+    },
+    SERVER_LOG: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.SERVER_LOG,
+    },
+    DB_CONN_OPEN: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.DB_CONN_OPEN,
+    },
+    DB_CONN_CLOSE: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.DB_CONN_CLOSE,
+    },
+    DB_LOG: {
+        from: 'n/a',
+        srv: 'n/a',
+        subsrv: 'n/a',
+        comp: 'STH',
+        op: module.exports.OPERATION_TYPE.DB_LOG,
+    },
 };
 
 var invalidLoggingLevel;
 var LOGGING_LEVELS = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'];
 if (ENV.LOGOPS_LEVEL && LOGGING_LEVELS.indexOf(ENV.LOGOPS_LEVEL.toUpperCase()) !== -1) {
-  module.exports.LOGOPS_LEVEL = ENV.LOGOPS_LEVEL.toUpperCase();
-} else if (config && config.logging && config.logging.level &&
-  LOGGING_LEVELS.indexOf(config.logging.level.toUpperCase()) !== -1) {
-  module.exports.LOGOPS_LEVEL = config.logging.level.toUpperCase();
+    module.exports.LOGOPS_LEVEL = ENV.LOGOPS_LEVEL.toUpperCase();
+} else if (
+    config &&
+    config.logging &&
+    config.logging.level &&
+    LOGGING_LEVELS.indexOf(config.logging.level.toUpperCase()) !== -1
+) {
+    module.exports.LOGOPS_LEVEL = config.logging.level.toUpperCase();
 } else {
-  invalidLoggingLevel = true;
-  module.exports.LOGOPS_LEVEL = 'INFO';
+    invalidLoggingLevel = true;
+    module.exports.LOGOPS_LEVEL = 'INFO';
 }
 sthLogger.setLevel(module.exports.LOGOPS_LEVEL);
 
 var invalidLoggingFormat;
 var LOGGING_FORMATS = ['json', 'dev', 'pipe'];
 if (ENV.LOGOPS_FORMAT && LOGGING_FORMATS.indexOf(ENV.LOGOPS_FORMAT.toLowerCase()) !== -1) {
-  module.exports.LOGOPS_FORMAT = ENV.LOGOPS_FORMAT.toLowerCase();
-} else if (config && config.logging && config.logging.format &&
-  LOGGING_FORMATS.indexOf(config.logging.format.toLowerCase()) !== -1) {
-  module.exports.LOGOPS_FORMAT = config.logging.format.toLowerCase();
+    module.exports.LOGOPS_FORMAT = ENV.LOGOPS_FORMAT.toLowerCase();
+} else if (
+    config &&
+    config.logging &&
+    config.logging.format &&
+    LOGGING_FORMATS.indexOf(config.logging.format.toLowerCase()) !== -1
+) {
+    module.exports.LOGOPS_FORMAT = config.logging.format.toLowerCase();
 } else {
-  invalidLoggingFormat = true;
-  module.exports.LOGOPS_FORMAT = 'pipe';
+    invalidLoggingFormat = true;
+    module.exports.LOGOPS_FORMAT = 'pipe';
 }
 switch (module.exports.LOGOPS_FORMAT) {
-  case 'json':
-    sthLogger.format = sthLogger.formatters.json;
-    break;
-  case 'dev':
-    sthLogger.format = sthLogger.formatters.dev;
-    break;
-  case 'pipe':
-    sthLogger.format = sthLogger.formatters.pipe;
-    break;
+    case 'json':
+        sthLogger.format = sthLogger.formatters.json;
+        break;
+    case 'dev':
+        sthLogger.format = sthLogger.formatters.dev;
+        break;
+    case 'pipe':
+        sthLogger.format = sthLogger.formatters.pipe;
+        break;
 }
 
-sthLogger.info(
-  module.exports.LOGGING_CONTEXT.STARTUP,
-  'Starting the STH component configuration...'
-);
+sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'Starting the STH component configuration...');
 
 if (invalidLoggingLevel) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured logging level, setting to default value: ' + module.exports.LOGOPS_LEVEL
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured logging level, setting to default value: ' + module.exports.LOGOPS_LEVEL
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Logging level set to value: ' + module.exports.LOGOPS_LEVEL
-  );
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Logging level set to value: ' + module.exports.LOGOPS_LEVEL
+    );
 }
 
 if (invalidLoggingFormat) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured logging format, setting to default value: ' + module.exports.LOGOPS_FORMAT
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured logging format, setting to default value: ' + module.exports.LOGOPS_FORMAT
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Logging format set to value: ' + module.exports.LOGOPS_FORMAT
-  );
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Logging format set to value: ' + module.exports.LOGOPS_FORMAT
+    );
 }
 
 module.exports.STH_HOST = ENV.STH_HOST || (config && config.server && config.server.host) || 'localhost';
 if (!ENV.STH_HOST && !(config && config.server && config.server.host)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured STH host, setting to default value: ' + module.exports.STH_HOST
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Not configured STH host, setting to default value: ' + module.exports.STH_HOST
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'STH host set to value: ' + module.exports.STH_HOST
-  );
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'STH host set to value: ' + module.exports.STH_HOST);
 }
 
 if (ENV.STH_PORT && !isNaN(ENV.STH_PORT)) {
-  module.exports.STH_PORT = parseInt(ENV.STH_PORT, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'STH port set to value: ' + module.exports.STH_PORT
-  );
+    module.exports.STH_PORT = parseInt(ENV.STH_PORT, 10);
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'STH port set to value: ' + module.exports.STH_PORT);
 } else if (config && config.server && config.server.port && !isNaN(config.server.port)) {
-  module.exports.STH_PORT = parseInt(config.server.port, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'STH port set to value: ' + module.exports.STH_PORT
-  );
+    module.exports.STH_PORT = parseInt(config.server.port, 10);
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'STH port set to value: ' + module.exports.STH_PORT);
 } else {
-  module.exports.STH_PORT = 8666;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured STH port, setting to default value: ' + module.exports.STH_PORT
-  );
+    module.exports.STH_PORT = 8666;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured STH port, setting to default value: ' + module.exports.STH_PORT
+    );
 }
 
 module.exports.DEFAULT_SERVICE = ENV.DEFAULT_SERVICE || config.server.defaultService || 'testservice';
 if (!ENV.DEFAULT_SERVICE && !(config && config.server && config.server.defaultService)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured default service, setting to default value: ' + module.exports.DEFAULT_SERVICE
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Not configured default service, setting to default value: ' + module.exports.DEFAULT_SERVICE
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Default service set to value: ' + module.exports.DEFAULT_SERVICE
-  );
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Default service set to value: ' + module.exports.DEFAULT_SERVICE
+    );
 }
 
 if (ENV.DEFAULT_SERVICE_PATH && ENV.DEFAULT_SERVICE_PATH.charAt(0) === '/') {
-  module.exports.DEFAULT_SERVICE_PATH = ENV.DEFAULT_SERVICE_PATH;
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Default service path set to value: ' + module.exports.DEFAULT_SERVICE_PATH
-  );
-} else if (config && config.server && config.server.defaultServicePath &&
-  config.server.defaultServicePath.charAt(0) === '/') {
+    module.exports.DEFAULT_SERVICE_PATH = ENV.DEFAULT_SERVICE_PATH;
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Default service path set to value: ' + module.exports.DEFAULT_SERVICE_PATH
+    );
+} else if (
+    config &&
+    config.server &&
+    config.server.defaultServicePath &&
+    config.server.defaultServicePath.charAt(0) === '/'
+) {
     module.exports.DEFAULT_SERVICE_PATH = config.server.defaultServicePath;
     sthLogger.info(
-      module.exports.LOGGING_CONTEXT.STARTUP,
-      'Default service path set to value: ' + module.exports.DEFAULT_SERVICE_PATH
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Default service path set to value: ' + module.exports.DEFAULT_SERVICE_PATH
     );
 } else {
-  module.exports.DEFAULT_SERVICE_PATH = '/testservicepath';
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured default service path, setting to default value: ' + module.exports.DEFAULT_SERVICE_PATH
-  );
+    module.exports.DEFAULT_SERVICE_PATH = '/testservicepath';
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured default service path, setting to default value: ' +
+            module.exports.DEFAULT_SERVICE_PATH
+    );
 }
 
 if (ENV.FILTER_OUT_EMPTY) {
-  module.exports.FILTER_OUT_EMPTY = (ENV.FILTER_OUT_EMPTY.toLowerCase() !== 'false');
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Filter out empty option set to value: ' + module.exports.FILTER_OUT_EMPTY
-  );
+    module.exports.FILTER_OUT_EMPTY = ENV.FILTER_OUT_EMPTY.toLowerCase() !== 'false';
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Filter out empty option set to value: ' + module.exports.FILTER_OUT_EMPTY
+    );
 } else if (config && config.server && config.server.filterOutEmpty) {
-  module.exports.FILTER_OUT_EMPTY = (config.server.filterOutEmpty.toLowerCase() !== 'false');
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Filter out empty option set to value: ' + module.exports.FILTER_OUT_EMPTY
-  );
+    module.exports.FILTER_OUT_EMPTY = config.server.filterOutEmpty.toLowerCase() !== 'false';
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Filter out empty option set to value: ' + module.exports.FILTER_OUT_EMPTY
+    );
 } else {
-  module.exports.FILTER_OUT_EMPTY = true;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured filter out empty option, setting to default value: ' + module.exports.FILTER_OUT_EMPTY
-  );
+    module.exports.FILTER_OUT_EMPTY = true;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured filter out empty option, setting to default value: ' +
+            module.exports.FILTER_OUT_EMPTY
+    );
 }
 
 module.exports.AGGREGATION_BY = [];
 var isEnvAggregationBy = false,
     envAggregationByParseError = false;
 if (ENV.AGGREGATION_BY) {
-  try {
-    var envAggregationBy = JSON.parse(ENV.AGGREGATION_BY);
-    if (Array.isArray(envAggregationBy) && envAggregationBy.length) {
-      isEnvAggregationBy = true;
-      envAggregationBy.forEach(function (entry) {
-        if (module.exports.RESOLUTION[entry.toUpperCase()]) {
-          module.exports.AGGREGATION_BY.push(entry);
-        } else {
-          sthLogger.warn(
-            module.exports.LOGGING_CONTEXT.STARTUP,
-            'The following resolution to include in aggregations is not valid: ' + entry +
-            '. It will be ignored. Valid values are: month, day, hour, minute and second.'
-          );
+    try {
+        var envAggregationBy = JSON.parse(ENV.AGGREGATION_BY);
+        if (Array.isArray(envAggregationBy) && envAggregationBy.length) {
+            isEnvAggregationBy = true;
+            envAggregationBy.forEach(function(entry) {
+                if (module.exports.RESOLUTION[entry.toUpperCase()]) {
+                    module.exports.AGGREGATION_BY.push(entry);
+                } else {
+                    sthLogger.warn(
+                        module.exports.LOGGING_CONTEXT.STARTUP,
+                        'The following resolution to include in aggregations is not valid: ' +
+                            entry +
+                            '. It will be ignored. Valid values are: month, day, hour, minute and second.'
+                    );
+                }
+            });
         }
-      });
+    } catch (exception) {
+        envAggregationByParseError = true;
     }
-  } catch (exception) {
-    envAggregationByParseError = true;
-  }
 }
 if (!isEnvAggregationBy || envAggregationByParseError) {
-  if (config && config.server && config.server.aggregationBy && Array.isArray(config.server.aggregationBy) &&
-    config.server.aggregationBy.length) {
-    config.server.aggregationBy.forEach(function (entry) {
-      if (module.exports.RESOLUTION[entry.toUpperCase()]) {
-        module.exports.AGGREGATION_BY.push(entry);
-      } else {
-        sthLogger.warn(
-          module.exports.LOGGING_CONTEXT.STARTUP,
-          'The following resolution to include in aggregations is not valid: ' + entry +
-          '. It will be ignored. Valid values are: month, day, hour, minute and second.'
-        );
-      }
-    });
-  }
+    if (
+        config &&
+        config.server &&
+        config.server.aggregationBy &&
+        Array.isArray(config.server.aggregationBy) &&
+        config.server.aggregationBy.length
+    ) {
+        config.server.aggregationBy.forEach(function(entry) {
+            if (module.exports.RESOLUTION[entry.toUpperCase()]) {
+                module.exports.AGGREGATION_BY.push(entry);
+            } else {
+                sthLogger.warn(
+                    module.exports.LOGGING_CONTEXT.STARTUP,
+                    'The following resolution to include in aggregations is not valid: ' +
+                        entry +
+                        '. It will be ignored. Valid values are: month, day, hour, minute and second.'
+                );
+            }
+        });
+    }
 }
 
 if (module.exports.AGGREGATION_BY.length === 0) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'No valid resolutions to aggregate the data by has been configured. Nothing will be aggregated. ' +
-    'Please, configure it according to the component documentation in Github.'
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'No valid resolutions to aggregate the data by has been configured. Nothing will be aggregated. ' +
+            'Please, configure it according to the component documentation in Github.'
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Component configured to aggregate data by the following resolutions: ' + module.exports.AGGREGATION_BY.toString()
-  );
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Component configured to aggregate data by the following resolutions: ' +
+            module.exports.AGGREGATION_BY.toString()
+    );
 }
 
 module.exports.TEMPORAL_DIR = ENV.TEMPORAL_DIR || (config && config.server && config.server.temporalDir) || 'temp';
 if (!ENV.TEMPORAL_DIR && !(config && config.server && config.server.temporalDir)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured temporal directory, setting to default value: ' + module.exports.TEMPORAL_DIR
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Not configured temporal directory, setting to default value: ' + module.exports.TEMPORAL_DIR
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Temporal directory set to value: ' + module.exports.TEMPORAL_DIR
-  );
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Temporal directory set to value: ' + module.exports.TEMPORAL_DIR
+    );
 }
 
 module.exports.MAX_PAGE_SIZE = ENV.MAX_PAGE_SIZE || (config && config.server && config.server.maxPageSize) || '100';
 if (!ENV.MAX_PAGE_SIZE && !(config && config.server && config.server.maxPageSize)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured maxPageSize, setting to default value: ' + module.exports.MAX_PAGE_SIZE
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Not configured maxPageSize, setting to default value: ' + module.exports.MAX_PAGE_SIZE
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'maxPageSize set to value: ' + module.exports.MAX_PAGE_SIZE
-  );
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'maxPageSize set to value: ' + module.exports.MAX_PAGE_SIZE);
 }
 
-
-var dataModels = [module.exports.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
-  module.exports.DATA_MODELS.COLLECTION_PER_ENTITY,
-  module.exports.DATA_MODELS.COLLECTION_PER_SERVICE_PATH];
-if(dataModels.indexOf(ENV.DATA_MODEL) !== -1) {
-  module.exports.DATA_MODEL = ENV.DATA_MODEL;
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Data model set to value: ' + module.exports.DATA_MODEL);
+var dataModels = [
+    module.exports.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
+    module.exports.DATA_MODELS.COLLECTION_PER_ENTITY,
+    module.exports.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+];
+if (dataModels.indexOf(ENV.DATA_MODEL) !== -1) {
+    module.exports.DATA_MODEL = ENV.DATA_MODEL;
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'Data model set to value: ' + module.exports.DATA_MODEL);
 } else if (dataModels.indexOf(config.database.dataModel) !== -1) {
-  module.exports.DATA_MODEL = config.database.dataModel;
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Data model set to value: ' + module.exports.DATA_MODEL);
+    module.exports.DATA_MODEL = config.database.dataModel;
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'Data model set to value: ' + module.exports.DATA_MODEL);
 } else {
-  module.exports.DATA_MODEL = module.exports.DATA_MODELS.COLLECTIONS_PER_ENTITY;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured data model, setting to default value: ' + module.exports.DATA_MODEL);
+    module.exports.DATA_MODEL = module.exports.DATA_MODELS.COLLECTIONS_PER_ENTITY;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured data model, setting to default value: ' + module.exports.DATA_MODEL
+    );
 }
 
 module.exports.DB_USERNAME = ENV.DB_USERNAME || (config && config.database && config.database.user) || '';
 if (!ENV.DB_USERNAME && !(config && config.database && config.database.user)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured database user, setting to default value: \'' +
-      module.exports.DB_USERNAME + '\'');
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        "Not configured database user, setting to default value: '" + module.exports.DB_USERNAME + "'"
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database user set to value: ' + module.exports.DB_USERNAME);
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'Database user set to value: ' + module.exports.DB_USERNAME);
 }
 
 module.exports.DB_PASSWORD = ENV.DB_PASSWORD || (config && config.database && config.database.password) || '';
 if (!ENV.DB_PASSWORD && !(config && config.database && config.database.password)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured database password, setting to default value: \'' +
-      module.exports.DB_PASSWORD + '\'');
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        "Not configured database password, setting to default value: '" + module.exports.DB_PASSWORD + "'"
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database password set to value: ' + module.exports.DB_PASSWORD);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database password set to value: ' + module.exports.DB_PASSWORD
+    );
 }
 
-module.exports.DB_AUTHENTICATION = (module.exports.DB_USERNAME && module.exports.DB_PASSWORD) ?
-  (module.exports.DB_USERNAME + ':' + module.exports.DB_PASSWORD) : '';
+module.exports.DB_AUTHENTICATION =
+    module.exports.DB_USERNAME && module.exports.DB_PASSWORD
+        ? module.exports.DB_USERNAME + ':' + module.exports.DB_PASSWORD
+        : '';
 
 module.exports.DB_URI = ENV.DB_URI || (config && config.database && config.database.URI) || 'localhost:27017';
 if (!ENV.DB_URI && !(config && config.database && config.database.URI)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured database URI, setting to default value: \'' +
-      module.exports.DB_URI + '\'');
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        "Not configured database URI, setting to default value: '" + module.exports.DB_URI + "'"
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database URI set to value: ' + module.exports.DB_URI);
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'Database URI set to value: ' + module.exports.DB_URI);
 }
 
 module.exports.REPLICA_SET = ENV.REPLICA_SET || (config && config.database && config.database.replicaSet) || '';
 if (!ENV.REPLICA_SET && !(config && config.database && config.database.replicaSet)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured database replica set, setting to default value: \'' +
-      module.exports.REPLICA_SET + '\'');
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        "Not configured database replica set, setting to default value: '" + module.exports.REPLICA_SET + "'"
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database replica set set to value: ' + module.exports.REPLICA_SET);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database replica set set to value: ' + module.exports.REPLICA_SET
+    );
 }
 
 module.exports.DB_PREFIX = ENV.DB_PREFIX || config.database.prefix || 'sth_';
 if (!ENV.DB_PREFIX && !(config && config.database && config.database.prefix)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured database prefix, setting to default value: ' + module.exports.DB_PREFIX
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Not configured database prefix, setting to default value: ' + module.exports.DB_PREFIX
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database prefix set to value: ' + module.exports.DB_PREFIX
-  );
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'Database prefix set to value: ' + module.exports.DB_PREFIX);
 }
 
 module.exports.COLLECTION_PREFIX = ENV.COLLECTION_PREFIX || config.database.collectionPrefix || 'sth_';
 if (!ENV.COLLECTION_PREFIX && !(config && config.database && config.database.collectionPrefix)) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Not configured collection prefix, setting to default value: ' + module.exports.COLLECTION_PREFIX
-  );
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Not configured collection prefix, setting to default value: ' + module.exports.COLLECTION_PREFIX
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Collection prefix set to value: ' + module.exports.COLLECTION_PREFIX
-  );
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Collection prefix set to value: ' + module.exports.COLLECTION_PREFIX
+    );
 }
 
 if (ENV.POOL_SIZE && !isNaN(ENV.POOL_SIZE) && parseInt(ENV.POOL_SIZE, 10) > 0) {
-  module.exports.POOL_SIZE = parseInt(ENV.POOL_SIZE, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database pool size set to value: ' + module.exports.POOL_SIZE);
+    module.exports.POOL_SIZE = parseInt(ENV.POOL_SIZE, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database pool size set to value: ' + module.exports.POOL_SIZE
+    );
 } else if (config.database.poolSize && !isNaN(config.database.poolSize) && parseInt(config.database.poolSize, 10) > 0) {
-  module.exports.POOL_SIZE = parseInt(config.database.poolSize, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database pool size set to value: ' + module.exports.POOL_SIZE);
+    module.exports.POOL_SIZE = parseInt(config.database.poolSize, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database pool size set to value: ' + module.exports.POOL_SIZE
+    );
 } else {
-  module.exports.POOL_SIZE = 5;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database pool size, setting to default value: ' + module.exports.POOL_SIZE
-  );
+    module.exports.POOL_SIZE = 5;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database pool size, setting to default value: ' + module.exports.POOL_SIZE
+    );
 }
 
 try {
-  if (ENV.WRITE_CONCERN &&
-    (!isNaN(ENV.WRITE_CONCERN) || ENV.WRITE_CONCERN === 'majority' || JSON.parse(ENV.WRITE_CONCERN))) {
-    module.exports.WRITE_CONCERN = ENV.WRITE_CONCERN;
-    sthLogger.info(
-      module.exports.LOGGING_CONTEXT.STARTUP,
-      'Database write concern set to value: ' + module.exports.WRITE_CONCERN);
-  } else if (config && config.database && config.database.writeConcern &&
-    (!isNaN(config.database.writeConcern) || config.database.writeConcern === 'majority' ||
-    JSON.parse(config.database.writeConcern))) {
-    module.exports.WRITE_CONCERN = config.database.writeConcern;
-    sthLogger.info(
-      module.exports.LOGGING_CONTEXT.STARTUP,
-      'Database write concern set to value: ' + module.exports.WRITE_CONCERN);
-  } else {
+    if (
+        ENV.WRITE_CONCERN &&
+        (!isNaN(ENV.WRITE_CONCERN) || ENV.WRITE_CONCERN === 'majority' || JSON.parse(ENV.WRITE_CONCERN))
+    ) {
+        module.exports.WRITE_CONCERN = ENV.WRITE_CONCERN;
+        sthLogger.info(
+            module.exports.LOGGING_CONTEXT.STARTUP,
+            'Database write concern set to value: ' + module.exports.WRITE_CONCERN
+        );
+    } else if (
+        config &&
+        config.database &&
+        config.database.writeConcern &&
+        (!isNaN(config.database.writeConcern) ||
+            config.database.writeConcern === 'majority' ||
+            JSON.parse(config.database.writeConcern))
+    ) {
+        module.exports.WRITE_CONCERN = config.database.writeConcern;
+        sthLogger.info(
+            module.exports.LOGGING_CONTEXT.STARTUP,
+            'Database write concern set to value: ' + module.exports.WRITE_CONCERN
+        );
+    } else {
+        module.exports.WRITE_CONCERN = '1';
+        sthLogger.warn(
+            module.exports.LOGGING_CONTEXT.STARTUP,
+            'Invalid or not configured database write concern, setting to default value: ' +
+                module.exports.WRITE_CONCERN
+        );
+    }
+} catch (exception) {
     module.exports.WRITE_CONCERN = '1';
     sthLogger.warn(
-      module.exports.LOGGING_CONTEXT.STARTUP,
-      'Invalid or not configured database write concern, setting to default value: ' + module.exports.WRITE_CONCERN);
-  }
-} catch (exception) {
-  module.exports.WRITE_CONCERN = '1';
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database write concern, setting to default value: ' + module.exports.WRITE_CONCERN);
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database write concern, setting to default value: ' + module.exports.WRITE_CONCERN
+    );
 }
 
-if ([
-    module.exports.DATA_TO_STORE.ONLY_RAW,
-    module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
-    module.exports.DATA_TO_STORE.BOTH
-  ].indexOf(ENV.SHOULD_STORE) !== -1) {
-  module.exports.SHOULD_STORE = ENV.SHOULD_STORE;
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database should store data set to value: ' + module.exports.SHOULD_STORE);
-} else if ([
-    module.exports.DATA_TO_STORE.ONLY_RAW,
-    module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
-    module.exports.DATA_TO_STORE.BOTH
-  ].indexOf(config.database.shouldStore) !== -1) {
-  module.exports.SHOULD_STORE = config.database.shouldStore;
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database should store data set to value: ' + module.exports.SHOULD_STORE);
+if (
+    [
+        module.exports.DATA_TO_STORE.ONLY_RAW,
+        module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
+        module.exports.DATA_TO_STORE.BOTH,
+    ].indexOf(ENV.SHOULD_STORE) !== -1
+) {
+    module.exports.SHOULD_STORE = ENV.SHOULD_STORE;
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database should store data set to value: ' + module.exports.SHOULD_STORE
+    );
+} else if (
+    [
+        module.exports.DATA_TO_STORE.ONLY_RAW,
+        module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
+        module.exports.DATA_TO_STORE.BOTH,
+    ].indexOf(config.database.shouldStore) !== -1
+) {
+    module.exports.SHOULD_STORE = config.database.shouldStore;
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database should store data set to value: ' + module.exports.SHOULD_STORE
+    );
 } else {
-  module.exports.SHOULD_STORE = 'both';
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database should store data value, setting to default value: ' +
-      module.exports.SHOULD_STORE);
+    module.exports.SHOULD_STORE = 'both';
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database should store data value, setting to default value: ' +
+            module.exports.SHOULD_STORE
+    );
 }
 
-if (ENV.TRUNCATION_EXPIRE_AFTER_SECONDS && !isNaN(ENV.TRUNCATION_EXPIRE_AFTER_SECONDS) &&
-  parseInt(ENV.TRUNCATION_EXPIRE_AFTER_SECONDS, 10) >= 0) {
-  module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = parseInt(ENV.TRUNCATION_EXPIRE_AFTER_SECONDS, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database truncation expiration time set to value: ' + module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS);
-} else if (config && config.database && config.database.truncation && config.database.truncation.expireAfterSeconds &&
-  parseInt(config.database.truncation.expireAfterSeconds, 10) >= 0) {
-  module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = parseInt(config.database.truncation.expireAfterSeconds, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database truncation expiration time set to value: ' + module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS);
+if (
+    ENV.TRUNCATION_EXPIRE_AFTER_SECONDS &&
+    !isNaN(ENV.TRUNCATION_EXPIRE_AFTER_SECONDS) &&
+    parseInt(ENV.TRUNCATION_EXPIRE_AFTER_SECONDS, 10) >= 0
+) {
+    module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = parseInt(ENV.TRUNCATION_EXPIRE_AFTER_SECONDS, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database truncation expiration time set to value: ' + module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS
+    );
+} else if (
+    config &&
+    config.database &&
+    config.database.truncation &&
+    config.database.truncation.expireAfterSeconds &&
+    parseInt(config.database.truncation.expireAfterSeconds, 10) >= 0
+) {
+    module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = parseInt(config.database.truncation.expireAfterSeconds, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database truncation expiration time set to value: ' + module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS
+    );
 } else {
-  module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = 0;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database truncation expiration time, setting to default value: ' +
-      module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS);
+    module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS = 0;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database truncation expiration time, setting to default value: ' +
+            module.exports.TRUNCATION_EXPIRE_AFTER_SECONDS
+    );
 }
 
 if (ENV.TRUNCATION_SIZE && parseInt(ENV.TRUNCATION_SIZE, 10) >= 0) {
-  module.exports.TRUNCATION_SIZE = parseInt(ENV.TRUNCATION_SIZE, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database truncation size set to value: ' + module.exports.TRUNCATION_SIZE);
-} else if (config && config.database && config.database.truncation && config.database.truncation.size &&
-  parseInt(config.database.truncation.size, 10) >= 0) {
-  module.exports.TRUNCATION_SIZE = parseInt(config.database.truncation.size, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database truncation size set to value: ' + module.exports.TRUNCATION_SIZE);
+    module.exports.TRUNCATION_SIZE = parseInt(ENV.TRUNCATION_SIZE, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database truncation size set to value: ' + module.exports.TRUNCATION_SIZE
+    );
+} else if (
+    config &&
+    config.database &&
+    config.database.truncation &&
+    config.database.truncation.size &&
+    parseInt(config.database.truncation.size, 10) >= 0
+) {
+    module.exports.TRUNCATION_SIZE = parseInt(config.database.truncation.size, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database truncation size set to value: ' + module.exports.TRUNCATION_SIZE
+    );
 } else {
-  module.exports.TRUNCATION_SIZE = 0;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database truncation size, setting to default value: ' +
-      module.exports.TRUNCATION_SIZE);
+    module.exports.TRUNCATION_SIZE = 0;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database truncation size, setting to default value: ' +
+            module.exports.TRUNCATION_SIZE
+    );
 }
 
 if (ENV.TRUNCATION_MAX && parseInt(ENV.TRUNCATION_MAX, 10) >= 0) {
-  module.exports.TRUNCATION_MAX = parseInt(ENV.TRUNCATION_MAX, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database truncation document number set to value: ' + module.exports.TRUNCATION_MAX);
-} else if (config && config.database && config.database.truncation && config.database.truncation.max &&
-  parseInt(config.database.truncation.max, 10) >= 0) {
-  module.exports.TRUNCATION_MAX = parseInt(config.database.truncation.max, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database truncation document number set to value: ' + module.exports.TRUNCATION_MAX);
+    module.exports.TRUNCATION_MAX = parseInt(ENV.TRUNCATION_MAX, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database truncation document number set to value: ' + module.exports.TRUNCATION_MAX
+    );
+} else if (
+    config &&
+    config.database &&
+    config.database.truncation &&
+    config.database.truncation.max &&
+    parseInt(config.database.truncation.max, 10) >= 0
+) {
+    module.exports.TRUNCATION_MAX = parseInt(config.database.truncation.max, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database truncation document number set to value: ' + module.exports.TRUNCATION_MAX
+    );
 } else {
-  module.exports.TRUNCATION_MAX = 0;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database truncation document number, setting to default value: ' +
-      module.exports.TRUNCATION_MAX);
+    module.exports.TRUNCATION_MAX = 0;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database truncation document number, setting to default value: ' +
+            module.exports.TRUNCATION_MAX
+    );
 }
 
 if (ENV.IGNORE_BLANK_SPACES) {
-  module.exports.IGNORE_BLANK_SPACES = (ENV.IGNORE_BLANK_SPACES.toLowerCase() !== 'false');
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database ignore blank spaces set to value: ' + module.exports.IGNORE_BLANK_SPACES);
+    module.exports.IGNORE_BLANK_SPACES = ENV.IGNORE_BLANK_SPACES.toLowerCase() !== 'false';
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database ignore blank spaces set to value: ' + module.exports.IGNORE_BLANK_SPACES
+    );
 } else if (config && config.database && config.database.ignoreBlankSpaces) {
-  module.exports.IGNORE_BLANK_SPACES = (config.database.ignoreBlankSpaces.toLowerCase() !== 'false');
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database ignore blank spaces set to value: ' + module.exports.IGNORE_BLANK_SPACES);
+    module.exports.IGNORE_BLANK_SPACES = config.database.ignoreBlankSpaces.toLowerCase() !== 'false';
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database ignore blank spaces set to value: ' + module.exports.IGNORE_BLANK_SPACES
+    );
 } else {
-  module.exports.IGNORE_BLANK_SPACES = true;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database ignore blank spaces, setting to default value: ' +
-      module.exports.IGNORE_BLANK_SPACES);
+    module.exports.IGNORE_BLANK_SPACES = true;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database ignore blank spaces, setting to default value: ' +
+            module.exports.IGNORE_BLANK_SPACES
+    );
 }
 
 var nameMapping;
 if (ENV.NAME_MAPPING) {
-  try {
-    nameMapping = JSON.parse(ENV.NAME_MAPPING);
-  } catch (exception) {
-    // Do nothing
-  }
+    try {
+        nameMapping = JSON.parse(ENV.NAME_MAPPING);
+    } catch (exception) {
+        // Do nothing
+    }
 }
 if (!nameMapping) {
-  if (config && config.database && config.database.nameMapping) {
-    nameMapping = config.database.nameMapping;
-  }
+    if (config && config.database && config.database.nameMapping) {
+        nameMapping = config.database.nameMapping;
+    }
 }
 if (nameMapping && nameMapping.hasOwnProperty('enabled') && nameMapping.hasOwnProperty('configFile')) {
-  if (nameMapping.enabled.toLocaleLowerCase() !== 'false' && !!nameMapping.enabled) {
-    try {
-      if (typeof nameMapping.configFile === 'string' && nameMapping.configFile[0] === '/') {
-        module.exports.NAME_MAPPING = require(nameMapping.configFile);
-      } else if (typeof nameMapping.configFile === 'string' && nameMapping.configFile[0] === '.') {
-        module.exports.NAME_MAPPING = require(ROOT_PATH + nameMapping.configFile.substring(1));
-      } else {
-        module.exports.NAME_MAPPING = require(ROOT_PATH + nameMapping.configFile);
-      }
-    } catch (exception) {
-      // Do nothing
+    if (nameMapping.enabled.toLocaleLowerCase() !== 'false' && !!nameMapping.enabled) {
+        try {
+            if (typeof nameMapping.configFile === 'string' && nameMapping.configFile[0] === '/') {
+                module.exports.NAME_MAPPING = require(nameMapping.configFile);
+            } else if (typeof nameMapping.configFile === 'string' && nameMapping.configFile[0] === '.') {
+                module.exports.NAME_MAPPING = require(ROOT_PATH + nameMapping.configFile.substring(1));
+            } else {
+                module.exports.NAME_MAPPING = require(ROOT_PATH + nameMapping.configFile);
+            }
+        } catch (exception) {
+            // Do nothing
+        }
     }
-  }
 }
 if (!module.exports.NAME_MAPPING) {
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Disabled, invalid or not configured database name mapping, ignoring the mapping mechanism');
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Disabled, invalid or not configured database name mapping, ignoring the mapping mechanism'
+    );
 } else {
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database name mapping to be applied: ' + JSON.stringify(module.exports.NAME_MAPPING));
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database name mapping to be applied: ' + JSON.stringify(module.exports.NAME_MAPPING)
+    );
 }
 
 if (ENV.NAME_ENCODING) {
-  // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
-  // module.exports.NAME_ENCODING = (ENV.NAME_ENCODING.toLowerCase() !== 'false');
-  module.exports.NAME_ENCODING = (ENV.NAME_ENCODING.toLowerCase() === 'true');
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database name encoding set to value: ' + module.exports.NAME_ENCODING);
+    // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
+    // module.exports.NAME_ENCODING = (ENV.NAME_ENCODING.toLowerCase() !== 'false');
+    module.exports.NAME_ENCODING = ENV.NAME_ENCODING.toLowerCase() === 'true';
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database name encoding set to value: ' + module.exports.NAME_ENCODING
+    );
 } else if (config && config.database && config.database.nameEncoding) {
-  module.exports.NAME_ENCODING = (config.database.nameEncoding.toLowerCase() !== 'false');
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Database name encoding set to value: ' + module.exports.NAME_ENCODING);
+    module.exports.NAME_ENCODING = config.database.nameEncoding.toLowerCase() !== 'false';
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Database name encoding set to value: ' + module.exports.NAME_ENCODING
+    );
 } else {
-  // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
-  // module.exports.NAME_ENCODING = true;
-  module.exports.NAME_ENCODING = false;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured database name encoding, setting to default value: ' +
-      module.exports.NAME_ENCODING);
+    // Default value: "true" (although we will set it to false until the Cygnus counterpart is ready and landed)
+    // module.exports.NAME_ENCODING = true;
+    module.exports.NAME_ENCODING = false;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured database name encoding, setting to default value: ' + module.exports.NAME_ENCODING
+    );
 }
 
 if (module.exports.NAME_ENCODING) {
-  module.exports.NAME_SEPARATOR = 'xffff';
+    module.exports.NAME_SEPARATOR = 'xffff';
 } else {
-  module.exports.NAME_SEPARATOR = '_';
+    module.exports.NAME_SEPARATOR = '_';
 }
 
 if (ENV.PROOF_OF_LIFE_INTERVAL && !isNaN(ENV.PROOF_OF_LIFE_INTERVAL)) {
-  module.exports.PROOF_OF_LIFE_INTERVAL = parseInt(ENV.PROOF_OF_LIFE_INTERVAL, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Proof of life interval set to value: ' + module.exports.PROOF_OF_LIFE_INTERVAL
-  );
-} else if (config && config.logging && config.logging.proofOfLifeInterval &&
-  !isNaN(config.logging.proofOfLifeInterval)) {
-  module.exports.PROOF_OF_LIFE_INTERVAL = parseInt(config.logging.proofOfLifeInterval, 10);
-  sthLogger.info(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Proof of life interval set to value: ' + module.exports.PROOF_OF_LIFE_INTERVAL
-  );
+    module.exports.PROOF_OF_LIFE_INTERVAL = parseInt(ENV.PROOF_OF_LIFE_INTERVAL, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Proof of life interval set to value: ' + module.exports.PROOF_OF_LIFE_INTERVAL
+    );
+} else if (
+    config &&
+    config.logging &&
+    config.logging.proofOfLifeInterval &&
+    !isNaN(config.logging.proofOfLifeInterval)
+) {
+    module.exports.PROOF_OF_LIFE_INTERVAL = parseInt(config.logging.proofOfLifeInterval, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Proof of life interval set to value: ' + module.exports.PROOF_OF_LIFE_INTERVAL
+    );
 } else {
-  module.exports.PROOF_OF_LIFE_INTERVAL = 60;
-  sthLogger.warn(
-    module.exports.LOGGING_CONTEXT.STARTUP,
-    'Invalid or not configured proof of life interval, setting to default value: ' +
-      module.exports.PROOF_OF_LIFE_INTERVAL
-  );
+    module.exports.PROOF_OF_LIFE_INTERVAL = 60;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured proof of life interval, setting to default value: ' +
+            module.exports.PROOF_OF_LIFE_INTERVAL
+    );
 }
 
-sthLogger.info(
-  module.exports.LOGGING_CONTEXT.STARTUP,
-  'STH component configuration successfully completed'
-);
+sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'STH component configuration successfully completed');

--- a/lib/database/model/sthDatabaseModelTool.js
+++ b/lib/database/model/sthDatabaseModelTool.js
@@ -38,7 +38,7 @@ var DATABASE_CONNECTION_PARAMS = {
     dbURI: sthConfig.DB_URI,
     replicaSet: sthConfig.REPLICA_SET,
     database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-    poolSize: sthConfig.POOL_SIZE,
+    poolSize: sthConfig.POOL_SIZE
 };
 
 /**
@@ -112,7 +112,7 @@ function hasPropertyTest(collection, propertyName, callback) {
     var query = {};
     var excludes = propertyName.charAt(0) === '!';
     query[excludes ? propertyName.substr(1) : propertyName] = {
-        $exists: true,
+        $exists: true
     };
     collection.count(query, function(err, count) {
         process.nextTick(callback.bind(null, err, excludes ? count === 0 : count > 0));
@@ -188,7 +188,7 @@ function getDataModel(collection, callback) {
         [
             sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
             sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-            sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
+            sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE
         ],
         async.apply(dataModelTest, collection),
         callback
@@ -297,7 +297,7 @@ function generateReport(databaseName, migratableCollections, callback) {
                 report.databaseName = databaseName;
                 report.collections2Migrate = mappedMigratableCollections;
                 process.nextTick(callback.bind(null, null, report));
-            },
+            }
         ],
         callback
     );
@@ -329,7 +329,7 @@ function analyseDatabase(options, database, callback) {
         [
             async.apply(listCollections, db),
             async.apply(filterCollections, options),
-            async.apply(generateReport, database.name),
+            async.apply(generateReport, database.name)
         ],
         callback
     );
@@ -381,7 +381,7 @@ function getDataModelAnalysis(options, callback) {
             listDatabasesInfo,
             async.apply(filterDatabases, options),
             async.apply(analyseDatabases, options),
-            includeCurrentDataModel,
+            includeCurrentDataModel
         ],
         callback
     );
@@ -450,7 +450,7 @@ function infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionNa
                 databaseName: databaseName,
                 service: sthDatabaseNaming.getService(databaseName),
                 servicePath: servicePath,
-                isAggregated: isAggregated,
+                isAggregated: isAggregated
             };
             return process.nextTick(
                 callback.bind(null, null, {
@@ -460,7 +460,7 @@ function infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionNa
                     entityId: cleanedOriginCollectionNameSplit[1],
                     entityType: cleanedOriginCollectionNameSplit[2],
                     collectionName: getTargetCollectionName(originCollectionNameParams),
-                    isAggregated: isAggregated,
+                    isAggregated: isAggregated
                 })
             );
         default:
@@ -496,8 +496,8 @@ function getTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName,
                             'entityId',
                             'entityType',
                             'attributeName',
-                            'attributeType',
-                        ],
+                            'attributeType'
+                        ]
                     })
                 )
                 .on('data', function(data) {
@@ -507,7 +507,7 @@ function getTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName,
                             databaseName: databaseName,
                             service: sthDatabaseNaming.getService(databaseName),
                             servicePath: data.servicePath,
-                            isAggregated: sthDatabase.isAggregated(originCollectionName),
+                            isAggregated: sthDatabase.isAggregated(originCollectionName)
                         };
                         var targetCollectionName = getTargetCollectionName(originCollectionNameParams);
                         return process.nextTick(
@@ -518,7 +518,7 @@ function getTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName,
                                 entityId: data.entityId,
                                 entityType: data.entityType,
                                 collectionName: targetCollectionName,
-                                isAggregated: sthDatabase.isAggregated(targetCollectionName),
+                                isAggregated: sthDatabase.isAggregated(targetCollectionName)
                             })
                         );
                     }
@@ -581,7 +581,7 @@ function doPipeFromCpE2CpSP(params, options, originCount, callback) {
     params.originCollection
         .find({})
         .stream({
-            transform: transformFromCpE2CpSP.bind(null, params.originCollection, params.targetCollectionData),
+            transform: transformFromCpE2CpSP.bind(null, params.originCollection, params.targetCollectionData)
         })
         .pipe(sthWritableStream)
         .on('progress', params.collectionMigrationProgress.emit.bind(params.collectionMigrationProgress, 'progress'))
@@ -698,7 +698,7 @@ function migrateFromCpE2CpSP(params, options, callback) {
                 options.dictionary
             ),
             async.apply(targetCollectionDataCheck, params.databaseName, options),
-            async.apply(doMigrateFromCpE2CpSP, params, options),
+            async.apply(doMigrateFromCpE2CpSP, params, options)
         ],
         callback
     );
@@ -821,7 +821,7 @@ function migrateCollection(databaseName, collectionName, options, callback) {
         callback = options;
         options = {
             removeCollection: false,
-            updateCollection: false,
+            updateCollection: false
         };
     }
 
@@ -835,11 +835,11 @@ function migrateCollection(databaseName, collectionName, options, callback) {
                 {
                     collectionMigrationProgress: collectionMigrationProgress,
                     databaseName: databaseName,
-                    originCollectionName: collectionName,
+                    originCollectionName: collectionName
                 },
                 options
             ),
-            async.apply(dropCollection, databaseName, collectionName, options),
+            async.apply(dropCollection, databaseName, collectionName, options)
         ],
         callback
     );
@@ -849,5 +849,5 @@ function migrateCollection(databaseName, collectionName, options, callback) {
 module.exports = {
     cleanResources: cleanResources,
     getDataModelAnalysis: getDataModelAnalysis,
-    migrateCollection: migrateCollection,
+    migrateCollection: migrateCollection
 };

--- a/lib/database/model/sthDatabaseModelTool.js
+++ b/lib/database/model/sthDatabaseModelTool.js
@@ -34,11 +34,11 @@ var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
 var sthError = require(ROOT_PATH + '/lib/utils/sthError');
 
 var DATABASE_CONNECTION_PARAMS = {
-  authentication: sthConfig.DB_AUTHENTICATION,
-  dbURI: sthConfig.DB_URI,
-  replicaSet: sthConfig.REPLICA_SET,
-  database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-  poolSize: sthConfig.POOL_SIZE
+    authentication: sthConfig.DB_AUTHENTICATION,
+    dbURI: sthConfig.DB_URI,
+    replicaSet: sthConfig.REPLICA_SET,
+    database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+    poolSize: sthConfig.POOL_SIZE,
 };
 
 /**
@@ -46,7 +46,7 @@ var DATABASE_CONNECTION_PARAMS = {
  * @param  {Function} callback The callback
  */
 function cleanResources(callback) {
-  sthDatabase.closeConnection(callback);
+    sthDatabase.closeConnection(callback);
 }
 
 /**
@@ -55,10 +55,10 @@ function cleanResources(callback) {
  * @param  {Function} callback The callback
  */
 function listDatabasesInfo(db, callback) {
-  var adminDb = db.admin();
-  adminDb.listDatabases(function(err, result) {
-    process.nextTick(callback.bind(null, err, result.databases));
-  });
+    var adminDb = db.admin();
+    adminDb.listDatabases(function(err, result) {
+        process.nextTick(callback.bind(null, err, result.databases));
+    });
 }
 
 /**
@@ -70,15 +70,15 @@ function listDatabasesInfo(db, callback) {
  * @param  {Function} callback     The callback
  */
 function databaseFilter(options, databaseData, callback) {
-  if (options && options.database) {
-    return process.nextTick(callback.bind(null, null, options.database === databaseData.name));
-  } else {
-    var decodedDatabaseName = databaseData.name;
-    if (sthConfig.NAME_ENCODING) {
-      decodedDatabaseName = sthDatabaseNameCodec.decodeDatabaseName(databaseData.name);
+    if (options && options.database) {
+        return process.nextTick(callback.bind(null, null, options.database === databaseData.name));
+    } else {
+        var decodedDatabaseName = databaseData.name;
+        if (sthConfig.NAME_ENCODING) {
+            decodedDatabaseName = sthDatabaseNameCodec.decodeDatabaseName(databaseData.name);
+        }
+        return process.nextTick(callback.bind(null, null, decodedDatabaseName.indexOf(sthConfig.DB_PREFIX) !== -1));
     }
-    return process.nextTick(callback.bind(null, null, decodedDatabaseName.indexOf(sthConfig.DB_PREFIX) !== -1));
-  }
 }
 
 /**
@@ -90,7 +90,7 @@ function databaseFilter(options, databaseData, callback) {
  * @param  {Function} callback The callback
  */
 function filterDatabases(options, databases, callback) {
-  async.filter(databases, async.apply(databaseFilter, options), callback);
+    async.filter(databases, async.apply(databaseFilter, options), callback);
 }
 
 /**
@@ -99,7 +99,7 @@ function filterDatabases(options, databases, callback) {
  * @param  {Function} callback The callback
  */
 function listCollections(database, callback) {
-  database.collections(callback);
+    database.collections(callback);
 }
 
 /**
@@ -109,17 +109,14 @@ function listCollections(database, callback) {
  * @param  {Function} callback     The callback
  */
 function hasPropertyTest(collection, propertyName, callback) {
-  var query = {};
-  var excludes = propertyName.charAt(0) === '!';
-  query[excludes ? propertyName.substr(1) : propertyName] = {
-    $exists: true
-  };
-  collection.count(
-    query,
-    function(err, count) {
-      process.nextTick(callback.bind(null, err, excludes ? count === 0 : count > 0));
-    }
-  );
+    var query = {};
+    var excludes = propertyName.charAt(0) === '!';
+    query[excludes ? propertyName.substr(1) : propertyName] = {
+        $exists: true,
+    };
+    collection.count(query, function(err, count) {
+        process.nextTick(callback.bind(null, err, excludes ? count === 0 : count > 0));
+    });
 }
 
 /**
@@ -128,11 +125,11 @@ function hasPropertyTest(collection, propertyName, callback) {
  * @param  {Function} callback   The callback
  */
 function isCollectionPerServicePath(collection, callback) {
-  if (sthDatabase.isAggregated(collection.s.name)) {
-    async.every(['_id.attrName', '_id.entityId'], hasPropertyTest.bind(null, collection), callback);
-  } else {
-    async.every(['attrName', 'entityId'], hasPropertyTest.bind(null, collection), callback);
-  }
+    if (sthDatabase.isAggregated(collection.s.name)) {
+        async.every(['_id.attrName', '_id.entityId'], hasPropertyTest.bind(null, collection), callback);
+    } else {
+        async.every(['attrName', 'entityId'], hasPropertyTest.bind(null, collection), callback);
+    }
 }
 
 /**
@@ -141,11 +138,11 @@ function isCollectionPerServicePath(collection, callback) {
  * @param  {Function} callback   The callback
  */
 function isCollectionPerEntity(collection, callback) {
-  if (sthDatabase.isAggregated(collection.s.name)) {
-    async.every(['_id.attrName', '!_id.entityId'], hasPropertyTest.bind(null, collection), callback);
-  } else {
-    async.every(['attrName', '!entityId'], hasPropertyTest.bind(null, collection), callback);
-  }
+    if (sthDatabase.isAggregated(collection.s.name)) {
+        async.every(['_id.attrName', '!_id.entityId'], hasPropertyTest.bind(null, collection), callback);
+    } else {
+        async.every(['attrName', '!entityId'], hasPropertyTest.bind(null, collection), callback);
+    }
 }
 
 /**
@@ -154,11 +151,11 @@ function isCollectionPerEntity(collection, callback) {
  * @param  {Function} callback   The callback
  */
 function isCollectionPerAttribute(collection, callback) {
-  if (sthDatabase.isAggregated(collection.s.name)) {
-    async.every(['!_id.attrName', '!_id.entityId'], hasPropertyTest.bind(null, collection), callback);
-  } else {
-    async.every(['!attrName', '!entityId'], hasPropertyTest.bind(null, collection), callback);
-  }
+    if (sthDatabase.isAggregated(collection.s.name)) {
+        async.every(['!_id.attrName', '!_id.entityId'], hasPropertyTest.bind(null, collection), callback);
+    } else {
+        async.every(['!attrName', '!entityId'], hasPropertyTest.bind(null, collection), callback);
+    }
 }
 
 /**
@@ -168,17 +165,17 @@ function isCollectionPerAttribute(collection, callback) {
  * @param  {Function} callback   The callback
  */
 function dataModelTest(collection, dataModel, callback) {
-  switch (dataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      isCollectionPerServicePath(collection, callback);
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      isCollectionPerEntity(collection, callback);
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      isCollectionPerAttribute(collection, callback);
-      break;
-  }
+    switch (dataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            isCollectionPerServicePath(collection, callback);
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            isCollectionPerEntity(collection, callback);
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            isCollectionPerAttribute(collection, callback);
+            break;
+    }
 }
 
 /**
@@ -187,15 +184,15 @@ function dataModelTest(collection, dataModel, callback) {
  * @param  {Function} callback   The callback
  */
 function getDataModel(collection, callback) {
-  async.detect(
-    [
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-      sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE
-    ],
-    async.apply(dataModelTest, collection),
-    callback
-  );
+    async.detect(
+        [
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+            sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
+        ],
+        async.apply(dataModelTest, collection),
+        callback
+    );
 }
 
 /**
@@ -207,45 +204,55 @@ function getDataModel(collection, callback) {
  * @param  {Function} callback   The callback
  */
 function collectionFilter(options, collection, callback) {
-  if ((options && options.collection && options.collection !== collection.s.name) ||
-    collection.s.name.indexOf('system.') === 0) {
-    return process.nextTick(callback.bind(null, null, true));
-  }
+    if (
+        (options && options.collection && options.collection !== collection.s.name) ||
+        collection.s.name.indexOf('system.') === 0
+    ) {
+        return process.nextTick(callback.bind(null, null, true));
+    }
 
-  collection.count(function(err, count) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    if (count > 0) {
-      if (sthDatabase.isAggregated(collection.s.name)) {
-        switch (sthConfig.DATA_MODEL) {
-          case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-            async.every(['_id.entityId', '_id.attrName'], hasPropertyTest.bind(null, collection), callback);
-            break;
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-            async.every(['!_id.entityId', '_id.attrName'], hasPropertyTest.bind(null, collection), callback);
-            break;
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-            async.every(['!_id.entityId', '!_id.attrName'], hasPropertyTest.bind(null, collection), callback);
-            break;
+    collection.count(function(err, count) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
         }
-      } else {
-        switch (sthConfig.DATA_MODEL) {
-          case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-            async.every(['entityId', 'attrName'], hasPropertyTest.bind(null, collection), callback);
-            break;
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-            async.every(['!entityId', 'attrName'], hasPropertyTest.bind(null, collection), callback);
-            break;
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-            async.every(['!entityId', '!attrName'], hasPropertyTest.bind(null, collection), callback);
-            break;
+        if (count > 0) {
+            if (sthDatabase.isAggregated(collection.s.name)) {
+                switch (sthConfig.DATA_MODEL) {
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                        async.every(['_id.entityId', '_id.attrName'], hasPropertyTest.bind(null, collection), callback);
+                        break;
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                        async.every(
+                            ['!_id.entityId', '_id.attrName'],
+                            hasPropertyTest.bind(null, collection),
+                            callback
+                        );
+                        break;
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                        async.every(
+                            ['!_id.entityId', '!_id.attrName'],
+                            hasPropertyTest.bind(null, collection),
+                            callback
+                        );
+                        break;
+                }
+            } else {
+                switch (sthConfig.DATA_MODEL) {
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                        async.every(['entityId', 'attrName'], hasPropertyTest.bind(null, collection), callback);
+                        break;
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                        async.every(['!entityId', 'attrName'], hasPropertyTest.bind(null, collection), callback);
+                        break;
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                        async.every(['!entityId', '!attrName'], hasPropertyTest.bind(null, collection), callback);
+                        break;
+                }
+            }
+        } else {
+            return process.nextTick(callback.bind(null, null, true));
         }
-      }
-    } else {
-      return process.nextTick(callback.bind(null, null, true));
-    }
-  });
+    });
 }
 
 /**
@@ -258,7 +265,7 @@ function collectionFilter(options, collection, callback) {
  * @param  {Function} callback    The callback
  */
 function filterCollections(options, collections, callback) {
-  async.reject(collections, async.apply(collectionFilter, options), callback);
+    async.reject(collections, async.apply(collectionFilter, options), callback);
 }
 
 /**
@@ -267,12 +274,12 @@ function filterCollections(options, collections, callback) {
  * @param  {Function} callback   The callback
  */
 function collectionMapper(collection, callback) {
-  var mappedCollection = {};
-  getDataModel(collection, function(err, result) {
-    mappedCollection.collectionName = collection.s.name;
-    mappedCollection.dataModel = result;
-    process.nextTick(callback.bind(null, null, mappedCollection));
-  });
+    var mappedCollection = {};
+    getDataModel(collection, function(err, result) {
+        mappedCollection.collectionName = collection.s.name;
+        mappedCollection.dataModel = result;
+        process.nextTick(callback.bind(null, null, mappedCollection));
+    });
 }
 
 /**
@@ -282,18 +289,18 @@ function collectionMapper(collection, callback) {
  * @param  {Function} callback              The callback
  */
 function generateReport(databaseName, migratableCollections, callback) {
-  async.waterfall(
-    [
-      async.map.bind(null, migratableCollections, collectionMapper),
-      function(mappedMigratableCollections, callback) {
-        var report = {};
-        report.databaseName = databaseName;
-        report.collections2Migrate = mappedMigratableCollections;
-        process.nextTick(callback.bind(null, null, report));
-      }
-    ],
-    callback
-  );
+    async.waterfall(
+        [
+            async.map.bind(null, migratableCollections, collectionMapper),
+            function(mappedMigratableCollections, callback) {
+                var report = {};
+                report.databaseName = databaseName;
+                report.collections2Migrate = mappedMigratableCollections;
+                process.nextTick(callback.bind(null, null, report));
+            },
+        ],
+        callback
+    );
 }
 
 /**
@@ -302,10 +309,10 @@ function generateReport(databaseName, migratableCollections, callback) {
  * @param  {Function} callback The callback
  */
 function includeCurrentDataModel(report, callback) {
-  var finalReport = {};
-  finalReport.currentDataModel = sthConfig.DATA_MODEL;
-  finalReport.result = report;
-  process.nextTick(callback.bind(null, null, finalReport));
+    var finalReport = {};
+    finalReport.currentDataModel = sthConfig.DATA_MODEL;
+    finalReport.result = report;
+    process.nextTick(callback.bind(null, null, finalReport));
 }
 
 /**
@@ -317,15 +324,15 @@ function includeCurrentDataModel(report, callback) {
  * @param  {Function} callback     The callback
  */
 function analyseDatabase(options, database, callback) {
-  var db = sthDatabase.connection.db(database.name);
-  async.waterfall(
-    [
-      async.apply(listCollections, db),
-      async.apply(filterCollections, options),
-      async.apply(generateReport, database.name)
-    ],
-    callback
-  );
+    var db = sthDatabase.connection.db(database.name);
+    async.waterfall(
+        [
+            async.apply(listCollections, db),
+            async.apply(filterCollections, options),
+            async.apply(generateReport, database.name),
+        ],
+        callback
+    );
 }
 
 /**
@@ -337,7 +344,7 @@ function analyseDatabase(options, database, callback) {
  * @param  {Function} callback The callback
  */
 function analyseDatabases(options, databases, callback) {
-  async.map(databases, async.apply(analyseDatabase, options), callback);
+    async.map(databases, async.apply(analyseDatabase, options), callback);
 }
 
 /**
@@ -346,11 +353,14 @@ function analyseDatabases(options, databases, callback) {
  * @param  {Function} callback The callback
  */
 function getDatabaseConnection(params, callback) {
-  if (sthDatabase.connection) {
-    process.nextTick(callback.bind(null, null, sthDatabase.connection));
-  } else {
-    sthDatabase.connect(params, callback);
-  }
+    if (sthDatabase.connection) {
+        process.nextTick(callback.bind(null, null, sthDatabase.connection));
+    } else {
+        sthDatabase.connect(
+            params,
+            callback
+        );
+    }
 }
 
 /**
@@ -361,20 +371,20 @@ function getDatabaseConnection(params, callback) {
  * @param  {Function} callback The callback
  */
 function getDataModelAnalysis(options, callback) {
-  if (typeof options === 'function' && !callback) {
-    callback = options;
-    options = undefined;
-  }
-  async.waterfall(
-    [
-      async.apply(getDatabaseConnection, DATABASE_CONNECTION_PARAMS),
-      listDatabasesInfo,
-      async.apply(filterDatabases, options),
-      async.apply(analyseDatabases, options),
-      includeCurrentDataModel
-    ],
-    callback
-  );
+    if (typeof options === 'function' && !callback) {
+        callback = options;
+        options = undefined;
+    }
+    async.waterfall(
+        [
+            async.apply(getDatabaseConnection, DATABASE_CONNECTION_PARAMS),
+            listDatabasesInfo,
+            async.apply(filterDatabases, options),
+            async.apply(analyseDatabases, options),
+            includeCurrentDataModel,
+        ],
+        callback
+    );
 }
 
 /**
@@ -384,10 +394,10 @@ function getDataModelAnalysis(options, callback) {
  * @param  {Function} callback       The callback
  */
 function collectionExists(databaseName, collectionName, callback) {
-  var db = sthDatabase.connection.db(databaseName);
-  db.listCollections({name: collectionName}).toArray(function(err, items) {
-    process.nextTick(callback.bind(null, err, !!items.length));
-  });
+    var db = sthDatabase.connection.db(databaseName);
+    db.listCollections({ name: collectionName }).toArray(function(err, items) {
+        process.nextTick(callback.bind(null, err, !!items.length));
+    });
 }
 
 /**
@@ -398,14 +408,8 @@ function collectionExists(databaseName, collectionName, callback) {
  * @param  {Function} callback           The callback
  */
 function getDataModelFromName(databaseName, collectionName, callback) {
-  var db = sthDatabase.connection.db(databaseName);
-  async.waterfall(
-    [
-      async.apply(db.collection.bind(db), collectionName),
-      getDataModel
-    ],
-    callback
-  );
+    var db = sthDatabase.connection.db(databaseName);
+    async.waterfall([async.apply(db.collection.bind(db), collectionName), getDataModel], callback);
 }
 
 /**
@@ -413,11 +417,11 @@ function getDataModelFromName(databaseName, collectionName, callback) {
  * @param  {Object} originCollectionParams The origin collection params
  */
 function getTargetCollectionName(originCollectionParams) {
-  if (originCollectionParams.isAggregated) {
-    return sthDatabaseNaming.getAggregatedCollectionName(originCollectionParams);
-  } else {
-    return sthDatabaseNaming.getRawCollectionName(originCollectionParams);
-  }
+    if (originCollectionParams.isAggregated) {
+        return sthDatabaseNaming.getAggregatedCollectionName(originCollectionParams);
+    } else {
+        return sthDatabaseNaming.getRawCollectionName(originCollectionParams);
+    }
 }
 
 /**
@@ -427,40 +431,43 @@ function getTargetCollectionName(originCollectionParams) {
  * @param  {Function} callback             The callback
  */
 function infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback) {
-  var isAggregated = sthDatabase.isAggregated(originCollectionName),
-      decodedOriginCollectionName = sthConfig.NAME_ENCODING ?
-        sthDatabaseNameCodec.decodeCollectionName(originCollectionName) :
-        originCollectionName,
-      cleanedOriginCollectionName = decodedOriginCollectionName.substring(sthConfig.COLLECTION_PREFIX.length,
-        decodedOriginCollectionName.length - (isAggregated ? '.aggr'.length : 0)),
-      cleanedOriginCollectionNameSplit = cleanedOriginCollectionName.split(sthConfig.NAME_SEPARATOR),
-      servicePath,
-      originCollectionNameParams;
-  switch (cleanedOriginCollectionNameSplit.length) {
-    case 3:
-    case 2:
-      servicePath = cleanedOriginCollectionNameSplit[0];
-      originCollectionNameParams = {
-        databaseName: databaseName,
-        service: sthDatabaseNaming.getService(databaseName),
-        servicePath: servicePath,
-        isAggregated: isAggregated
-      };
-      return process.nextTick(callback.bind(null, null,
-        {
-          databaseName: databaseName,
-          service: sthDatabaseNaming.getService(databaseName),
-          servicePath: servicePath,
-          entityId: cleanedOriginCollectionNameSplit[1],
-          entityType: cleanedOriginCollectionNameSplit[2],
-          collectionName: getTargetCollectionName(originCollectionNameParams),
-          isAggregated: isAggregated
-        }
-      ));
-    default:
-      return process.nextTick(
-        callback.bind(null, new sthError.CollectionDataInferenceError(databaseName, originCollectionName)));
-  }
+    var isAggregated = sthDatabase.isAggregated(originCollectionName),
+        decodedOriginCollectionName = sthConfig.NAME_ENCODING
+            ? sthDatabaseNameCodec.decodeCollectionName(originCollectionName)
+            : originCollectionName,
+        cleanedOriginCollectionName = decodedOriginCollectionName.substring(
+            sthConfig.COLLECTION_PREFIX.length,
+            decodedOriginCollectionName.length - (isAggregated ? '.aggr'.length : 0)
+        ),
+        cleanedOriginCollectionNameSplit = cleanedOriginCollectionName.split(sthConfig.NAME_SEPARATOR),
+        servicePath,
+        originCollectionNameParams;
+    switch (cleanedOriginCollectionNameSplit.length) {
+        case 3:
+        case 2:
+            servicePath = cleanedOriginCollectionNameSplit[0];
+            originCollectionNameParams = {
+                databaseName: databaseName,
+                service: sthDatabaseNaming.getService(databaseName),
+                servicePath: servicePath,
+                isAggregated: isAggregated,
+            };
+            return process.nextTick(
+                callback.bind(null, null, {
+                    databaseName: databaseName,
+                    service: sthDatabaseNaming.getService(databaseName),
+                    servicePath: servicePath,
+                    entityId: cleanedOriginCollectionNameSplit[1],
+                    entityType: cleanedOriginCollectionNameSplit[2],
+                    collectionName: getTargetCollectionName(originCollectionNameParams),
+                    isAggregated: isAggregated,
+                })
+            );
+        default:
+            return process.nextTick(
+                callback.bind(null, new sthError.CollectionDataInferenceError(databaseName, originCollectionName))
+            );
+    }
 }
 
 /**
@@ -473,50 +480,60 @@ function infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionNa
  * @param  {Function} callback             The callback
  */
 function getTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, dictionary, callback) {
-  var collectionFound = false;
-  if (dictionary) {
-    try {
-      var dictionaryStream = fs.createReadStream(dictionary);
-      dictionaryStream.on('error', function() {
-        return infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
-      });
-      dictionaryStream.pipe(csvParser(
-        {
-          headers: ['collectionName', 'servicePath', 'entityId', 'entityType', 'attributeName', 'attributeType']
+    var collectionFound = false;
+    if (dictionary) {
+        try {
+            var dictionaryStream = fs.createReadStream(dictionary);
+            dictionaryStream.on('error', function() {
+                return infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
+            });
+            dictionaryStream
+                .pipe(
+                    csvParser({
+                        headers: [
+                            'collectionName',
+                            'servicePath',
+                            'entityId',
+                            'entityType',
+                            'attributeName',
+                            'attributeType',
+                        ],
+                    })
+                )
+                .on('data', function(data) {
+                    if (data.collectionName === originCollectionName) {
+                        collectionFound = true;
+                        var originCollectionNameParams = {
+                            databaseName: databaseName,
+                            service: sthDatabaseNaming.getService(databaseName),
+                            servicePath: data.servicePath,
+                            isAggregated: sthDatabase.isAggregated(originCollectionName),
+                        };
+                        var targetCollectionName = getTargetCollectionName(originCollectionNameParams);
+                        return process.nextTick(
+                            callback.bind(null, null, {
+                                databaseName: databaseName,
+                                service: sthDatabaseNaming.getService(databaseName),
+                                servicePath: data.servicePath,
+                                entityId: data.entityId,
+                                entityType: data.entityType,
+                                collectionName: targetCollectionName,
+                                isAggregated: sthDatabase.isAggregated(targetCollectionName),
+                            })
+                        );
+                    }
+                })
+                .on('end', function() {
+                    if (!collectionFound) {
+                        infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
+                    }
+                });
+        } catch (err) {
+            infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
         }
-      )).on('data', function(data) {
-        if (data.collectionName === originCollectionName) {
-          collectionFound = true;
-          var originCollectionNameParams = {
-            databaseName: databaseName,
-            service: sthDatabaseNaming.getService(databaseName),
-            servicePath: data.servicePath,
-            isAggregated: sthDatabase.isAggregated(originCollectionName)
-          };
-          var targetCollectionName = getTargetCollectionName(originCollectionNameParams);
-          return process.nextTick(callback.bind(null, null,
-            {
-              databaseName: databaseName,
-              service: sthDatabaseNaming.getService(databaseName),
-              servicePath: data.servicePath,
-              entityId: data.entityId,
-              entityType: data.entityType,
-              collectionName: targetCollectionName,
-              isAggregated: sthDatabase.isAggregated(targetCollectionName)
-            }
-          ));
-        }
-      }).on('end', function() {
-        if (!collectionFound) {
-          infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
-        }
-      });
-    } catch(err) {
-      infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
+    } else {
+        infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
     }
-  } else {
-    infereTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName, callback);
-  }
 }
 
 /**
@@ -526,14 +543,14 @@ function getTargetCollectionDataFromCpE2CpSP(databaseName, originCollectionName,
  * @param  {Object} doc                  The document to transform
  */
 function transformFromCpE2CpSP(originCollection, targetCollectionData, doc) {
-  if (sthDatabase.isAggregated(originCollection.s.name)) {
-    doc._id.entityId = targetCollectionData.entityId;
-    doc._id.entityType = targetCollectionData.entityType;
-  } else {
-    doc.entityId = targetCollectionData.entityId;
-    doc.entityType = targetCollectionData.entityType;
-  }
-  return doc;
+    if (sthDatabase.isAggregated(originCollection.s.name)) {
+        doc._id.entityId = targetCollectionData.entityId;
+        doc._id.entityType = targetCollectionData.entityType;
+    } else {
+        doc.entityId = targetCollectionData.entityId;
+        doc.entityType = targetCollectionData.entityType;
+    }
+    return doc;
 }
 
 /**
@@ -555,16 +572,20 @@ function transformFromCpE2CpSP(originCollection, targetCollectionData, doc) {
  * @param  {Function} callback    The callback
  */
 function doPipeFromCpE2CpSP(params, options, originCount, callback) {
-  var sthWritableStream = new STHWritableStream(
-    sthDatabase.connection, params.databaseName, params.targetCollectionData.collectionName, originCount);
-  params.originCollection.find({}).stream(
-    {
-      transform: transformFromCpE2CpSP.bind(null, params.originCollection, params.targetCollectionData)
-    }
-  ).
-  pipe(sthWritableStream).
-  on('progress', params.collectionMigrationProgress.emit.bind(params.collectionMigrationProgress, 'progress')).
-  on('finish', callback);
+    var sthWritableStream = new STHWritableStream(
+        sthDatabase.connection,
+        params.databaseName,
+        params.targetCollectionData.collectionName,
+        originCount
+    );
+    params.originCollection
+        .find({})
+        .stream({
+            transform: transformFromCpE2CpSP.bind(null, params.originCollection, params.targetCollectionData),
+        })
+        .pipe(sthWritableStream)
+        .on('progress', params.collectionMigrationProgress.emit.bind(params.collectionMigrationProgress, 'progress'))
+        .on('finish', callback);
 }
 
 /**
@@ -584,14 +605,11 @@ function doPipeFromCpE2CpSP(params, options, originCount, callback) {
  * @param  {Function} callback         The callback
  */
 function pipeFromCpE2CpSP(params, options, originCollection, callback) {
-  params.originCollection = originCollection;
-  async.waterfall(
-    [
-      originCollection.count.bind(originCollection),
-      async.apply(doPipeFromCpE2CpSP, params, options)
-    ],
-    callback
-  );
+    params.originCollection = originCollection;
+    async.waterfall(
+        [originCollection.count.bind(originCollection), async.apply(doPipeFromCpE2CpSP, params, options)],
+        callback
+    );
 }
 
 /**
@@ -610,14 +628,14 @@ function pipeFromCpE2CpSP(params, options, originCollection, callback) {
  * @param  {Function} callback             The callback
  */
 function doMigrateFromCpE2CpSP(params, options, targetCollectionData, callback) {
-  var db = sthDatabase.connection.db(params.databaseName);
-  var functions = [];
-  params.targetCollectionData = targetCollectionData;
-  functions.push(
-    async.apply(db.collection.bind(db), params.originCollectionName),
-    async.apply(pipeFromCpE2CpSP, params, options)
-  );
-  async.waterfall(functions, callback);
+    var db = sthDatabase.connection.db(params.databaseName);
+    var functions = [];
+    params.targetCollectionData = targetCollectionData;
+    functions.push(
+        async.apply(db.collection.bind(db), params.originCollectionName),
+        async.apply(pipeFromCpE2CpSP, params, options)
+    );
+    async.waterfall(functions, callback);
 }
 
 /**
@@ -633,20 +651,24 @@ function doMigrateFromCpE2CpSP(params, options, targetCollectionData, callback) 
  * @param  {Function} callback             The callback
  */
 function targetCollectionDataCheck(databaseName, options, targetCollectionData, callback) {
-  if (!options.updateCollection) {
-    collectionExists(databaseName, targetCollectionData.collectionName, function (err, result) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      } else if (result) {
-        process.nextTick(callback.bind(
-          null, new sthError.CollectionExistsError(databaseName, targetCollectionData.collectionName)));
-      } else {
+    if (!options.updateCollection) {
+        collectionExists(databaseName, targetCollectionData.collectionName, function(err, result) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            } else if (result) {
+                process.nextTick(
+                    callback.bind(
+                        null,
+                        new sthError.CollectionExistsError(databaseName, targetCollectionData.collectionName)
+                    )
+                );
+            } else {
+                return process.nextTick(callback.bind(null, null, targetCollectionData));
+            }
+        });
+    } else {
         return process.nextTick(callback.bind(null, null, targetCollectionData));
-      }
-    });
-  } else {
-    return process.nextTick(callback.bind(null, null, targetCollectionData));
-  }
+    }
 }
 
 /**
@@ -667,15 +689,19 @@ function targetCollectionDataCheck(databaseName, options, targetCollectionData, 
  * @param  {Function} callback The callback
  */
 function migrateFromCpE2CpSP(params, options, callback) {
-  async.waterfall(
-    [
-      async.apply(getTargetCollectionDataFromCpE2CpSP,
-        params.databaseName, params.originCollectionName, options.dictionary),
-      async.apply(targetCollectionDataCheck, params.databaseName, options),
-      async.apply(doMigrateFromCpE2CpSP, params, options)
-    ],
-    callback
-  );
+    async.waterfall(
+        [
+            async.apply(
+                getTargetCollectionDataFromCpE2CpSP,
+                params.databaseName,
+                params.originCollectionName,
+                options.dictionary
+            ),
+            async.apply(targetCollectionDataCheck, params.databaseName, options),
+            async.apply(doMigrateFromCpE2CpSP, params, options),
+        ],
+        callback
+    );
 }
 
 /**
@@ -696,21 +722,39 @@ function migrateFromCpE2CpSP(params, options, callback) {
  * @param  {Function} callback        The callback
  */
 function migrate2DataModel(params, options, originDataModel, callback) {
-  switch(originDataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      switch (sthConfig.DATA_MODEL) {
-        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-          migrateFromCpE2CpSP(params, options, callback);
-          break;
+    switch (originDataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            switch (sthConfig.DATA_MODEL) {
+                case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                    migrateFromCpE2CpSP(params, options, callback);
+                    break;
+                default:
+                    return process.nextTick(
+                        callback.bind(
+                            null,
+                            new sthError.NotSupportedMigration(
+                                params.databaseName,
+                                params.originCollectionName,
+                                originDataModel,
+                                sthConfig.DATA_MODEL
+                            )
+                        )
+                    );
+            }
+            break;
         default:
-        return process.nextTick(callback.bind(null, new sthError.NotSupportedMigration(
-          params.databaseName, params.originCollectionName, originDataModel, sthConfig.DATA_MODEL)));
-      }
-      break;
-    default:
-      return process.nextTick(callback.bind(null, new sthError.NotSupportedMigration(
-        params.databaseName, params.originCollectionName, originDataModel, sthConfig.DATA_MODEL)));
-  }
+            return process.nextTick(
+                callback.bind(
+                    null,
+                    new sthError.NotSupportedMigration(
+                        params.databaseName,
+                        params.originCollectionName,
+                        originDataModel,
+                        sthConfig.DATA_MODEL
+                    )
+                )
+            );
+    }
 }
 
 /**
@@ -721,16 +765,16 @@ function migrate2DataModel(params, options, originDataModel, callback) {
  * @param  {Function} callback           The callback
  */
 function originCollectionCheck(databaseName, collectionName, databaseConnection, callback) {
-  var error;
-  collectionExists(databaseName, collectionName, function(err, collectionExistsResult) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    if (!collectionExistsResult) {
-      error = new sthError.NotExistentCollectionError(databaseName, collectionName);
-    }
-    process.nextTick(callback.bind(null, error));
-  });
+    var error;
+    collectionExists(databaseName, collectionName, function(err, collectionExistsResult) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
+        }
+        if (!collectionExistsResult) {
+            error = new sthError.NotExistentCollectionError(databaseName, collectionName);
+        }
+        process.nextTick(callback.bind(null, error));
+    });
 }
 
 /**
@@ -746,12 +790,12 @@ function originCollectionCheck(databaseName, collectionName, databaseConnection,
  * @param  {Function} callback       The callback
  */
 function dropCollection(databaseName, collectionName, options, callback) {
-  if (options.removeCollection) {
-    var db = sthDatabase.connection.db(databaseName);
-    db.dropCollection(collectionName, callback);
-  } else {
-    process.nextTick(callback);
-  }
+    if (options.removeCollection) {
+        var db = sthDatabase.connection.db(databaseName);
+        db.dropCollection(collectionName, callback);
+    } else {
+        process.nextTick(callback);
+    }
 }
 
 /**
@@ -771,38 +815,39 @@ function dropCollection(databaseName, collectionName, options, callback) {
  * @returns {EventEmitter}                An EventEmitter instance to notify the progress of the migration process
  */
 function migrateCollection(databaseName, collectionName, options, callback) {
-  var collectionMigrationProgress = new events.EventEmitter();
+    var collectionMigrationProgress = new events.EventEmitter();
 
-  if (typeof options === 'function') {
-      callback = options;
-      options = {
-        removeCollection: false,
-        updateCollection: false
-      };
-  }
+    if (typeof options === 'function') {
+        callback = options;
+        options = {
+            removeCollection: false,
+            updateCollection: false,
+        };
+    }
 
-  async.waterfall(
-    [
-      async.apply(getDatabaseConnection, DATABASE_CONNECTION_PARAMS),
-      async.apply(originCollectionCheck, databaseName, collectionName),
-      async.apply(getDataModelFromName, databaseName, collectionName),
-      async.apply(migrate2DataModel,
-        {
-          collectionMigrationProgress: collectionMigrationProgress,
-          databaseName: databaseName,
-          originCollectionName: collectionName,
-        },
-        options
-      ),
-      async.apply(dropCollection, databaseName, collectionName, options)
-    ],
-    callback
-  );
-  return collectionMigrationProgress;
+    async.waterfall(
+        [
+            async.apply(getDatabaseConnection, DATABASE_CONNECTION_PARAMS),
+            async.apply(originCollectionCheck, databaseName, collectionName),
+            async.apply(getDataModelFromName, databaseName, collectionName),
+            async.apply(
+                migrate2DataModel,
+                {
+                    collectionMigrationProgress: collectionMigrationProgress,
+                    databaseName: databaseName,
+                    originCollectionName: collectionName,
+                },
+                options
+            ),
+            async.apply(dropCollection, databaseName, collectionName, options),
+        ],
+        callback
+    );
+    return collectionMigrationProgress;
 }
 
 module.exports = {
-  cleanResources: cleanResources,
-  getDataModelAnalysis: getDataModelAnalysis,
-  migrateCollection: migrateCollection
+    cleanResources: cleanResources,
+    getDataModelAnalysis: getDataModelAnalysis,
+    migrateCollection: migrateCollection,
 };

--- a/lib/database/model/sthDatabaseNameCodec.js
+++ b/lib/database/model/sthDatabaseNameCodec.js
@@ -157,5 +157,5 @@ module.exports = {
     decodeDatabaseName: decodeDatabaseName,
     encodeDatabaseName: encodeDatabaseName,
     encodeCollectionName: encodeCollectionName,
-    decodeCollectionName: decodeCollectionName,
+    decodeCollectionName: decodeCollectionName
 };

--- a/lib/database/model/sthDatabaseNameCodec.js
+++ b/lib/database/model/sthDatabaseNameCodec.js
@@ -34,19 +34,16 @@ var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
  * @return {String}              The encoded name
  */
 function encode(originalName, matchRegExp) {
-  var encodedName = originalName.replace(
-    matchRegExp,
-    function encoder(match, index, originalString) {
-      if (match.length === 1) {
-        // Forbidden character or uppercase letter match case
-        return 'x' + _.padStart(originalString.charCodeAt(index).toString(16), 4, '0');
-      } else {
-        // x12ab or .system match case
-        return 'x' + match;
-      }
-    }
-  );
-  return encodedName;
+    var encodedName = originalName.replace(matchRegExp, function encoder(match, index, originalString) {
+        if (match.length === 1) {
+            // Forbidden character or uppercase letter match case
+            return 'x' + _.padStart(originalString.charCodeAt(index).toString(16), 4, '0');
+        } else {
+            // x12ab or .system match case
+            return 'x' + match;
+        }
+    });
+    return encodedName;
 }
 
 /**
@@ -56,25 +53,22 @@ function encode(originalName, matchRegExp) {
  * @return {String}             The decoded name
  */
 function decode(encodedName, matchRegExp) {
-  var decodedName = encodedName.replace(
-    matchRegExp,
-    function decoder(match) {
-      if (match.length === 5) {
-        // x12ab match case
-        if (match === sthConfig.NAME_SEPARATOR) {
-          // Do not decode, it is the name separator character
-          return match;
+    var decodedName = encodedName.replace(matchRegExp, function decoder(match) {
+        if (match.length === 5) {
+            // x12ab match case
+            if (match === sthConfig.NAME_SEPARATOR) {
+                // Do not decode, it is the name separator character
+                return match;
+            } else {
+                // x12ab match case
+                return String.fromCharCode(parseInt(match.substring(1), 16));
+            }
         } else {
-          // x12ab match case
-          return String.fromCharCode(parseInt(match.substring(1), 16));
+            // xx12ab or x.system match case
+            return match.substring(1);
         }
-      } else {
-        // xx12ab or x.system match case
-        return match.substring(1);
-      }
-    }
-  );
-  return decodedName;
+    });
+    return decodedName;
 }
 
 /**
@@ -93,8 +87,8 @@ function decode(encodedName, matchRegExp) {
  * @return {String}              The encoded database name
  */
 function encodeDatabaseName(databaseName) {
-  var databaseNameRegExp = /[\/\\.\s"$\0A-Z]|x[0-9a-f]{4}/g;
-  return encode(databaseName, databaseNameRegExp);
+    var databaseNameRegExp = /[\/\\.\s"$\0A-Z]|x[0-9a-f]{4}/g;
+    return encode(databaseName, databaseNameRegExp);
 }
 
 /**
@@ -113,8 +107,8 @@ function encodeDatabaseName(databaseName) {
  * @return {String}                     The decoded database name
  */
 function decodeDatabaseName(encodedDatabaseName) {
-  var encodedDatabaseNameRE = /xx?[0-9a-f]{4}/g;
-  return decode(encodedDatabaseName, encodedDatabaseNameRE);
+    var encodedDatabaseNameRE = /xx?[0-9a-f]{4}/g;
+    return decode(encodedDatabaseName, encodedDatabaseNameRE);
 }
 
 /**
@@ -134,8 +128,8 @@ function decodeDatabaseName(encodedDatabaseName) {
  * @return {String}              The encoded database name
  */
 function encodeCollectionName(collectionName) {
-  var collectionNameRegExp = /[$\0/]|^x?system.|x[0-9a-f]{4}/g;
-  return encode(collectionName, collectionNameRegExp);
+    var collectionNameRegExp = /[$\0/]|^x?system.|x[0-9a-f]{4}/g;
+    return encode(collectionName, collectionNameRegExp);
 }
 
 /**
@@ -155,13 +149,13 @@ function encodeCollectionName(collectionName) {
  * @return {String}                     The decoded database name
  */
 function decodeCollectionName(encodedCollectionName) {
-  var encodedCollectionNameRE = /xx?[0-9a-f]{4}|^xx?system./g;
-  return decode(encodedCollectionName, encodedCollectionNameRE);
+    var encodedCollectionNameRE = /xx?[0-9a-f]{4}|^xx?system./g;
+    return decode(encodedCollectionName, encodedCollectionNameRE);
 }
 
 module.exports = {
-  decodeDatabaseName: decodeDatabaseName,
-  encodeDatabaseName: encodeDatabaseName,
-  encodeCollectionName: encodeCollectionName,
-  decodeCollectionName: decodeCollectionName,
+    decodeDatabaseName: decodeDatabaseName,
+    encodeDatabaseName: encodeDatabaseName,
+    encodeCollectionName: encodeCollectionName,
+    decodeCollectionName: decodeCollectionName,
 };

--- a/lib/database/model/sthDatabaseNameCodecTool.js
+++ b/lib/database/model/sthDatabaseNameCodecTool.js
@@ -175,7 +175,7 @@ function analyseCollection(options, collectionData, callback) {
     analysisResult[collectionData.database].collections[collectionData.name] = {
         name: options.encode
             ? sthDatabaseNameCodec.encodeCollectionName(collectionData.name)
-            : sthDatabaseNameCodec.decodeCollectionName(collectionData.name),
+            : sthDatabaseNameCodec.decodeCollectionName(collectionData.name)
     };
     process.nextTick(callback);
 }
@@ -232,7 +232,7 @@ function analyseDatabase(options, databaseData, callback) {
     analysisResult[databaseData.name] = {
         name: options.encode
             ? sthDatabaseNameCodec.encodeDatabaseName(databaseData.name)
-            : sthDatabaseNameCodec.decodeDatabaseName(databaseData.name),
+            : sthDatabaseNameCodec.decodeDatabaseName(databaseData.name)
     };
     analyseCollections(options, databaseData.name, callback);
 }
@@ -319,7 +319,7 @@ function getEncodingAnalysis(options, callback) {
             dbURI: sthConfig.DB_URI,
             replicaSet: sthConfig.REPLICA_SET,
             database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-            poolSize: sthConfig.POOL_SIZE,
+            poolSize: sthConfig.POOL_SIZE
         }),
         listDatabases,
         async.apply(filterDatabases, options),
@@ -395,7 +395,7 @@ function copyDatabase(options, databaseName, callback) {
         fromdb: databaseName,
         todb: options.encode
             ? sthDatabaseNameCodec.encodeDatabaseName(databaseName)
-            : sthDatabaseNameCodec.decodeDatabaseName(databaseName),
+            : sthDatabaseNameCodec.decodeDatabaseName(databaseName)
     };
     adminDB.command(copyCommand, function onCopyDatabase(err) {
         if (err) {
@@ -534,5 +534,5 @@ function encodeOrDecode(options, callback) {
 
 module.exports = {
     getEncodingAnalysis: getEncodingAnalysis,
-    encodeOrDecode: encodeOrDecode,
+    encodeOrDecode: encodeOrDecode
 };

--- a/lib/database/model/sthDatabaseNameCodecTool.js
+++ b/lib/database/model/sthDatabaseNameCodecTool.js
@@ -38,8 +38,8 @@ var analysisResult = {};
  * Resets the analysis report
  */
 function resetAnalysisResult(callback) {
-  analysisResult = {};
-  return process.nextTick(callback);
+    analysisResult = {};
+    return process.nextTick(callback);
 }
 
 /**
@@ -49,8 +49,8 @@ function resetAnalysisResult(callback) {
  *                               as the second one
  */
 function listDatabases(connection, callback) {
-  var adminDB = connection.admin();
-  adminDB.listDatabases(callback);
+    var adminDB = connection.admin();
+    adminDB.listDatabases(callback);
 }
 
 /**
@@ -66,10 +66,13 @@ function listDatabases(connection, callback) {
  * @param  {Function} callback     The callback
  */
 function databaseFilter(options, databaseData, callback) {
-  callback(null,
-    (databaseData.name.indexOf(
-      (options.decode ? sthDatabaseNameCodec.decodeDatabaseName(sthConfig.DB_PREFIX) : sthConfig.DB_PREFIX) === 0)) &&
-      (!options.database || ((options.database && options.database === databaseData.name))));
+    callback(
+        null,
+        databaseData.name.indexOf(
+            (options.decode ? sthDatabaseNameCodec.decodeDatabaseName(sthConfig.DB_PREFIX) : sthConfig.DB_PREFIX) === 0
+        ) &&
+            (!options.database || (options.database && options.database === databaseData.name))
+    );
 }
 
 /**
@@ -85,7 +88,7 @@ function databaseFilter(options, databaseData, callback) {
  * @param  {Function} callback      The callback
  */
 function filterDatabases(options, databasesData, callback) {
-  async.filter(databasesData.databases, async.apply(databaseFilter, options), callback);
+    async.filter(databasesData.databases, async.apply(databaseFilter, options), callback);
 }
 
 /**
@@ -95,8 +98,8 @@ function filterDatabases(options, databasesData, callback) {
  * @param {Function} callback       The callback
  */
 function addDatabaseName(databaseName, collectionData, callback) {
-  collectionData.database = databaseName;
-  return callback(null, collectionData);
+    collectionData.database = databaseName;
+    return callback(null, collectionData);
 }
 
 /**
@@ -105,15 +108,14 @@ function addDatabaseName(databaseName, collectionData, callback) {
  * @param  {Function} callback     The callback
  */
 function listCollections(databaseName, callback) {
-  sthDatabase.connection.db(databaseName).listCollections().toArray(function(err, collections) {
-    if (collections) {
-      async.map(
-        collections,
-        async.apply(addDatabaseName, databaseName),
-        callback
-      );
-    }
-  });
+    sthDatabase.connection
+        .db(databaseName)
+        .listCollections()
+        .toArray(function(err, collections) {
+            if (collections) {
+                async.map(collections, async.apply(addDatabaseName, databaseName), callback);
+            }
+        });
 }
 
 /**
@@ -129,11 +131,15 @@ function listCollections(databaseName, callback) {
  * @param  {Function} callback       The callback
  */
 function collectionFilter(options, collectionData, callback) {
-  return callback(null,
-    (collectionData.name.indexOf(
-      (options.decode ? sthDatabaseNameCodec.decodeCollectionName(sthConfig.COLLECTION_PREFIX) :
-        sthConfig.COLLECTION_PREFIX)) === 0) &&
-      (!options.collection || (options.collection && options.collection === collectionData.name)));
+    return callback(
+        null,
+        collectionData.name.indexOf(
+            options.decode
+                ? sthDatabaseNameCodec.decodeCollectionName(sthConfig.COLLECTION_PREFIX)
+                : sthConfig.COLLECTION_PREFIX
+        ) === 0 &&
+            (!options.collection || (options.collection && options.collection === collectionData.name))
+    );
 }
 
 /**
@@ -149,7 +155,7 @@ function collectionFilter(options, collectionData, callback) {
  * @param  {Function} callback        The callback
  */
 function filterCollections(options, collectionsData, callback) {
-  async.filter(collectionsData, async.apply(collectionFilter, options), callback);
+    async.filter(collectionsData, async.apply(collectionFilter, options), callback);
 }
 
 /**
@@ -165,13 +171,13 @@ function filterCollections(options, collectionsData, callback) {
  * @param  {Function} callback       The callback
  */
 function analyseCollection(options, collectionData, callback) {
-  analysisResult[collectionData.database].collections = analysisResult[collectionData.database].collections || {};
-  analysisResult[collectionData.database].collections[collectionData.name] = {
-    name: (options.encode ?
-      sthDatabaseNameCodec.encodeCollectionName(collectionData.name) :
-      sthDatabaseNameCodec.decodeCollectionName(collectionData.name))
-  };
-  process.nextTick(callback);
+    analysisResult[collectionData.database].collections = analysisResult[collectionData.database].collections || {};
+    analysisResult[collectionData.database].collections[collectionData.name] = {
+        name: options.encode
+            ? sthDatabaseNameCodec.encodeCollectionName(collectionData.name)
+            : sthDatabaseNameCodec.decodeCollectionName(collectionData.name),
+    };
+    process.nextTick(callback);
 }
 
 /**
@@ -187,7 +193,7 @@ function analyseCollection(options, collectionData, callback) {
  * @param  {Function} callback        The callback
  */
 function doAnalyseCollections(options, collectionsData, callback) {
-  async.each(collectionsData, async.apply(analyseCollection, options), callback);
+    async.each(collectionsData, async.apply(analyseCollection, options), callback);
 }
 
 /**
@@ -203,11 +209,11 @@ function doAnalyseCollections(options, collectionsData, callback) {
  * @param  {Function} callback     The callback
  */
 function analyseCollections(options, databaseName, callback) {
-  async.seq(
-    async.apply(listCollections, databaseName),
-    async.apply(filterCollections, options),
-    async.apply(doAnalyseCollections, options)
-  )(callback);
+    async.seq(
+        async.apply(listCollections, databaseName),
+        async.apply(filterCollections, options),
+        async.apply(doAnalyseCollections, options)
+    )(callback);
 }
 
 /**
@@ -223,12 +229,12 @@ function analyseCollections(options, databaseName, callback) {
  * @param  {Function} callback     The callback
  */
 function analyseDatabase(options, databaseData, callback) {
-  analysisResult[databaseData.name] = {
-    name: (options.encode ?
-      sthDatabaseNameCodec.encodeDatabaseName(databaseData.name) :
-      sthDatabaseNameCodec.decodeDatabaseName(databaseData.name))
-  };
-  analyseCollections(options, databaseData.name, callback);
+    analysisResult[databaseData.name] = {
+        name: options.encode
+            ? sthDatabaseNameCodec.encodeDatabaseName(databaseData.name)
+            : sthDatabaseNameCodec.decodeDatabaseName(databaseData.name),
+    };
+    analyseCollections(options, databaseData.name, callback);
 }
 
 /**
@@ -244,7 +250,7 @@ function analyseDatabase(options, databaseData, callback) {
  * @param  {Function} callback      The callback
  */
 function analyseDatabases(options, databasesData, callback) {
-  async.each(databasesData, async.apply(analyseDatabase, options), callback);
+    async.each(databasesData, async.apply(analyseDatabase, options), callback);
 }
 
 /**
@@ -253,26 +259,26 @@ function analyseDatabases(options, databasesData, callback) {
  * @param  {Function} callback The callback
  */
 function cleanAnalysis(callback) {
-  var databaseNames = Object.getOwnPropertyNames(analysisResult);
-  databaseNames.forEach(function(databaseName) {
-    if (analysisResult[databaseName].collections) {
-      var collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
-      collectionNames.forEach(function(collectionName) {
-        if (collectionName === analysisResult[databaseName].collections[collectionName].name) {
-          delete analysisResult[databaseName].collections[collectionName];
+    var databaseNames = Object.getOwnPropertyNames(analysisResult);
+    databaseNames.forEach(function(databaseName) {
+        if (analysisResult[databaseName].collections) {
+            var collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
+            collectionNames.forEach(function(collectionName) {
+                if (collectionName === analysisResult[databaseName].collections[collectionName].name) {
+                    delete analysisResult[databaseName].collections[collectionName];
+                }
+            });
+            if (Object.keys(analysisResult[databaseName].collections).length === 0) {
+                delete analysisResult[databaseName].collections;
+                if (databaseName === analysisResult[databaseName].name) {
+                    delete analysisResult[databaseName];
+                }
+            }
+        } else if (databaseName === analysisResult[databaseName].name) {
+            delete analysisResult[databaseName];
         }
-      });
-      if (Object.keys(analysisResult[databaseName].collections).length === 0) {
-        delete analysisResult[databaseName].collections;
-        if (databaseName === analysisResult[databaseName].name) {
-          delete analysisResult[databaseName];
-        }
-      }
-    } else if (databaseName === analysisResult[databaseName].name) {
-      delete analysisResult[databaseName];
-    }
-  });
-  process.nextTick(callback.bind(null, null, analysisResult));
+    });
+    process.nextTick(callback.bind(null, null, analysisResult));
 }
 
 /**
@@ -286,32 +292,40 @@ function cleanAnalysis(callback) {
  *                            returned by the last function of the sequence
  */
 function getEncodingAnalysis(options, callback) {
-  if (!options.encode && !options.decode) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound('Either the -e (--encode) or the -d (--decode) options are mandatory')));
-  }
-  if (options.collection && !options.database) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound(
-        'The -b (--database) option is mandatory if the -c (--collection) option is set')));
-  }
-  async.seq(
-    resetAnalysisResult,
-    sthDatabase.connect.bind(
-      null,
-      {
-        authentication: sthConfig.DB_AUTHENTICATION,
-        dbURI: sthConfig.DB_URI,
-        replicaSet: sthConfig.REPLICA_SET,
-        database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-        poolSize: sthConfig.POOL_SIZE
-      }
-    ),
-    listDatabases,
-    async.apply(filterDatabases, options),
-    async.apply(analyseDatabases, options),
-    cleanAnalysis
-  )(callback);
+    if (!options.encode && !options.decode) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound(
+                    'Either the -e (--encode) or the -d (--decode) options are mandatory'
+                )
+            )
+        );
+    }
+    if (options.collection && !options.database) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound(
+                    'The -b (--database) option is mandatory if the -c (--collection) option is set'
+                )
+            )
+        );
+    }
+    async.seq(
+        resetAnalysisResult,
+        sthDatabase.connect.bind(null, {
+            authentication: sthConfig.DB_AUTHENTICATION,
+            dbURI: sthConfig.DB_URI,
+            replicaSet: sthConfig.REPLICA_SET,
+            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+            poolSize: sthConfig.POOL_SIZE,
+        }),
+        listDatabases,
+        async.apply(filterDatabases, options),
+        async.apply(analyseDatabases, options),
+        cleanAnalysis
+    )(callback);
 }
 
 /**
@@ -328,27 +342,39 @@ function getEncodingAnalysis(options, callback) {
  * @param  {Function} callback       The callback
  */
 function encodeOrDecodeCollection(options, databaseName, collectionName, callback) {
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_LOG,
-    (options.encode ? 'Codification' : 'Decodification') + ' of collection \'' + collectionName +
-      '\' of database \'' + databaseName + '\' started...');
-
-  sthDatabase.connection.db(databaseName).renameCollection(
-    collectionName,
-    options.encode ?
-      sthDatabaseNameCodec.encodeCollectionName(collectionName) :
-      sthDatabaseNameCodec.decodeCollectionName(collectionName),
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      sthLogger.info(
+    sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.encode ? 'Codification' : 'Decodification') + ' of collection \'' + collectionName +
-          '\' of database \'' + databaseName + '\' successfully completed.');
-      return process.nextTick(callback);
-    }
-  );
+        (options.encode ? 'Codification' : 'Decodification') +
+            " of collection '" +
+            collectionName +
+            "' of database '" +
+            databaseName +
+            "' started..."
+    );
+
+    sthDatabase.connection
+        .db(databaseName)
+        .renameCollection(
+            collectionName,
+            options.encode
+                ? sthDatabaseNameCodec.encodeCollectionName(collectionName)
+                : sthDatabaseNameCodec.decodeCollectionName(collectionName),
+            function(err) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                sthLogger.info(
+                    sthConfig.LOGGING_CONTEXT.DB_LOG,
+                    (options.encode ? 'Codification' : 'Decodification') +
+                        " of collection '" +
+                        collectionName +
+                        "' of database '" +
+                        databaseName +
+                        "' successfully completed."
+                );
+                return process.nextTick(callback);
+            }
+        );
 }
 
 /**
@@ -363,29 +389,32 @@ function encodeOrDecodeCollection(options, databaseName, collectionName, callbac
  * @param  {Function} callback     The callback
  */
 function copyDatabase(options, databaseName, callback) {
-  var adminDB = sthDatabase.connection.admin();
-  var copyCommand = {
-    copydb: 1,
-    fromdb: databaseName,
-    todb: (options.encode ?
-            sthDatabaseNameCodec.encodeDatabaseName(databaseName) :
-            sthDatabaseNameCodec.decodeDatabaseName(databaseName))
-  };
-  adminDB.command(copyCommand, function onCopyDatabase(err) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    sthDatabase.connection.db(databaseName).dropDatabase(function onDropDatabase(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      sthLogger.info(
-        sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.encode ? 'Codification' : 'Decodification') + ' of database \'' + databaseName +
-          ' successfully completed.');
-      process.nextTick(callback);
+    var adminDB = sthDatabase.connection.admin();
+    var copyCommand = {
+        copydb: 1,
+        fromdb: databaseName,
+        todb: options.encode
+            ? sthDatabaseNameCodec.encodeDatabaseName(databaseName)
+            : sthDatabaseNameCodec.decodeDatabaseName(databaseName),
+    };
+    adminDB.command(copyCommand, function onCopyDatabase(err) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
+        }
+        sthDatabase.connection.db(databaseName).dropDatabase(function onDropDatabase(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            sthLogger.info(
+                sthConfig.LOGGING_CONTEXT.DB_LOG,
+                (options.encode ? 'Codification' : 'Decodification') +
+                    " of database '" +
+                    databaseName +
+                    ' successfully completed.'
+            );
+            process.nextTick(callback);
+        });
     });
-  });
 }
 
 /**
@@ -400,43 +429,52 @@ function copyDatabase(options, databaseName, callback) {
  * @param  {Function} callback     The callback
  */
 function encodeOrDecodeDatabase(options, databaseName, callback) {
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_LOG,
-    (options.encode ? 'Codification' : 'Decodification') + ' of database \'' + databaseName + ' started...');
-
-  var collectionNames;
-  if (analysisResult[databaseName].collections &&
-    Object.getOwnPropertyNames(analysisResult[databaseName].collections).length) {
-      collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
-      async.eachSeries(
-        collectionNames,
-        async.apply(encodeOrDecodeCollection, options, databaseName),
-        function onEncodeOrDecodeCollection(err) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          if (databaseName !== analysisResult[databaseName].name) {
-            copyDatabase(options, databaseName, callback);
-          } else {
-            sthLogger.info(
-              sthConfig.LOGGING_CONTEXT.DB_LOG,
-              (options.encode ? 'Codification' : 'Decodification') + ' of database \'' + databaseName +
-                ' successfully completed.');
-            process.nextTick(callback);
-          }
-        }
-      );
-  } else {
-    if (databaseName !== analysisResult[databaseName].name) {
-      copyDatabase(options, databaseName, callback);
-    } else {
-      sthLogger.info(
+    sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.encode ? 'Codification' : 'Decodification') + ' of database \'' + databaseName +
-          ' successfully completed.');
-      process.nextTick(callback);
+        (options.encode ? 'Codification' : 'Decodification') + " of database '" + databaseName + ' started...'
+    );
+
+    var collectionNames;
+    if (
+        analysisResult[databaseName].collections &&
+        Object.getOwnPropertyNames(analysisResult[databaseName].collections).length
+    ) {
+        collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
+        async.eachSeries(
+            collectionNames,
+            async.apply(encodeOrDecodeCollection, options, databaseName),
+            function onEncodeOrDecodeCollection(err) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                if (databaseName !== analysisResult[databaseName].name) {
+                    copyDatabase(options, databaseName, callback);
+                } else {
+                    sthLogger.info(
+                        sthConfig.LOGGING_CONTEXT.DB_LOG,
+                        (options.encode ? 'Codification' : 'Decodification') +
+                            " of database '" +
+                            databaseName +
+                            ' successfully completed.'
+                    );
+                    process.nextTick(callback);
+                }
+            }
+        );
+    } else {
+        if (databaseName !== analysisResult[databaseName].name) {
+            copyDatabase(options, databaseName, callback);
+        } else {
+            sthLogger.info(
+                sthConfig.LOGGING_CONTEXT.DB_LOG,
+                (options.encode ? 'Codification' : 'Decodification') +
+                    " of database '" +
+                    databaseName +
+                    ' successfully completed.'
+            );
+            process.nextTick(callback);
+        }
     }
-  }
 }
 
 /**
@@ -451,8 +489,8 @@ function encodeOrDecodeDatabase(options, databaseName, callback) {
  * @param  {Function} callback The callback
  */
 function doEncodeOrDecode(options, analysis, callback) {
-  var databaseNames = Object.getOwnPropertyNames(analysis);
-  async.eachSeries(databaseNames, async.apply(encodeOrDecodeDatabase, options), callback);
+    var databaseNames = Object.getOwnPropertyNames(analysis);
+    async.eachSeries(databaseNames, async.apply(encodeOrDecodeDatabase, options), callback);
 }
 
 /**
@@ -465,28 +503,36 @@ function doEncodeOrDecode(options, analysis, callback) {
  * @param  {Function} callback The callback
  */
 function encodeOrDecode(options, callback) {
-  if (!options.encode && !options.decode) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound('Either the -e (--encode) or the -d (--decode) options are mandatory')));
-  }
-  if (options.collection && !options.database) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound(
-        'The -b (--database) option is mandatory if the -c (--collection) option is set')));
-  }
+    if (!options.encode && !options.decode) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound(
+                    'Either the -e (--encode) or the -d (--decode) options are mandatory'
+                )
+            )
+        );
+    }
+    if (options.collection && !options.database) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound(
+                    'The -b (--database) option is mandatory if the -c (--collection) option is set'
+                )
+            )
+        );
+    }
 
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_LOG,
-    (options.encode ? 'Codification' : 'Decodification') + ' process started...'
-  );
+    sthLogger.info(
+        sthConfig.LOGGING_CONTEXT.DB_LOG,
+        (options.encode ? 'Codification' : 'Decodification') + ' process started...'
+    );
 
-  async.seq(
-    async.apply(getEncodingAnalysis, options),
-    async.apply(doEncodeOrDecode, options)
-  )(callback);
+    async.seq(async.apply(getEncodingAnalysis, options), async.apply(doEncodeOrDecode, options))(callback);
 }
 
 module.exports = {
-  getEncodingAnalysis: getEncodingAnalysis,
-  encodeOrDecode: encodeOrDecode
+    getEncodingAnalysis: getEncodingAnalysis,
+    encodeOrDecode: encodeOrDecode,
 };

--- a/lib/database/model/sthDatabaseNameCodecTool.js
+++ b/lib/database/model/sthDatabaseNameCodecTool.js
@@ -344,12 +344,9 @@ function getEncodingAnalysis(options, callback) {
 function encodeOrDecodeCollection(options, databaseName, collectionName, callback) {
     sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.encode ? 'Codification' : 'Decodification') +
-            " of collection '" +
-            collectionName +
-            "' of database '" +
-            databaseName +
-            "' started..."
+        // prettier-ignore
+        (options.encode ? 'Codification' : 'Decodification') + " of collection '" + collectionName + 
+            "' of database '" + databaseName + "' started..."
     );
 
     sthDatabase.connection
@@ -365,12 +362,9 @@ function encodeOrDecodeCollection(options, databaseName, collectionName, callbac
                 }
                 sthLogger.info(
                     sthConfig.LOGGING_CONTEXT.DB_LOG,
-                    (options.encode ? 'Codification' : 'Decodification') +
-                        " of collection '" +
-                        collectionName +
-                        "' of database '" +
-                        databaseName +
-                        "' successfully completed."
+                    // prettier-ignore
+                    (options.encode ? 'Codification' : 'Decodification') + " of collection '" + collectionName +
+                         "' of database '" + databaseName + "' successfully completed."
                 );
                 return process.nextTick(callback);
             }
@@ -407,9 +401,8 @@ function copyDatabase(options, databaseName, callback) {
             }
             sthLogger.info(
                 sthConfig.LOGGING_CONTEXT.DB_LOG,
-                (options.encode ? 'Codification' : 'Decodification') +
-                    " of database '" +
-                    databaseName +
+                // prettier-ignore
+                (options.encode ? 'Codification' : 'Decodification') + " of database '" + databaseName + 
                     ' successfully completed.'
             );
             process.nextTick(callback);
@@ -452,9 +445,8 @@ function encodeOrDecodeDatabase(options, databaseName, callback) {
                 } else {
                     sthLogger.info(
                         sthConfig.LOGGING_CONTEXT.DB_LOG,
-                        (options.encode ? 'Codification' : 'Decodification') +
-                            " of database '" +
-                            databaseName +
+                        // prettier-ignore
+                        (options.encode ? 'Codification' : 'Decodification') + " of database '" + databaseName + 
                             ' successfully completed.'
                     );
                     process.nextTick(callback);
@@ -467,9 +459,8 @@ function encodeOrDecodeDatabase(options, databaseName, callback) {
         } else {
             sthLogger.info(
                 sthConfig.LOGGING_CONTEXT.DB_LOG,
-                (options.encode ? 'Codification' : 'Decodification') +
-                    " of database '" +
-                    databaseName +
+                // prettier-ignore
+                (options.encode ? 'Codification' : 'Decodification') + " of database '" + databaseName + 
                     ' successfully completed.'
             );
             process.nextTick(callback);

--- a/lib/database/model/sthDatabaseNameMapper.js
+++ b/lib/database/model/sthDatabaseNameMapper.js
@@ -32,15 +32,18 @@ var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
  * @return {String}         The new service name or null if no mapping is available
  */
 function mapService(service) {
-  if (sthConfig.NAME_MAPPING && sthConfig.NAME_MAPPING.serviceMappings &&
-    Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)) {
-    for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
-      if (sthConfig.NAME_MAPPING.serviceMappings[ii].originalService === service) {
-        return sthConfig.NAME_MAPPING.serviceMappings[ii].newService;
-      }
+    if (
+        sthConfig.NAME_MAPPING &&
+        sthConfig.NAME_MAPPING.serviceMappings &&
+        Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)
+    ) {
+        for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
+            if (sthConfig.NAME_MAPPING.serviceMappings[ii].originalService === service) {
+                return sthConfig.NAME_MAPPING.serviceMappings[ii].newService;
+            }
+        }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -49,15 +52,18 @@ function mapService(service) {
  * @return {String}         The original service name or null if no mapping is available
  */
 function unmapService(service) {
-  if (sthConfig.NAME_MAPPING && sthConfig.NAME_MAPPING.serviceMappings &&
-    Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)) {
-    for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
-      if (sthConfig.NAME_MAPPING.serviceMappings[ii].newService === service) {
-        return sthConfig.NAME_MAPPING.serviceMappings[ii].originalService;
-      }
+    if (
+        sthConfig.NAME_MAPPING &&
+        sthConfig.NAME_MAPPING.serviceMappings &&
+        Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)
+    ) {
+        for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
+            if (sthConfig.NAME_MAPPING.serviceMappings[ii].newService === service) {
+                return sthConfig.NAME_MAPPING.serviceMappings[ii].originalService;
+            }
+        }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -66,15 +72,18 @@ function unmapService(service) {
  * @return {Number}         The array index associated to the concrete service mapping or -1 if no mapping is available
  */
 function getserviceMappingsIndexFromOriginal(service) {
-  if (sthConfig.NAME_MAPPING && sthConfig.NAME_MAPPING.serviceMappings &&
-    Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)) {
-    for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
-      if (sthConfig.NAME_MAPPING.serviceMappings[ii].originalService === service) {
-        return ii;
-      }
+    if (
+        sthConfig.NAME_MAPPING &&
+        sthConfig.NAME_MAPPING.serviceMappings &&
+        Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)
+    ) {
+        for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
+            if (sthConfig.NAME_MAPPING.serviceMappings[ii].originalService === service) {
+                return ii;
+            }
+        }
     }
-  }
-  return -1;
+    return -1;
 }
 
 /**
@@ -83,15 +92,18 @@ function getserviceMappingsIndexFromOriginal(service) {
  * @return {Number}         The array index associated to the concrete service mapping or -1 if no mapping is available
  */
 function getserviceMappingsIndexFromNew(service) {
-  if (sthConfig.NAME_MAPPING && sthConfig.NAME_MAPPING.serviceMappings &&
-    Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)) {
-    for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
-      if (sthConfig.NAME_MAPPING.serviceMappings[ii].newService === service) {
-        return ii;
-      }
+    if (
+        sthConfig.NAME_MAPPING &&
+        sthConfig.NAME_MAPPING.serviceMappings &&
+        Array.isArray(sthConfig.NAME_MAPPING.serviceMappings)
+    ) {
+        for (var ii = 0; ii < sthConfig.NAME_MAPPING.serviceMappings.length; ii++) {
+            if (sthConfig.NAME_MAPPING.serviceMappings[ii].newService === service) {
+                return ii;
+            }
+        }
     }
-  }
-  return -1;
+    return -1;
 }
 
 /**
@@ -101,19 +113,19 @@ function getserviceMappingsIndexFromNew(service) {
  * @return {String}             The new service path or null if no mapping is available
  */
 function mapServicePath(service, servicePath) {
-  var serviceMappingsIndex = getserviceMappingsIndexFromOriginal(service),
-      servicePathMappings;
-  if (serviceMappingsIndex >= 0) {
-    servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
-    if (servicePathMappings && Array.isArray(servicePathMappings)) {
-      for (var ii = 0; ii < servicePathMappings.length; ii++) {
-        if (servicePathMappings[ii].originalServicePath === servicePath) {
-          return servicePathMappings[ii].newServicePath;
+    var serviceMappingsIndex = getserviceMappingsIndexFromOriginal(service),
+        servicePathMappings;
+    if (serviceMappingsIndex >= 0) {
+        servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
+        if (servicePathMappings && Array.isArray(servicePathMappings)) {
+            for (var ii = 0; ii < servicePathMappings.length; ii++) {
+                if (servicePathMappings[ii].originalServicePath === servicePath) {
+                    return servicePathMappings[ii].newServicePath;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -124,19 +136,19 @@ function mapServicePath(service, servicePath) {
  * @return {String}             The original service path or null if no mapping is available
  */
 function unmapServicePath(service, servicePath) {
-  var serviceMappingsIndex = getserviceMappingsIndexFromNew(service),
-      servicePathMappings;
-  if (serviceMappingsIndex >= 0) {
-    servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
-    if (servicePathMappings && Array.isArray(servicePathMappings)) {
-      for (var ii = 0; ii < servicePathMappings.length; ii++) {
-        if (servicePathMappings[ii].newServicePath === servicePath) {
-          return servicePathMappings[ii].originalServicePath;
+    var serviceMappingsIndex = getserviceMappingsIndexFromNew(service),
+        servicePathMappings;
+    if (serviceMappingsIndex >= 0) {
+        servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
+        if (servicePathMappings && Array.isArray(servicePathMappings)) {
+            for (var ii = 0; ii < servicePathMappings.length; ii++) {
+                if (servicePathMappings[ii].newServicePath === servicePath) {
+                    return servicePathMappings[ii].originalServicePath;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -147,19 +159,19 @@ function unmapServicePath(service, servicePath) {
  *                              service path mapping is available
  */
 function getServicePathMappingIndexesFromOriginal(service, servicePath) {
-  var serviceMappingsIndex = getserviceMappingsIndexFromOriginal(service),
-      servicePathMappings;
-  if (serviceMappingsIndex >= 0) {
-    servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
-    if (servicePathMappings && Array.isArray(servicePathMappings)) {
-      for (var ii = 0; ii < servicePathMappings.length; ii++) {
-        if (servicePathMappings[ii].originalServicePath === servicePath) {
-          return [serviceMappingsIndex, ii];
+    var serviceMappingsIndex = getserviceMappingsIndexFromOriginal(service),
+        servicePathMappings;
+    if (serviceMappingsIndex >= 0) {
+        servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
+        if (servicePathMappings && Array.isArray(servicePathMappings)) {
+            for (var ii = 0; ii < servicePathMappings.length; ii++) {
+                if (servicePathMappings[ii].originalServicePath === servicePath) {
+                    return [serviceMappingsIndex, ii];
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -170,19 +182,19 @@ function getServicePathMappingIndexesFromOriginal(service, servicePath) {
  *                              service path mapping is available
  */
 function getServicePathMappingIndexesFromNew(service, servicePath) {
-  var serviceMappingsIndex = getserviceMappingsIndexFromNew(service),
-      servicePathMappings;
-  if (serviceMappingsIndex >= 0) {
-    servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
-    if (servicePathMappings && Array.isArray(servicePathMappings)) {
-      for (var ii = 0; ii < servicePathMappings.length; ii++) {
-        if (servicePathMappings[ii].newServicePath === servicePath) {
-          return [serviceMappingsIndex, ii];
+    var serviceMappingsIndex = getserviceMappingsIndexFromNew(service),
+        servicePathMappings;
+    if (serviceMappingsIndex >= 0) {
+        servicePathMappings = sthConfig.NAME_MAPPING.serviceMappings[serviceMappingsIndex].servicePathMappings;
+        if (servicePathMappings && Array.isArray(servicePathMappings)) {
+            for (var ii = 0; ii < servicePathMappings.length; ii++) {
+                if (servicePathMappings[ii].newServicePath === servicePath) {
+                    return [serviceMappingsIndex, ii];
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -193,20 +205,22 @@ function getServicePathMappingIndexesFromNew(service, servicePath) {
  * @return {String}             The new entity name or null if no mapping is available
  */
 function mapEntityName(service, servicePath, entityId) {
-  var servicePathMappingsIndexes = getServicePathMappingIndexesFromOriginal(service, servicePath),
-      entityMappings;
-  if (servicePathMappingsIndexes) {
-    entityMappings = sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].
-      servicePathMappings[servicePathMappingsIndexes[1]].entityMappings;
-    if (entityMappings && Array.isArray(entityMappings)) {
-      for (var ii = 0; ii < entityMappings.length; ii++) {
-        if (entityMappings[ii].originalEntityId === entityId) {
-          return entityMappings[ii].newEntityId;
+    var servicePathMappingsIndexes = getServicePathMappingIndexesFromOriginal(service, servicePath),
+        entityMappings;
+    if (servicePathMappingsIndexes) {
+        entityMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].servicePathMappings[
+                servicePathMappingsIndexes[1]
+            ].entityMappings;
+        if (entityMappings && Array.isArray(entityMappings)) {
+            for (var ii = 0; ii < entityMappings.length; ii++) {
+                if (entityMappings[ii].originalEntityId === entityId) {
+                    return entityMappings[ii].newEntityId;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -217,20 +231,22 @@ function mapEntityName(service, servicePath, entityId) {
  * @return {String}             The original entity name or null if no mapping is available
  */
 function unmapEntityName(service, servicePath, entityId) {
-  var servicePathMappingsIndexes = getServicePathMappingIndexesFromNew(service, servicePath),
-      entityMappings;
-  if (servicePathMappingsIndexes) {
-    entityMappings = sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].
-      servicePathMappings[servicePathMappingsIndexes[1]].entityMappings;
-    if (entityMappings && Array.isArray(entityMappings)) {
-      for (var ii = 0; ii < entityMappings.length; ii++) {
-        if (entityMappings[ii].newEntityId === entityId) {
-          return entityMappings[ii].originalEntityId;
+    var servicePathMappingsIndexes = getServicePathMappingIndexesFromNew(service, servicePath),
+        entityMappings;
+    if (servicePathMappingsIndexes) {
+        entityMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].servicePathMappings[
+                servicePathMappingsIndexes[1]
+            ].entityMappings;
+        if (entityMappings && Array.isArray(entityMappings)) {
+            for (var ii = 0; ii < entityMappings.length; ii++) {
+                if (entityMappings[ii].newEntityId === entityId) {
+                    return entityMappings[ii].originalEntityId;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -241,20 +257,22 @@ function unmapEntityName(service, servicePath, entityId) {
  * @return {String}             The new entity type or null if no mapping is available
  */
 function mapEntityType(service, servicePath, entityType) {
-  var servicePathMappingsIndexes = getServicePathMappingIndexesFromOriginal(service, servicePath),
-      entityMappings;
-  if (servicePathMappingsIndexes) {
-    entityMappings = sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].
-      servicePathMappings[servicePathMappingsIndexes[1]].entityMappings;
-    if (entityMappings && Array.isArray(entityMappings)) {
-      for (var ii = 0; ii < entityMappings.length; ii++) {
-        if (entityMappings[ii].originalEntityType === entityType) {
-          return entityMappings[ii].newEntityType;
+    var servicePathMappingsIndexes = getServicePathMappingIndexesFromOriginal(service, servicePath),
+        entityMappings;
+    if (servicePathMappingsIndexes) {
+        entityMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].servicePathMappings[
+                servicePathMappingsIndexes[1]
+            ].entityMappings;
+        if (entityMappings && Array.isArray(entityMappings)) {
+            for (var ii = 0; ii < entityMappings.length; ii++) {
+                if (entityMappings[ii].originalEntityType === entityType) {
+                    return entityMappings[ii].newEntityType;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -265,20 +283,22 @@ function mapEntityType(service, servicePath, entityType) {
  * @return {String}             The original entity type or null if no mapping is available
  */
 function unmapEntityType(service, servicePath, entityType) {
-  var servicePathMappingsIndexes = getServicePathMappingIndexesFromNew(service, servicePath),
-      entityMappings;
-  if (servicePathMappingsIndexes) {
-    entityMappings = sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].
-      servicePathMappings[servicePathMappingsIndexes[1]].entityMappings;
-    if (entityMappings && Array.isArray(entityMappings)) {
-      for (var ii = 0; ii < entityMappings.length; ii++) {
-        if (entityMappings[ii].newEntityType === entityType) {
-          return entityMappings[ii].originalEntityType;
+    var servicePathMappingsIndexes = getServicePathMappingIndexesFromNew(service, servicePath),
+        entityMappings;
+    if (servicePathMappingsIndexes) {
+        entityMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].servicePathMappings[
+                servicePathMappingsIndexes[1]
+            ].entityMappings;
+        if (entityMappings && Array.isArray(entityMappings)) {
+            for (var ii = 0; ii < entityMappings.length; ii++) {
+                if (entityMappings[ii].newEntityType === entityType) {
+                    return entityMappings[ii].originalEntityType;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -291,20 +311,22 @@ function unmapEntityType(service, servicePath, entityType) {
  *                              indexes or null if no entity mapping is available
  */
 function getEntityMappingIndexesFromOriginal(service, servicePath, entityId) {
-  var servicePathMappingsIndexes = getServicePathMappingIndexesFromOriginal(service, servicePath),
-      entityMappings;
-  if (servicePathMappingsIndexes) {
-    entityMappings = sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].
-      servicePathMappings[servicePathMappingsIndexes[1]].entityMappings;
-    if (entityMappings && Array.isArray(entityMappings)) {
-      for (var ii = 0; ii < entityMappings.length; ii++) {
-        if (entityMappings[ii].originalEntityId === entityId) {
-          return [servicePathMappingsIndexes[0], servicePathMappingsIndexes[1], ii];
+    var servicePathMappingsIndexes = getServicePathMappingIndexesFromOriginal(service, servicePath),
+        entityMappings;
+    if (servicePathMappingsIndexes) {
+        entityMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].servicePathMappings[
+                servicePathMappingsIndexes[1]
+            ].entityMappings;
+        if (entityMappings && Array.isArray(entityMappings)) {
+            for (var ii = 0; ii < entityMappings.length; ii++) {
+                if (entityMappings[ii].originalEntityId === entityId) {
+                    return [servicePathMappingsIndexes[0], servicePathMappingsIndexes[1], ii];
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -317,20 +339,22 @@ function getEntityMappingIndexesFromOriginal(service, servicePath, entityId) {
  *                              indexes or null if no entity mapping is available
  */
 function getEntityMappingIndexesFromNew(service, servicePath, entityId) {
-  var servicePathMappingsIndexes = getServicePathMappingIndexesFromNew(service, servicePath),
-      entityMappings;
-  if (servicePathMappingsIndexes) {
-    entityMappings = sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].
-      servicePathMappings[servicePathMappingsIndexes[1]].entityMappings;
-    if (entityMappings && Array.isArray(entityMappings)) {
-      for (var ii = 0; ii < entityMappings.length; ii++) {
-        if (entityMappings[ii].newEntityId === entityId) {
-          return [servicePathMappingsIndexes[0], servicePathMappingsIndexes[1], ii];
+    var servicePathMappingsIndexes = getServicePathMappingIndexesFromNew(service, servicePath),
+        entityMappings;
+    if (servicePathMappingsIndexes) {
+        entityMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[servicePathMappingsIndexes[0]].servicePathMappings[
+                servicePathMappingsIndexes[1]
+            ].entityMappings;
+        if (entityMappings && Array.isArray(entityMappings)) {
+            for (var ii = 0; ii < entityMappings.length; ii++) {
+                if (entityMappings[ii].newEntityId === entityId) {
+                    return [servicePathMappingsIndexes[0], servicePathMappingsIndexes[1], ii];
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -342,20 +366,22 @@ function getEntityMappingIndexesFromNew(service, servicePath, entityId) {
  * @return {String}                The new attribute name or null if no mapping is available
  */
 function mapAttributeName(service, servicePath, entityId, attributeName) {
-  var entityMappingsIndexes = getEntityMappingIndexesFromOriginal(service, servicePath, entityId),
-      attributeMappings;
-  if (entityMappingsIndexes) {
-    attributeMappings = sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].
-      servicePathMappings[entityMappingsIndexes[1]].entityMappings[entityMappingsIndexes[2]].attributeMappings;
-    if (attributeMappings && Array.isArray(attributeMappings)) {
-      for (var ii = 0; ii < attributeMappings.length; ii++) {
-        if (attributeMappings[ii].originalAttributeName === attributeName) {
-          return attributeMappings[ii].newAttributeName;
+    var entityMappingsIndexes = getEntityMappingIndexesFromOriginal(service, servicePath, entityId),
+        attributeMappings;
+    if (entityMappingsIndexes) {
+        attributeMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].servicePathMappings[
+                entityMappingsIndexes[1]
+            ].entityMappings[entityMappingsIndexes[2]].attributeMappings;
+        if (attributeMappings && Array.isArray(attributeMappings)) {
+            for (var ii = 0; ii < attributeMappings.length; ii++) {
+                if (attributeMappings[ii].originalAttributeName === attributeName) {
+                    return attributeMappings[ii].newAttributeName;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -367,20 +393,22 @@ function mapAttributeName(service, servicePath, entityId, attributeName) {
  * @return {String}                The original attribute name or null if no mapping is available
  */
 function unmapAttributeName(service, servicePath, entityId, attributeName) {
-  var entityMappingsIndexes = getEntityMappingIndexesFromNew(service, servicePath, entityId),
-      attributeMappings;
-  if (entityMappingsIndexes) {
-    attributeMappings = sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].
-      servicePathMappings[entityMappingsIndexes[1]].entityMappings[entityMappingsIndexes[2]].attributeMappings;
-    if (attributeMappings && Array.isArray(attributeMappings)) {
-      for (var ii = 0; ii < attributeMappings.length; ii++) {
-        if (attributeMappings[ii].newAttributeName === attributeName) {
-          return attributeMappings[ii].originalAttributeName;
+    var entityMappingsIndexes = getEntityMappingIndexesFromNew(service, servicePath, entityId),
+        attributeMappings;
+    if (entityMappingsIndexes) {
+        attributeMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].servicePathMappings[
+                entityMappingsIndexes[1]
+            ].entityMappings[entityMappingsIndexes[2]].attributeMappings;
+        if (attributeMappings && Array.isArray(attributeMappings)) {
+            for (var ii = 0; ii < attributeMappings.length; ii++) {
+                if (attributeMappings[ii].newAttributeName === attributeName) {
+                    return attributeMappings[ii].originalAttributeName;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -392,20 +420,22 @@ function unmapAttributeName(service, servicePath, entityId, attributeName) {
  * @return {String}                The new attribute type or null if no mapping is available
  */
 function mapAttributeType(service, servicePath, entityId, attributeType) {
-  var entityMappingsIndexes = getEntityMappingIndexesFromOriginal(service, servicePath, entityId),
-      attributeMappings;
-  if (entityMappingsIndexes) {
-    attributeMappings = sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].
-      servicePathMappings[entityMappingsIndexes[1]].entityMappings[entityMappingsIndexes[2]].attributeMappings;
-    if (attributeMappings && Array.isArray(attributeMappings)) {
-      for (var ii = 0; ii < attributeMappings.length; ii++) {
-        if (attributeMappings[ii].originalAttributeType === attributeType) {
-          return attributeMappings[ii].newAttributeType;
+    var entityMappingsIndexes = getEntityMappingIndexesFromOriginal(service, servicePath, entityId),
+        attributeMappings;
+    if (entityMappingsIndexes) {
+        attributeMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].servicePathMappings[
+                entityMappingsIndexes[1]
+            ].entityMappings[entityMappingsIndexes[2]].attributeMappings;
+        if (attributeMappings && Array.isArray(attributeMappings)) {
+            for (var ii = 0; ii < attributeMappings.length; ii++) {
+                if (attributeMappings[ii].originalAttributeType === attributeType) {
+                    return attributeMappings[ii].newAttributeType;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -417,20 +447,22 @@ function mapAttributeType(service, servicePath, entityId, attributeType) {
  * @return {String}                The original attribute type or null if no mapping is available
  */
 function unmapAttributeType(service, servicePath, entityId, attributeType) {
-  var entityMappingsIndexes = getEntityMappingIndexesFromNew(service, servicePath, entityId),
-      attributeMappings;
-  if (entityMappingsIndexes) {
-    attributeMappings = sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].
-      servicePathMappings[entityMappingsIndexes[1]].entityMappings[entityMappingsIndexes[2]].attributeMappings;
-    if (attributeMappings && Array.isArray(attributeMappings)) {
-      for (var ii = 0; ii < attributeMappings.length; ii++) {
-        if (attributeMappings[ii].newAttributeType === attributeType) {
-          return attributeMappings[ii].originalAttributeType;
+    var entityMappingsIndexes = getEntityMappingIndexesFromNew(service, servicePath, entityId),
+        attributeMappings;
+    if (entityMappingsIndexes) {
+        attributeMappings =
+            sthConfig.NAME_MAPPING.serviceMappings[entityMappingsIndexes[0]].servicePathMappings[
+                entityMappingsIndexes[1]
+            ].entityMappings[entityMappingsIndexes[2]].attributeMappings;
+        if (attributeMappings && Array.isArray(attributeMappings)) {
+            for (var ii = 0; ii < attributeMappings.length; ii++) {
+                if (attributeMappings[ii].newAttributeType === attributeType) {
+                    return attributeMappings[ii].originalAttributeType;
+                }
+            }
         }
-      }
     }
-  }
-  return null;
+    return null;
 }
 
 /**
@@ -439,13 +471,13 @@ function unmapAttributeType(service, servicePath, entityId, attributeType) {
  * @return {String}              The mapped database name
  */
 function mapDatabaseName(databaseName) {
-  var originalService = databaseName.substring(sthConfig.DB_PREFIX.length);
-  var newService = mapService(originalService);
-  if (newService) {
-    return sthConfig.DB_PREFIX + newService;
-  } else {
-    return databaseName;
-  }
+    var originalService = databaseName.substring(sthConfig.DB_PREFIX.length);
+    var newService = mapService(originalService);
+    if (newService) {
+        return sthConfig.DB_PREFIX + newService;
+    } else {
+        return databaseName;
+    }
 }
 
 /**
@@ -454,13 +486,13 @@ function mapDatabaseName(databaseName) {
  * @return {String}              The unmapped database name
  */
 function unmapDatabaseName(databaseName) {
-  var newService = databaseName.substring(sthConfig.DB_PREFIX.length);
-  var originalService = unmapService(newService);
-  if (originalService) {
-    return sthConfig.DB_PREFIX + originalService;
-  } else {
-    return databaseName;
-  }
+    var newService = databaseName.substring(sthConfig.DB_PREFIX.length);
+    var originalService = unmapService(newService);
+    if (originalService) {
+        return sthConfig.DB_PREFIX + originalService;
+    } else {
+        return databaseName;
+    }
 }
 
 /**
@@ -469,12 +501,14 @@ function unmapDatabaseName(databaseName) {
  * @return {boolean} True if the collection name corresponds to an aggregated data collection, false otherwise.
  */
 function isAggregated(collectionName) {
-  if (collectionName.lastIndexOf('.aggr') === -1 ||
-    collectionName.lastIndexOf('.aggr') !== collectionName.length - '.aggr'.length) {
-    return false;
-  } else {
-    return true;
-  }
+    if (
+        collectionName.lastIndexOf('.aggr') === -1 ||
+        collectionName.lastIndexOf('.aggr') !== collectionName.length - '.aggr'.length
+    ) {
+        return false;
+    } else {
+        return true;
+    }
 }
 
 /**
@@ -484,79 +518,105 @@ function isAggregated(collectionName) {
  * @return {String}                The new collection name
  */
 function mapCollectionName(service, collectionName) {
-  var auxCollectionName,
-      originalServicePath,
-      newServicePath,
-      originalEntityId,
-      newEntityId,
-      originalEntityType,
-      newEntityType,
-      originalAttributeName,
-      newAttributeName;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      originalServicePath = collectionName.substring(
-        sthConfig.COLLECTION_PREFIX.length,
-        isAggregated(collectionName) ? collectionName.length - '.aggr'.length : collectionName.length
-      );
-      newServicePath = mapServicePath(service, originalServicePath);
-      if (newServicePath) {
-        return sthConfig.COLLECTION_PREFIX + newServicePath + (isAggregated(collectionName) ? '.aggr' : '');
-      } else {
-        return collectionName;
-      }
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
-      originalServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-      newServicePath = mapServicePath(service, originalServicePath);
-      auxCollectionName = auxCollectionName.substring(originalServicePath.length + sthConfig.NAME_SEPARATOR.length);
-      if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
-        originalEntityId = isAggregated(collectionName) ?
-          auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length) :
-          auxCollectionName;
-        newEntityId = mapEntityName(service, originalServicePath, originalEntityId);
-      } else {
-        originalEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-        newEntityId = mapEntityName(service, originalServicePath, originalEntityId);
-        originalEntityType = auxCollectionName.substring(
-          originalEntityId.length + sthConfig.NAME_SEPARATOR.length,
-          isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
-        );
-        newEntityType = mapEntityType(service, originalServicePath, originalEntityType);
-      }
-      return sthConfig.COLLECTION_PREFIX + (newServicePath || originalServicePath) + sthConfig.NAME_SEPARATOR +
-        (newEntityId || originalEntityId) +
-        (originalEntityType ? sthConfig.NAME_SEPARATOR + (newEntityType || originalEntityType) : '') +
-        (isAggregated(collectionName) ? '.aggr' : '');
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
-      originalServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-      newServicePath = mapServicePath(service, originalServicePath);
-      auxCollectionName = auxCollectionName.substring(originalServicePath.length + sthConfig.NAME_SEPARATOR.length);
-      originalEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-      newEntityId = mapEntityName(service, originalServicePath, originalEntityId);
-      auxCollectionName = auxCollectionName.substring(originalEntityId.length + sthConfig.NAME_SEPARATOR.length);
-      if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
-        originalAttributeName = isAggregated(collectionName) ?
-          auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length) :
-        auxCollectionName;
-        newAttributeName = mapAttributeName(service, originalServicePath, originalEntityId, originalAttributeName);
-      } else {
-        originalEntityType = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-        newEntityType = mapEntityType(service, originalServicePath, originalEntityType);
-        originalAttributeName = auxCollectionName.substring(
-          originalEntityType.length + sthConfig.NAME_SEPARATOR.length,
-          isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
-        );
-        newAttributeName = mapAttributeName(service, originalServicePath, originalEntityId, originalAttributeName);
-      }
-      return sthConfig.COLLECTION_PREFIX + (newServicePath || originalServicePath) + sthConfig.NAME_SEPARATOR +
-        (newEntityId || originalEntityId) +
-        (originalEntityType ? sthConfig.NAME_SEPARATOR + (newEntityType || originalEntityType) : '') +
-        sthConfig.NAME_SEPARATOR + (newAttributeName || originalAttributeName) +
-        (isAggregated(collectionName) ? '.aggr' : '');
-  }
+    var auxCollectionName,
+        originalServicePath,
+        newServicePath,
+        originalEntityId,
+        newEntityId,
+        originalEntityType,
+        newEntityType,
+        originalAttributeName,
+        newAttributeName;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            originalServicePath = collectionName.substring(
+                sthConfig.COLLECTION_PREFIX.length,
+                isAggregated(collectionName) ? collectionName.length - '.aggr'.length : collectionName.length
+            );
+            newServicePath = mapServicePath(service, originalServicePath);
+            if (newServicePath) {
+                return sthConfig.COLLECTION_PREFIX + newServicePath + (isAggregated(collectionName) ? '.aggr' : '');
+            } else {
+                return collectionName;
+            }
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
+            originalServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+            newServicePath = mapServicePath(service, originalServicePath);
+            auxCollectionName = auxCollectionName.substring(
+                originalServicePath.length + sthConfig.NAME_SEPARATOR.length
+            );
+            if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
+                originalEntityId = isAggregated(collectionName)
+                    ? auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length)
+                    : auxCollectionName;
+                newEntityId = mapEntityName(service, originalServicePath, originalEntityId);
+            } else {
+                originalEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+                newEntityId = mapEntityName(service, originalServicePath, originalEntityId);
+                originalEntityType = auxCollectionName.substring(
+                    originalEntityId.length + sthConfig.NAME_SEPARATOR.length,
+                    isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
+                );
+                newEntityType = mapEntityType(service, originalServicePath, originalEntityType);
+            }
+            return (
+                sthConfig.COLLECTION_PREFIX +
+                (newServicePath || originalServicePath) +
+                sthConfig.NAME_SEPARATOR +
+                (newEntityId || originalEntityId) +
+                (originalEntityType ? sthConfig.NAME_SEPARATOR + (newEntityType || originalEntityType) : '') +
+                (isAggregated(collectionName) ? '.aggr' : '')
+            );
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
+            originalServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+            newServicePath = mapServicePath(service, originalServicePath);
+            auxCollectionName = auxCollectionName.substring(
+                originalServicePath.length + sthConfig.NAME_SEPARATOR.length
+            );
+            originalEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+            newEntityId = mapEntityName(service, originalServicePath, originalEntityId);
+            auxCollectionName = auxCollectionName.substring(originalEntityId.length + sthConfig.NAME_SEPARATOR.length);
+            if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
+                originalAttributeName = isAggregated(collectionName)
+                    ? auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length)
+                    : auxCollectionName;
+                newAttributeName = mapAttributeName(
+                    service,
+                    originalServicePath,
+                    originalEntityId,
+                    originalAttributeName
+                );
+            } else {
+                originalEntityType = auxCollectionName.substring(
+                    0,
+                    auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR)
+                );
+                newEntityType = mapEntityType(service, originalServicePath, originalEntityType);
+                originalAttributeName = auxCollectionName.substring(
+                    originalEntityType.length + sthConfig.NAME_SEPARATOR.length,
+                    isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
+                );
+                newAttributeName = mapAttributeName(
+                    service,
+                    originalServicePath,
+                    originalEntityId,
+                    originalAttributeName
+                );
+            }
+            return (
+                sthConfig.COLLECTION_PREFIX +
+                (newServicePath || originalServicePath) +
+                sthConfig.NAME_SEPARATOR +
+                (newEntityId || originalEntityId) +
+                (originalEntityType ? sthConfig.NAME_SEPARATOR + (newEntityType || originalEntityType) : '') +
+                sthConfig.NAME_SEPARATOR +
+                (newAttributeName || originalAttributeName) +
+                (isAggregated(collectionName) ? '.aggr' : '')
+            );
+    }
 }
 
 /**
@@ -566,96 +626,107 @@ function mapCollectionName(service, collectionName) {
  * @return {String}                The unmapped collection name
  */
 function unmapCollectionName(service, collectionName) {
-  var auxCollectionName,
-      originalServicePath,
-      newServicePath,
-      originalEntityId,
-      newEntityId,
-      originalEntityType,
-      newEntityType,
-      originalAttributeName,
-      newAttributeName;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      newServicePath = collectionName.substring(
-        sthConfig.COLLECTION_PREFIX.length,
-        isAggregated(collectionName) ? collectionName.length - '.aggr'.length : collectionName.length
-      );
-      originalServicePath = unmapServicePath(service, newServicePath);
-      if (originalServicePath) {
-        return sthConfig.COLLECTION_PREFIX + originalServicePath + (isAggregated(collectionName) ? '.aggr' : '');
-      } else {
-        return collectionName;
-      }
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
-      newServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-      originalServicePath = unmapServicePath(service, newServicePath);
-      auxCollectionName = auxCollectionName.substring(newServicePath.length + sthConfig.NAME_SEPARATOR.length);
-      if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
-        newEntityId = isAggregated(collectionName) ?
-          auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length) :
-          auxCollectionName;
-        originalEntityId = unmapEntityName(service, newServicePath, newEntityId);
-      } else {
-        newEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-        originalEntityId = unmapEntityName(service, newServicePath, newEntityId);
-        newEntityType = auxCollectionName.substring(
-          newEntityId.length + sthConfig.NAME_SEPARATOR.length,
-          isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
-        );
-        originalEntityType = unmapEntityType(service, newServicePath, newEntityType);
-      }
-      return sthConfig.COLLECTION_PREFIX + (originalServicePath || newServicePath) + sthConfig.NAME_SEPARATOR +
-        (originalEntityId || newEntityId) +
-        (newEntityType ? sthConfig.NAME_SEPARATOR + (originalEntityType || newEntityType) : '') +
-        (isAggregated(collectionName) ? '.aggr' : '');
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
-      newServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-      originalServicePath = unmapServicePath(service, newServicePath);
-      auxCollectionName = auxCollectionName.substring(newServicePath.length + sthConfig.NAME_SEPARATOR.length);
-      newEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-      originalEntityId = unmapEntityName(service, newServicePath, newEntityId);
-      auxCollectionName = auxCollectionName.substring(newEntityId.length + sthConfig.NAME_SEPARATOR.length);
-      if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
-        newAttributeName = isAggregated(collectionName) ?
-          auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length) :
-          auxCollectionName;
-        originalAttributeName = unmapAttributeName(service, newServicePath, newEntityId, newAttributeName);
-      } else {
-        newEntityType = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
-        originalEntityType = unmapEntityType(service, newServicePath, newEntityType);
-        newAttributeName = auxCollectionName.substring(
-          newEntityType.length + sthConfig.NAME_SEPARATOR.length,
-          isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
-        );
-        originalAttributeName = unmapAttributeName(service, newServicePath, newEntityId, newAttributeName);
-      }
-      return sthConfig.COLLECTION_PREFIX + (originalServicePath || newServicePath) + sthConfig.NAME_SEPARATOR +
-        (originalEntityId || newEntityId) +
-        (newEntityType ? sthConfig.NAME_SEPARATOR + (originalEntityType || newEntityType) : '') +
-        sthConfig.NAME_SEPARATOR + (originalAttributeName || newAttributeName) +
-        (isAggregated(collectionName) ? '.aggr' : '');
-  }
+    var auxCollectionName,
+        originalServicePath,
+        newServicePath,
+        originalEntityId,
+        newEntityId,
+        originalEntityType,
+        newEntityType,
+        originalAttributeName,
+        newAttributeName;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            newServicePath = collectionName.substring(
+                sthConfig.COLLECTION_PREFIX.length,
+                isAggregated(collectionName) ? collectionName.length - '.aggr'.length : collectionName.length
+            );
+            originalServicePath = unmapServicePath(service, newServicePath);
+            if (originalServicePath) {
+                return (
+                    sthConfig.COLLECTION_PREFIX + originalServicePath + (isAggregated(collectionName) ? '.aggr' : '')
+                );
+            } else {
+                return collectionName;
+            }
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
+            newServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+            originalServicePath = unmapServicePath(service, newServicePath);
+            auxCollectionName = auxCollectionName.substring(newServicePath.length + sthConfig.NAME_SEPARATOR.length);
+            if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
+                newEntityId = isAggregated(collectionName)
+                    ? auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length)
+                    : auxCollectionName;
+                originalEntityId = unmapEntityName(service, newServicePath, newEntityId);
+            } else {
+                newEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+                originalEntityId = unmapEntityName(service, newServicePath, newEntityId);
+                newEntityType = auxCollectionName.substring(
+                    newEntityId.length + sthConfig.NAME_SEPARATOR.length,
+                    isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
+                );
+                originalEntityType = unmapEntityType(service, newServicePath, newEntityType);
+            }
+            return (
+                sthConfig.COLLECTION_PREFIX +
+                (originalServicePath || newServicePath) +
+                sthConfig.NAME_SEPARATOR +
+                (originalEntityId || newEntityId) +
+                (newEntityType ? sthConfig.NAME_SEPARATOR + (originalEntityType || newEntityType) : '') +
+                (isAggregated(collectionName) ? '.aggr' : '')
+            );
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            auxCollectionName = collectionName.substring(sthConfig.COLLECTION_PREFIX.length);
+            newServicePath = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+            originalServicePath = unmapServicePath(service, newServicePath);
+            auxCollectionName = auxCollectionName.substring(newServicePath.length + sthConfig.NAME_SEPARATOR.length);
+            newEntityId = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+            originalEntityId = unmapEntityName(service, newServicePath, newEntityId);
+            auxCollectionName = auxCollectionName.substring(newEntityId.length + sthConfig.NAME_SEPARATOR.length);
+            if (auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR) === -1) {
+                newAttributeName = isAggregated(collectionName)
+                    ? auxCollectionName.substring(0, auxCollectionName.length - '.aggr'.length)
+                    : auxCollectionName;
+                originalAttributeName = unmapAttributeName(service, newServicePath, newEntityId, newAttributeName);
+            } else {
+                newEntityType = auxCollectionName.substring(0, auxCollectionName.indexOf(sthConfig.NAME_SEPARATOR));
+                originalEntityType = unmapEntityType(service, newServicePath, newEntityType);
+                newAttributeName = auxCollectionName.substring(
+                    newEntityType.length + sthConfig.NAME_SEPARATOR.length,
+                    isAggregated(collectionName) ? auxCollectionName.length - '.aggr'.length : auxCollectionName.length
+                );
+                originalAttributeName = unmapAttributeName(service, newServicePath, newEntityId, newAttributeName);
+            }
+            return (
+                sthConfig.COLLECTION_PREFIX +
+                (originalServicePath || newServicePath) +
+                sthConfig.NAME_SEPARATOR +
+                (originalEntityId || newEntityId) +
+                (newEntityType ? sthConfig.NAME_SEPARATOR + (originalEntityType || newEntityType) : '') +
+                sthConfig.NAME_SEPARATOR +
+                (originalAttributeName || newAttributeName) +
+                (isAggregated(collectionName) ? '.aggr' : '')
+            );
+    }
 }
 
 module.exports = {
-  mapService: mapService,
-  unmapService: unmapService,
-  mapServicePath: mapServicePath,
-  unmapServicePath: unmapServicePath,
-  mapEntityName: mapEntityName,
-  unmapEntityName: unmapEntityName,
-  mapEntityType: mapEntityType,
-  unmapEntityType: unmapEntityType,
-  mapAttributeName: mapAttributeName,
-  unmapAttributeName: unmapAttributeName,
-  mapAttributeType: mapAttributeType,
-  unmapAttributeType: unmapAttributeType,
-  mapDatabaseName: mapDatabaseName,
-  unmapDatabaseName: unmapDatabaseName,
-  mapCollectionName: mapCollectionName,
-  unmapCollectionName: unmapCollectionName
+    mapService: mapService,
+    unmapService: unmapService,
+    mapServicePath: mapServicePath,
+    unmapServicePath: unmapServicePath,
+    mapEntityName: mapEntityName,
+    unmapEntityName: unmapEntityName,
+    mapEntityType: mapEntityType,
+    unmapEntityType: unmapEntityType,
+    mapAttributeName: mapAttributeName,
+    unmapAttributeName: unmapAttributeName,
+    mapAttributeType: mapAttributeType,
+    unmapAttributeType: unmapAttributeType,
+    mapDatabaseName: mapDatabaseName,
+    unmapDatabaseName: unmapDatabaseName,
+    mapCollectionName: mapCollectionName,
+    unmapCollectionName: unmapCollectionName,
 };

--- a/lib/database/model/sthDatabaseNameMapper.js
+++ b/lib/database/model/sthDatabaseNameMapper.js
@@ -728,5 +728,5 @@ module.exports = {
     mapDatabaseName: mapDatabaseName,
     unmapDatabaseName: unmapDatabaseName,
     mapCollectionName: mapCollectionName,
-    unmapCollectionName: unmapCollectionName,
+    unmapCollectionName: unmapCollectionName
 };

--- a/lib/database/model/sthDatabaseNameMapperTool.js
+++ b/lib/database/model/sthDatabaseNameMapperTool.js
@@ -38,8 +38,8 @@ var analysisResult = {};
  * Resets the analysis report
  */
 function resetAnalysisResult(callback) {
-  analysisResult = {};
-  return process.nextTick(callback);
+    analysisResult = {};
+    return process.nextTick(callback);
 }
 
 /**
@@ -49,8 +49,8 @@ function resetAnalysisResult(callback) {
  *                               as the second one
  */
 function listDatabases(connection, callback) {
-  var adminDB = connection.admin();
-  adminDB.listDatabases(callback);
+    var adminDB = connection.admin();
+    adminDB.listDatabases(callback);
 }
 
 /**
@@ -66,9 +66,11 @@ function listDatabases(connection, callback) {
  * @param  {Function} callback     The callback
  */
 function databaseFilter(options, databaseData, callback) {
-  callback(null,
-    (databaseData.name.indexOf(sthConfig.DB_PREFIX) === 0) &&
-      (!options.database || ((options.database && options.database === databaseData.name))));
+    callback(
+        null,
+        databaseData.name.indexOf(sthConfig.DB_PREFIX) === 0 &&
+            (!options.database || (options.database && options.database === databaseData.name))
+    );
 }
 
 /**
@@ -84,7 +86,7 @@ function databaseFilter(options, databaseData, callback) {
  * @param  {Function} callback      The callback
  */
 function filterDatabases(options, databasesData, callback) {
-  async.filter(databasesData.databases, async.apply(databaseFilter, options), callback);
+    async.filter(databasesData.databases, async.apply(databaseFilter, options), callback);
 }
 
 /**
@@ -94,8 +96,8 @@ function filterDatabases(options, databasesData, callback) {
  * @param {Function} callback       The callback
  */
 function addDatabaseName(databaseName, collectionData, callback) {
-  collectionData.database = databaseName;
-  return callback(null, collectionData);
+    collectionData.database = databaseName;
+    return callback(null, collectionData);
 }
 
 /**
@@ -104,15 +106,14 @@ function addDatabaseName(databaseName, collectionData, callback) {
  * @param  {Function} callback     The callback
  */
 function listCollections(databaseName, callback) {
-  sthDatabase.connection.db(databaseName).listCollections().toArray(function(err, collections) {
-    if (collections) {
-      async.map(
-        collections,
-        async.apply(addDatabaseName, databaseName),
-        callback
-      );
-    }
-  });
+    sthDatabase.connection
+        .db(databaseName)
+        .listCollections()
+        .toArray(function(err, collections) {
+            if (collections) {
+                async.map(collections, async.apply(addDatabaseName, databaseName), callback);
+            }
+        });
 }
 
 /**
@@ -128,9 +129,11 @@ function listCollections(databaseName, callback) {
  * @param  {Function} callback       The callback
  */
 function collectionFilter(options, collectionData, callback) {
-  return callback(null,
-    (collectionData.name.indexOf(sthConfig.COLLECTION_PREFIX) === 0) &&
-      (!options.collection || (options.collection && options.collection === collectionData.name)));
+    return callback(
+        null,
+        collectionData.name.indexOf(sthConfig.COLLECTION_PREFIX) === 0 &&
+            (!options.collection || (options.collection && options.collection === collectionData.name))
+    );
 }
 
 /**
@@ -146,7 +149,7 @@ function collectionFilter(options, collectionData, callback) {
  * @param  {Function} callback        The callback
  */
 function filterCollections(options, collectionsData, callback) {
-  async.filter(collectionsData, async.apply(collectionFilter, options), callback);
+    async.filter(collectionsData, async.apply(collectionFilter, options), callback);
 }
 
 /**
@@ -162,18 +165,19 @@ function filterCollections(options, collectionsData, callback) {
  * @param  {Function} callback       The callback
  */
 function analyseCollection(options, collectionData, callback) {
-  analysisResult[collectionData.database].collections = analysisResult[collectionData.database].collections || {};
-  analysisResult[collectionData.database].collections[collectionData.name] = {
-    name: (options.map ?
-      sthDatabaseNameMapper.mapCollectionName(
-        collectionData.database.substring(sthConfig.DB_PREFIX.length),
-        collectionData.name) :
-      sthDatabaseNameMapper.unmapCollectionName(
-        collectionData.database.substring(sthConfig.DB_PREFIX.length),
-        collectionData.name)
-    )
-  };
-  process.nextTick(callback);
+    analysisResult[collectionData.database].collections = analysisResult[collectionData.database].collections || {};
+    analysisResult[collectionData.database].collections[collectionData.name] = {
+        name: options.map
+            ? sthDatabaseNameMapper.mapCollectionName(
+                  collectionData.database.substring(sthConfig.DB_PREFIX.length),
+                  collectionData.name
+              )
+            : sthDatabaseNameMapper.unmapCollectionName(
+                  collectionData.database.substring(sthConfig.DB_PREFIX.length),
+                  collectionData.name
+              ),
+    };
+    process.nextTick(callback);
 }
 
 /**
@@ -189,7 +193,7 @@ function analyseCollection(options, collectionData, callback) {
  * @param  {Function} callback        The callback
  */
 function doAnalyseCollections(options, collectionsData, callback) {
-  async.each(collectionsData, async.apply(analyseCollection, options), callback);
+    async.each(collectionsData, async.apply(analyseCollection, options), callback);
 }
 
 /**
@@ -205,11 +209,11 @@ function doAnalyseCollections(options, collectionsData, callback) {
  * @param  {Function} callback     The callback
  */
 function analyseCollections(options, databaseName, callback) {
-  async.seq(
-    async.apply(listCollections, databaseName),
-    async.apply(filterCollections, options),
-    async.apply(doAnalyseCollections, options)
-  )(callback);
+    async.seq(
+        async.apply(listCollections, databaseName),
+        async.apply(filterCollections, options),
+        async.apply(doAnalyseCollections, options)
+    )(callback);
 }
 
 /**
@@ -225,13 +229,12 @@ function analyseCollections(options, databaseName, callback) {
  * @param  {Function} callback     The callback
  */
 function analyseDatabase(options, databaseData, callback) {
-  analysisResult[databaseData.name] = {
-    name: (options.map ?
-      sthDatabaseNameMapper.mapDatabaseName(databaseData.name) :
-      sthDatabaseNameMapper.unmapDatabaseName(databaseData.name)
-    )
-  };
-  analyseCollections(options, databaseData.name, callback);
+    analysisResult[databaseData.name] = {
+        name: options.map
+            ? sthDatabaseNameMapper.mapDatabaseName(databaseData.name)
+            : sthDatabaseNameMapper.unmapDatabaseName(databaseData.name),
+    };
+    analyseCollections(options, databaseData.name, callback);
 }
 
 /**
@@ -247,7 +250,7 @@ function analyseDatabase(options, databaseData, callback) {
  * @param  {Function} callback      The callback
  */
 function analyseDatabases(options, databasesData, callback) {
-  async.each(databasesData, async.apply(analyseDatabase, options), callback);
+    async.each(databasesData, async.apply(analyseDatabase, options), callback);
 }
 
 /**
@@ -256,26 +259,26 @@ function analyseDatabases(options, databasesData, callback) {
  * @param  {Function} callback The callback
  */
 function cleanAnalysis(callback) {
-  var databaseNames = Object.getOwnPropertyNames(analysisResult);
-  databaseNames.forEach(function(databaseName) {
-    if (analysisResult[databaseName].collections) {
-      var collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
-      collectionNames.forEach(function(collectionName) {
-        if (collectionName === analysisResult[databaseName].collections[collectionName].name) {
-          delete analysisResult[databaseName].collections[collectionName];
+    var databaseNames = Object.getOwnPropertyNames(analysisResult);
+    databaseNames.forEach(function(databaseName) {
+        if (analysisResult[databaseName].collections) {
+            var collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
+            collectionNames.forEach(function(collectionName) {
+                if (collectionName === analysisResult[databaseName].collections[collectionName].name) {
+                    delete analysisResult[databaseName].collections[collectionName];
+                }
+            });
+            if (Object.keys(analysisResult[databaseName].collections).length === 0) {
+                delete analysisResult[databaseName].collections;
+                if (databaseName === analysisResult[databaseName].name) {
+                    delete analysisResult[databaseName];
+                }
+            }
+        } else if (databaseName === analysisResult[databaseName].name) {
+            delete analysisResult[databaseName];
         }
-      });
-      if (Object.keys(analysisResult[databaseName].collections).length === 0) {
-        delete analysisResult[databaseName].collections;
-        if (databaseName === analysisResult[databaseName].name) {
-          delete analysisResult[databaseName];
-        }
-      }
-    } else if (databaseName === analysisResult[databaseName].name) {
-      delete analysisResult[databaseName];
-    }
-  });
-  process.nextTick(callback.bind(null, null, analysisResult));
+    });
+    process.nextTick(callback.bind(null, null, analysisResult));
 }
 
 /**
@@ -289,32 +292,38 @@ function cleanAnalysis(callback) {
  *                            returned by the last function of the sequence
  */
 function getMappingAnalysis(options, callback) {
-  if (!options.map && !options.unmap) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound('Either the -m (--map) or the -u (--unmap) options are mandatory')));
-  }
-  if (options.collection && !options.database) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound(
-        'The -b (--database) option is mandatory if the -c (--collection) option is set')));
-  }
-  async.seq(
-    resetAnalysisResult,
-    sthDatabase.connect.bind(
-      null,
-      {
-        authentication: sthConfig.DB_AUTHENTICATION,
-        dbURI: sthConfig.DB_URI,
-        replicaSet: sthConfig.REPLICA_SET,
-        database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-        poolSize: sthConfig.POOL_SIZE
-      }
-    ),
-    listDatabases,
-    async.apply(filterDatabases, options),
-    async.apply(analyseDatabases, options),
-    cleanAnalysis
-  )(callback);
+    if (!options.map && !options.unmap) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound('Either the -m (--map) or the -u (--unmap) options are mandatory')
+            )
+        );
+    }
+    if (options.collection && !options.database) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound(
+                    'The -b (--database) option is mandatory if the -c (--collection) option is set'
+                )
+            )
+        );
+    }
+    async.seq(
+        resetAnalysisResult,
+        sthDatabase.connect.bind(null, {
+            authentication: sthConfig.DB_AUTHENTICATION,
+            dbURI: sthConfig.DB_URI,
+            replicaSet: sthConfig.REPLICA_SET,
+            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+            poolSize: sthConfig.POOL_SIZE,
+        }),
+        listDatabases,
+        async.apply(filterDatabases, options),
+        async.apply(analyseDatabases, options),
+        cleanAnalysis
+    )(callback);
 }
 
 /**
@@ -331,27 +340,45 @@ function getMappingAnalysis(options, callback) {
  * @param  {Function} callback       The callback
  */
 function mapOrUnmapCollection(options, databaseName, collectionName, callback) {
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_LOG,
-    (options.map ? 'Mapping' : 'Unmapping') + ' of collection \'' + collectionName +
-      '\' of database \'' + databaseName + '\' started...');
-
-  sthDatabase.connection.db(databaseName).renameCollection(
-    collectionName,
-    options.map ?
-      sthDatabaseNameMapper.mapCollectionName(databaseName.substring(sthConfig.DB_PREFIX.length), collectionName) :
-      sthDatabaseNameMapper.unmapCollectionName(databaseName.substring(sthConfig.DB_PREFIX.length), collectionName),
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      sthLogger.info(
+    sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.map ? 'Mapping' : 'Unmapping') + ' of collection \'' + collectionName +
-          '\' of database \'' + databaseName + '\' successfully completed.');
-      return process.nextTick(callback);
-    }
-  );
+        (options.map ? 'Mapping' : 'Unmapping') +
+            " of collection '" +
+            collectionName +
+            "' of database '" +
+            databaseName +
+            "' started..."
+    );
+
+    sthDatabase.connection
+        .db(databaseName)
+        .renameCollection(
+            collectionName,
+            options.map
+                ? sthDatabaseNameMapper.mapCollectionName(
+                      databaseName.substring(sthConfig.DB_PREFIX.length),
+                      collectionName
+                  )
+                : sthDatabaseNameMapper.unmapCollectionName(
+                      databaseName.substring(sthConfig.DB_PREFIX.length),
+                      collectionName
+                  ),
+            function(err) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                sthLogger.info(
+                    sthConfig.LOGGING_CONTEXT.DB_LOG,
+                    (options.map ? 'Mapping' : 'Unmapping') +
+                        " of collection '" +
+                        collectionName +
+                        "' of database '" +
+                        databaseName +
+                        "' successfully completed."
+                );
+                return process.nextTick(callback);
+            }
+        );
 }
 
 /**
@@ -366,29 +393,29 @@ function mapOrUnmapCollection(options, databaseName, collectionName, callback) {
  * @param  {Function} callback     The callback
  */
 function copyDatabase(options, databaseName, callback) {
-  var adminDB = sthDatabase.connection.admin();
-  var copyCommand = {
-    copydb: 1,
-    fromdb: databaseName,
-    todb: (options.map ?
-            sthDatabaseNameMapper.mapDatabaseName(databaseName) :
-            sthDatabaseNameMapper.unmapDatabaseName(databaseName))
-  };
-  adminDB.command(copyCommand, function onCopyDatabase(err) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    sthDatabase.connection.db(databaseName).dropDatabase(function onDropDatabase(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      sthLogger.info(
-        sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.map ? 'Mapping' : 'Unmapping') + ' of database \'' + databaseName +
-          '\' successfully completed.');
-      process.nextTick(callback);
+    var adminDB = sthDatabase.connection.admin();
+    var copyCommand = {
+        copydb: 1,
+        fromdb: databaseName,
+        todb: options.map
+            ? sthDatabaseNameMapper.mapDatabaseName(databaseName)
+            : sthDatabaseNameMapper.unmapDatabaseName(databaseName),
+    };
+    adminDB.command(copyCommand, function onCopyDatabase(err) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
+        }
+        sthDatabase.connection.db(databaseName).dropDatabase(function onDropDatabase(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            sthLogger.info(
+                sthConfig.LOGGING_CONTEXT.DB_LOG,
+                (options.map ? 'Mapping' : 'Unmapping') + " of database '" + databaseName + "' successfully completed."
+            );
+            process.nextTick(callback);
+        });
     });
-  });
 }
 
 /**
@@ -403,43 +430,49 @@ function copyDatabase(options, databaseName, callback) {
  * @param  {Function} callback     The callback
  */
 function mapOrUnmapDatabase(options, databaseName, callback) {
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_LOG,
-    (options.map ? 'Mapping' : 'Unmapping') + ' of database \'' + databaseName + '\' started...');
-
-  var collectionNames;
-  if (analysisResult[databaseName].collections &&
-    Object.getOwnPropertyNames(analysisResult[databaseName].collections).length) {
-      collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
-      async.eachSeries(
-        collectionNames,
-        async.apply(mapOrUnmapCollection, options, databaseName),
-        function onMapOrUnmapCollection(err) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          if (databaseName !== analysisResult[databaseName].name) {
-            copyDatabase(options, databaseName, callback);
-          } else {
-            sthLogger.info(
-              sthConfig.LOGGING_CONTEXT.DB_LOG,
-              (options.map ? 'Mapping' : 'Unmapping') + ' of database \'' + databaseName +
-                ' successfully completed.');
-            process.nextTick(callback);
-          }
-        }
-      );
-  } else {
-    if (databaseName !== analysisResult[databaseName].name) {
-      copyDatabase(options, databaseName, callback);
-    } else {
-      sthLogger.info(
+    sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.map ? 'Mapping' : 'Unmapping') + ' of database \'' + databaseName +
-          ' successfully completed.');
-      process.nextTick(callback);
+        (options.map ? 'Mapping' : 'Unmapping') + " of database '" + databaseName + "' started..."
+    );
+
+    var collectionNames;
+    if (
+        analysisResult[databaseName].collections &&
+        Object.getOwnPropertyNames(analysisResult[databaseName].collections).length
+    ) {
+        collectionNames = Object.getOwnPropertyNames(analysisResult[databaseName].collections);
+        async.eachSeries(
+            collectionNames,
+            async.apply(mapOrUnmapCollection, options, databaseName),
+            function onMapOrUnmapCollection(err) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                if (databaseName !== analysisResult[databaseName].name) {
+                    copyDatabase(options, databaseName, callback);
+                } else {
+                    sthLogger.info(
+                        sthConfig.LOGGING_CONTEXT.DB_LOG,
+                        (options.map ? 'Mapping' : 'Unmapping') +
+                            " of database '" +
+                            databaseName +
+                            ' successfully completed.'
+                    );
+                    process.nextTick(callback);
+                }
+            }
+        );
+    } else {
+        if (databaseName !== analysisResult[databaseName].name) {
+            copyDatabase(options, databaseName, callback);
+        } else {
+            sthLogger.info(
+                sthConfig.LOGGING_CONTEXT.DB_LOG,
+                (options.map ? 'Mapping' : 'Unmapping') + " of database '" + databaseName + ' successfully completed.'
+            );
+            process.nextTick(callback);
+        }
     }
-  }
 }
 
 /**
@@ -454,8 +487,8 @@ function mapOrUnmapDatabase(options, databaseName, callback) {
  * @param  {Function} callback The callback
  */
 function doMapOrUnmap(options, analysis, callback) {
-  var databaseNames = Object.getOwnPropertyNames(analysis);
-  async.eachSeries(databaseNames, async.apply(mapOrUnmapDatabase, options), callback);
+    var databaseNames = Object.getOwnPropertyNames(analysis);
+    async.eachSeries(databaseNames, async.apply(mapOrUnmapDatabase, options), callback);
 }
 
 /**
@@ -468,28 +501,31 @@ function doMapOrUnmap(options, analysis, callback) {
  * @param  {Function} callback The callback
  */
 function mapOrUnmap(options, callback) {
-  if (!options.map && !options.unmap) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound('Either the -m (--map) or the -u (--unmap) options are mandatory')));
-  }
-  if (options.collection && !options.database) {
-    return process.nextTick(callback.bind(null,
-      new sthErrors.MandatoryOptionNotFound(
-        'The -b (--database) option is mandatory if the -c (--collection) option is set')));
-  }
+    if (!options.map && !options.unmap) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound('Either the -m (--map) or the -u (--unmap) options are mandatory')
+            )
+        );
+    }
+    if (options.collection && !options.database) {
+        return process.nextTick(
+            callback.bind(
+                null,
+                new sthErrors.MandatoryOptionNotFound(
+                    'The -b (--database) option is mandatory if the -c (--collection) option is set'
+                )
+            )
+        );
+    }
 
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_LOG,
-    (options.map ? 'Mapping' : 'Unmapping') + ' process started...'
-  );
+    sthLogger.info(sthConfig.LOGGING_CONTEXT.DB_LOG, (options.map ? 'Mapping' : 'Unmapping') + ' process started...');
 
-  async.seq(
-    async.apply(getMappingAnalysis, options),
-    async.apply(doMapOrUnmap, options)
-  )(callback);
+    async.seq(async.apply(getMappingAnalysis, options), async.apply(doMapOrUnmap, options))(callback);
 }
 
 module.exports = {
-  getMappingAnalysis: getMappingAnalysis,
-  mapOrUnmap: mapOrUnmap
+    getMappingAnalysis: getMappingAnalysis,
+    mapOrUnmap: mapOrUnmap,
 };

--- a/lib/database/model/sthDatabaseNameMapperTool.js
+++ b/lib/database/model/sthDatabaseNameMapperTool.js
@@ -175,7 +175,7 @@ function analyseCollection(options, collectionData, callback) {
             : sthDatabaseNameMapper.unmapCollectionName(
                   collectionData.database.substring(sthConfig.DB_PREFIX.length),
                   collectionData.name
-              ),
+              )
     };
     process.nextTick(callback);
 }
@@ -232,7 +232,7 @@ function analyseDatabase(options, databaseData, callback) {
     analysisResult[databaseData.name] = {
         name: options.map
             ? sthDatabaseNameMapper.mapDatabaseName(databaseData.name)
-            : sthDatabaseNameMapper.unmapDatabaseName(databaseData.name),
+            : sthDatabaseNameMapper.unmapDatabaseName(databaseData.name)
     };
     analyseCollections(options, databaseData.name, callback);
 }
@@ -317,7 +317,7 @@ function getMappingAnalysis(options, callback) {
             dbURI: sthConfig.DB_URI,
             replicaSet: sthConfig.REPLICA_SET,
             database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-            poolSize: sthConfig.POOL_SIZE,
+            poolSize: sthConfig.POOL_SIZE
         }),
         listDatabases,
         async.apply(filterDatabases, options),
@@ -399,7 +399,7 @@ function copyDatabase(options, databaseName, callback) {
         fromdb: databaseName,
         todb: options.map
             ? sthDatabaseNameMapper.mapDatabaseName(databaseName)
-            : sthDatabaseNameMapper.unmapDatabaseName(databaseName),
+            : sthDatabaseNameMapper.unmapDatabaseName(databaseName)
     };
     adminDB.command(copyCommand, function onCopyDatabase(err) {
         if (err) {
@@ -527,5 +527,5 @@ function mapOrUnmap(options, callback) {
 
 module.exports = {
     getMappingAnalysis: getMappingAnalysis,
-    mapOrUnmap: mapOrUnmap,
+    mapOrUnmap: mapOrUnmap
 };

--- a/lib/database/model/sthDatabaseNameMapperTool.js
+++ b/lib/database/model/sthDatabaseNameMapperTool.js
@@ -342,12 +342,9 @@ function getMappingAnalysis(options, callback) {
 function mapOrUnmapCollection(options, databaseName, collectionName, callback) {
     sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_LOG,
-        (options.map ? 'Mapping' : 'Unmapping') +
-            " of collection '" +
-            collectionName +
-            "' of database '" +
-            databaseName +
-            "' started..."
+        // prettier-ignore
+        (options.map ? 'Mapping' : 'Unmapping') + " of collection '" + collectionName + "' of database '" +
+            databaseName + "' started..."
     );
 
     sthDatabase.connection
@@ -369,12 +366,9 @@ function mapOrUnmapCollection(options, databaseName, collectionName, callback) {
                 }
                 sthLogger.info(
                     sthConfig.LOGGING_CONTEXT.DB_LOG,
-                    (options.map ? 'Mapping' : 'Unmapping') +
-                        " of collection '" +
-                        collectionName +
-                        "' of database '" +
-                        databaseName +
-                        "' successfully completed."
+                    // prettier-ignore
+                    (options.map ? 'Mapping' : 'Unmapping') + " of collection '" + collectionName + "' of database '" +
+                        databaseName + "' successfully completed."
                 );
                 return process.nextTick(callback);
             }
@@ -453,9 +447,8 @@ function mapOrUnmapDatabase(options, databaseName, callback) {
                 } else {
                     sthLogger.info(
                         sthConfig.LOGGING_CONTEXT.DB_LOG,
-                        (options.map ? 'Mapping' : 'Unmapping') +
-                            " of database '" +
-                            databaseName +
+                        // prettier-ignore
+                        (options.map ? 'Mapping' : 'Unmapping') + " of database '" + databaseName + 
                             ' successfully completed.'
                     );
                     process.nextTick(callback);

--- a/lib/database/model/sthDatabaseNaming.js
+++ b/lib/database/model/sthDatabaseNaming.js
@@ -51,13 +51,11 @@ var MAX_NAMESPACE_SIZE_IN_BYTES = 120;
  *  in bytes
  */
 function getNamespaceSizeInBytes(datebaseName, rawCollectionName) {
-    return bytesCounter.count(datebaseName) +
-        // prettier-ignore
-        rawCollectionName
-        ? bytesCounter.count(sthConfig.COLLECTION_PREFIX) +
-              bytesCounter.count(rawCollectionName) +
-              bytesCounter.count('.aggr')
-        : 0;
+    // prettier-ignore
+    return (bytesCounter.count(datebaseName) +
+        (rawCollectionName ? bytesCounter.count(sthConfig.COLLECTION_PREFIX) + bytesCounter.count(rawCollectionName) +
+        bytesCounter.count('.aggr') : 0)
+    );
 }
 
 /**

--- a/lib/database/model/sthDatabaseNaming.js
+++ b/lib/database/model/sthDatabaseNaming.js
@@ -262,5 +262,5 @@ module.exports = {
     getDatabaseName: getDatabaseName,
     getService: getService,
     getRawCollectionName: getRawCollectionName,
-    getAggregatedCollectionName: getAggregatedCollectionName,
+    getAggregatedCollectionName: getAggregatedCollectionName
 };

--- a/lib/database/model/sthDatabaseNaming.js
+++ b/lib/database/model/sthDatabaseNaming.js
@@ -51,11 +51,13 @@ var MAX_NAMESPACE_SIZE_IN_BYTES = 120;
  *  in bytes
  */
 function getNamespaceSizeInBytes(datebaseName, rawCollectionName) {
-  return bytesCounter.count(datebaseName) +
-    (rawCollectionName ?
-      bytesCounter.count(sthConfig.COLLECTION_PREFIX) + bytesCounter.count(rawCollectionName) +
-        bytesCounter.count('.aggr') :
-      0
+    return (
+        bytesCounter.count(datebaseName) +
+        (rawCollectionName
+            ? bytesCounter.count(sthConfig.COLLECTION_PREFIX) +
+              bytesCounter.count(rawCollectionName) +
+              bytesCounter.count('.aggr')
+            : 0)
     );
 }
 
@@ -65,26 +67,31 @@ function getNamespaceSizeInBytes(datebaseName, rawCollectionName) {
  * @return {string}         The (encoded, if configured this way) database name
  */
 function getDatabaseName(service) {
-  var databaseName, newService;
-  if (sthConfig.NAME_MAPPING) {
-    newService = sthDatabaseNameMapper.mapService(service);
-  }
-  if (sthConfig.NAME_ENCODING) {
-    databaseName = sthDatabaseNameCodec.encodeDatabaseName(sthConfig.DB_PREFIX + (newService || service));
-  } else {
-    databaseName = sthConfig.DB_PREFIX + (newService || service);
-  }
-  if (getNamespaceSizeInBytes(databaseName) > MAX_DATABASE_NAME_SIZE_IN_BYTES) {
-    sthLogger.warn(
-      sthConfig.LOGGING_CONTEXT.DB_LOG,
-      'The size in bytes of the database ("' + databaseName + '", ' +
-      getNamespaceSizeInBytes(databaseName) +
-      ' bytes)' + ' is bigger than ' + MAX_DATABASE_NAME_SIZE_IN_BYTES + ' bytes'
-    );
-    return null;
-  } else {
-    return databaseName;
-  }
+    var databaseName, newService;
+    if (sthConfig.NAME_MAPPING) {
+        newService = sthDatabaseNameMapper.mapService(service);
+    }
+    if (sthConfig.NAME_ENCODING) {
+        databaseName = sthDatabaseNameCodec.encodeDatabaseName(sthConfig.DB_PREFIX + (newService || service));
+    } else {
+        databaseName = sthConfig.DB_PREFIX + (newService || service);
+    }
+    if (getNamespaceSizeInBytes(databaseName) > MAX_DATABASE_NAME_SIZE_IN_BYTES) {
+        sthLogger.warn(
+            sthConfig.LOGGING_CONTEXT.DB_LOG,
+            'The size in bytes of the database ("' +
+                databaseName +
+                '", ' +
+                getNamespaceSizeInBytes(databaseName) +
+                ' bytes)' +
+                ' is bigger than ' +
+                MAX_DATABASE_NAME_SIZE_IN_BYTES +
+                ' bytes'
+        );
+        return null;
+    } else {
+        return databaseName;
+    }
 }
 
 /**
@@ -93,23 +100,23 @@ function getDatabaseName(service) {
  * @return {string}              The associated service
  */
 function getService(databaseName) {
-  var newService, originalService;
-  if (sthConfig.NAME_MAPPING) {
+    var newService, originalService;
+    if (sthConfig.NAME_MAPPING) {
+        if (sthConfig.NAME_ENCODING) {
+            newService = sthDatabaseNameCodec.decodeDatabaseName(databaseName).substring(sthConfig.DB_PREFIX.length);
+        } else {
+            newService = databaseName.substring(sthConfig.DB_PREFIX.length);
+        }
+        originalService = sthDatabaseNameMapper.unmapService(newService);
+        if (originalService) {
+            return originalService;
+        }
+    }
     if (sthConfig.NAME_ENCODING) {
-      newService = sthDatabaseNameCodec.decodeDatabaseName(databaseName).substring(sthConfig.DB_PREFIX.length);
-    } else {
-      newService = databaseName.substring(sthConfig.DB_PREFIX.length);
+        var decodedDatabaseName = sthDatabaseNameCodec.decodeDatabaseName(databaseName);
+        return decodedDatabaseName.substring(sthConfig.DB_PREFIX.length);
     }
-    originalService = sthDatabaseNameMapper.unmapService(newService);
-    if (originalService) {
-      return originalService;
-    }
-  }
-  if (sthConfig.NAME_ENCODING) {
-    var decodedDatabaseName = sthDatabaseNameCodec.decodeDatabaseName(databaseName);
-    return decodedDatabaseName.substring(sthConfig.DB_PREFIX.length);
-  }
-  return databaseName.substring(sthConfig.DB_PREFIX.length);
+    return databaseName.substring(sthConfig.DB_PREFIX.length);
 }
 
 /**
@@ -123,124 +130,137 @@ function getService(databaseName) {
  * @returns {String}          The raw data collection name
  */
 function getRawCollectionName(params) {
-  var collectionName4Events;
-  var databaseName = getDatabaseName(params.service),
-      servicePath = params.servicePath,
-      entityId = params.entityId,
-      entityType = params.entityType,
-      attrName = params.attrName;
-  var newServicePath,
-      newEntityId,
-      newEntityType,
-      newAttrName;
+    var collectionName4Events;
+    var databaseName = getDatabaseName(params.service),
+        servicePath = params.servicePath,
+        entityId = params.entityId,
+        entityType = params.entityType,
+        attrName = params.attrName;
+    var newServicePath, newEntityId, newEntityType, newAttrName;
 
-  if (sthConfig.NAME_MAPPING && servicePath) {
-    newServicePath = sthDatabaseNameMapper.mapServicePath(params.service, servicePath);
-    if (newServicePath && sthConfig.NAME_ENCODING) {
-      newServicePath = sthDatabaseNameCodec.encodeCollectionName(newServicePath);
+    if (sthConfig.NAME_MAPPING && servicePath) {
+        newServicePath = sthDatabaseNameMapper.mapServicePath(params.service, servicePath);
+        if (newServicePath && sthConfig.NAME_ENCODING) {
+            newServicePath = sthDatabaseNameCodec.encodeCollectionName(newServicePath);
+        }
     }
-  }
-  if (!newServicePath && sthConfig.NAME_ENCODING && servicePath) {
-    newServicePath = sthDatabaseNameCodec.encodeCollectionName(servicePath);
-  }
-  if (!newServicePath) {
-    newServicePath = servicePath;
-  }
-
-  if (sthConfig.NAME_MAPPING && servicePath && entityId) {
-    newEntityId = sthDatabaseNameMapper.mapEntityName(params.service, servicePath, entityId);
-    if (newEntityId && sthConfig.NAME_ENCODING) {
-      newEntityId = sthDatabaseNameCodec.encodeCollectionName(newEntityId);
+    if (!newServicePath && sthConfig.NAME_ENCODING && servicePath) {
+        newServicePath = sthDatabaseNameCodec.encodeCollectionName(servicePath);
     }
-  }
-  if (!newEntityId && sthConfig.NAME_ENCODING && entityId) {
-    newEntityId = sthDatabaseNameCodec.encodeCollectionName(entityId);
-  }
-  if (!newEntityId) {
-    newEntityId = entityId;
-  }
-
-  if (sthConfig.NAME_MAPPING && servicePath && entityType) {
-    newEntityType = sthDatabaseNameMapper.mapEntityType(params.service, servicePath, entityType);
-    if (newEntityType && sthConfig.NAME_ENCODING) {
-      newEntityType = sthDatabaseNameCodec.encodeCollectionName(newEntityType);
+    if (!newServicePath) {
+        newServicePath = servicePath;
     }
-  }
-  if (!newEntityType && sthConfig.NAME_ENCODING && entityType) {
-    newEntityType = sthDatabaseNameCodec.encodeCollectionName(entityType);
-  }
-  if (!newEntityType) {
-    newEntityType = entityType;
-  }
 
-  if (sthConfig.NAME_MAPPING && servicePath && entityId && attrName) {
-    newAttrName = sthDatabaseNameMapper.mapAttributeName(params.service, servicePath, entityId, attrName);
-    if (newAttrName && sthConfig.NAME_ENCODING) {
-      newAttrName = sthDatabaseNameCodec.encodeCollectionName(newAttrName);
+    if (sthConfig.NAME_MAPPING && servicePath && entityId) {
+        newEntityId = sthDatabaseNameMapper.mapEntityName(params.service, servicePath, entityId);
+        if (newEntityId && sthConfig.NAME_ENCODING) {
+            newEntityId = sthDatabaseNameCodec.encodeCollectionName(newEntityId);
+        }
     }
-  }
-  if (!newAttrName && sthConfig.NAME_ENCODING && attrName) {
-    newAttrName = sthDatabaseNameCodec.encodeCollectionName(attrName);
-  }
-  if (!newAttrName) {
-    newAttrName = attrName;
-  }
-
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      collectionName4Events = newServicePath;
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      collectionName4Events = newServicePath + sthConfig.NAME_SEPARATOR + newEntityId +
-          (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '');
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-    collectionName4Events = newServicePath + sthConfig.NAME_SEPARATOR + newEntityId +
-        (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '') +
-        sthConfig.NAME_SEPARATOR + newAttrName;
-      break;
-  }
-
-  if (getNamespaceSizeInBytes(databaseName, collectionName4Events) > MAX_NAMESPACE_SIZE_IN_BYTES) {
-    sthLogger.warn(
-      sthConfig.LOGGING_CONTEXT.DB_LOG,
-      'The size in bytes of the namespace for storing the aggregated data ("' + databaseName + '" plus "' +
-      sthConfig.COLLECTION_PREFIX + collectionName4Events + '.aggr", ' +
-      getNamespaceSizeInBytes(databaseName, collectionName4Events) +
-      ' bytes)' + ' is bigger than ' + MAX_NAMESPACE_SIZE_IN_BYTES + ' bytes'
-    );
-    return null;
-  } else {
-    if (sthConfig.NAME_ENCODING) {
-      return sthDatabaseNameCodec.encodeCollectionName(sthConfig.COLLECTION_PREFIX) + collectionName4Events;
+    if (!newEntityId && sthConfig.NAME_ENCODING && entityId) {
+        newEntityId = sthDatabaseNameCodec.encodeCollectionName(entityId);
     }
-    return sthConfig.COLLECTION_PREFIX + collectionName4Events;
-  }
+    if (!newEntityId) {
+        newEntityId = entityId;
+    }
+
+    if (sthConfig.NAME_MAPPING && servicePath && entityType) {
+        newEntityType = sthDatabaseNameMapper.mapEntityType(params.service, servicePath, entityType);
+        if (newEntityType && sthConfig.NAME_ENCODING) {
+            newEntityType = sthDatabaseNameCodec.encodeCollectionName(newEntityType);
+        }
+    }
+    if (!newEntityType && sthConfig.NAME_ENCODING && entityType) {
+        newEntityType = sthDatabaseNameCodec.encodeCollectionName(entityType);
+    }
+    if (!newEntityType) {
+        newEntityType = entityType;
+    }
+
+    if (sthConfig.NAME_MAPPING && servicePath && entityId && attrName) {
+        newAttrName = sthDatabaseNameMapper.mapAttributeName(params.service, servicePath, entityId, attrName);
+        if (newAttrName && sthConfig.NAME_ENCODING) {
+            newAttrName = sthDatabaseNameCodec.encodeCollectionName(newAttrName);
+        }
+    }
+    if (!newAttrName && sthConfig.NAME_ENCODING && attrName) {
+        newAttrName = sthDatabaseNameCodec.encodeCollectionName(attrName);
+    }
+    if (!newAttrName) {
+        newAttrName = attrName;
+    }
+
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            collectionName4Events = newServicePath;
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            collectionName4Events =
+                newServicePath +
+                sthConfig.NAME_SEPARATOR +
+                newEntityId +
+                (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '');
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            collectionName4Events =
+                newServicePath +
+                sthConfig.NAME_SEPARATOR +
+                newEntityId +
+                (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '') +
+                sthConfig.NAME_SEPARATOR +
+                newAttrName;
+            break;
+    }
+
+    if (getNamespaceSizeInBytes(databaseName, collectionName4Events) > MAX_NAMESPACE_SIZE_IN_BYTES) {
+        sthLogger.warn(
+            sthConfig.LOGGING_CONTEXT.DB_LOG,
+            'The size in bytes of the namespace for storing the aggregated data ("' +
+                databaseName +
+                '" plus "' +
+                sthConfig.COLLECTION_PREFIX +
+                collectionName4Events +
+                '.aggr", ' +
+                getNamespaceSizeInBytes(databaseName, collectionName4Events) +
+                ' bytes)' +
+                ' is bigger than ' +
+                MAX_NAMESPACE_SIZE_IN_BYTES +
+                ' bytes'
+        );
+        return null;
+    } else {
+        if (sthConfig.NAME_ENCODING) {
+            return sthDatabaseNameCodec.encodeCollectionName(sthConfig.COLLECTION_PREFIX) + collectionName4Events;
+        }
+        return sthConfig.COLLECTION_PREFIX + collectionName4Events;
+    }
 }
 
 /**
-* Returns the name of the collection which will store the aggregated data
-* @param  {Object}  params   Params object including the following properties:
-*                              - service: The service
-*                              - servicePath: The service path
-*                              - entityId: The entity id
-*                              - entityType: The entity type
-*                              - attrName: The attribute name
-* @returns {String}          The aggregated data collection name
+ * Returns the name of the collection which will store the aggregated data
+ * @param  {Object}  params   Params object including the following properties:
+ *                              - service: The service
+ *                              - servicePath: The service path
+ *                              - entityId: The entity id
+ *                              - entityType: The entity type
+ *                              - attrName: The attribute name
+ * @returns {String}          The aggregated data collection name
  */
 function getAggregatedCollectionName(params) {
-  var collectionName4Events = getRawCollectionName(params);
-  if (collectionName4Events) {
-    return collectionName4Events +
-      (sthConfig.NAME_ENCODING ? sthDatabaseNameCodec.encodeCollectionName('.aggr') : '.aggr');
-  } else {
-    return null;
-  }
+    var collectionName4Events = getRawCollectionName(params);
+    if (collectionName4Events) {
+        return (
+            collectionName4Events +
+            (sthConfig.NAME_ENCODING ? sthDatabaseNameCodec.encodeCollectionName('.aggr') : '.aggr')
+        );
+    } else {
+        return null;
+    }
 }
 
 module.exports = {
-  getDatabaseName: getDatabaseName,
-  getService: getService,
-  getRawCollectionName: getRawCollectionName,
-  getAggregatedCollectionName: getAggregatedCollectionName
+    getDatabaseName: getDatabaseName,
+    getService: getService,
+    getRawCollectionName: getRawCollectionName,
+    getAggregatedCollectionName: getAggregatedCollectionName,
 };

--- a/lib/database/model/sthDatabaseNaming.js
+++ b/lib/database/model/sthDatabaseNaming.js
@@ -51,14 +51,13 @@ var MAX_NAMESPACE_SIZE_IN_BYTES = 120;
  *  in bytes
  */
 function getNamespaceSizeInBytes(datebaseName, rawCollectionName) {
-    return (
-        bytesCounter.count(datebaseName) +
-        (rawCollectionName
-            ? bytesCounter.count(sthConfig.COLLECTION_PREFIX) +
+    return bytesCounter.count(datebaseName) +
+        // prettier-ignore
+        rawCollectionName
+        ? bytesCounter.count(sthConfig.COLLECTION_PREFIX) +
               bytesCounter.count(rawCollectionName) +
               bytesCounter.count('.aggr')
-            : 0)
-    );
+        : 0;
 }
 
 /**
@@ -79,14 +78,9 @@ function getDatabaseName(service) {
     if (getNamespaceSizeInBytes(databaseName) > MAX_DATABASE_NAME_SIZE_IN_BYTES) {
         sthLogger.warn(
             sthConfig.LOGGING_CONTEXT.DB_LOG,
-            'The size in bytes of the database ("' +
-                databaseName +
-                '", ' +
-                getNamespaceSizeInBytes(databaseName) +
-                ' bytes)' +
-                ' is bigger than ' +
-                MAX_DATABASE_NAME_SIZE_IN_BYTES +
-                ' bytes'
+            // prettier-ignore
+            'The size in bytes of the database ("' + databaseName + '", ' + getNamespaceSizeInBytes(databaseName) + 
+                ' bytes)' + ' is bigger than ' + MAX_DATABASE_NAME_SIZE_IN_BYTES + ' bytes'
         );
         return null;
     } else {

--- a/lib/database/model/sthDatabaseNaming.js
+++ b/lib/database/model/sthDatabaseNaming.js
@@ -187,37 +187,26 @@ function getRawCollectionName(params) {
             collectionName4Events = newServicePath;
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-            collectionName4Events =
-                newServicePath +
-                sthConfig.NAME_SEPARATOR +
-                newEntityId +
+            // prettier-ignore
+            collectionName4Events = newServicePath + sthConfig.NAME_SEPARATOR + newEntityId + 
                 (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '');
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-            collectionName4Events =
-                newServicePath +
-                sthConfig.NAME_SEPARATOR +
-                newEntityId +
-                (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '') +
-                sthConfig.NAME_SEPARATOR +
+            // prettier-ignore
+            collectionName4Events = newServicePath + sthConfig.NAME_SEPARATOR + newEntityId + 
+                (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '') + sthConfig.NAME_SEPARATOR + 
                 newAttrName;
             break;
     }
 
     if (getNamespaceSizeInBytes(databaseName, collectionName4Events) > MAX_NAMESPACE_SIZE_IN_BYTES) {
+        // prettier-ignore
         sthLogger.warn(
             sthConfig.LOGGING_CONTEXT.DB_LOG,
-            'The size in bytes of the namespace for storing the aggregated data ("' +
-                databaseName +
-                '" plus "' +
-                sthConfig.COLLECTION_PREFIX +
-                collectionName4Events +
-                '.aggr", ' +
-                getNamespaceSizeInBytes(databaseName, collectionName4Events) +
-                ' bytes)' +
-                ' is bigger than ' +
-                MAX_NAMESPACE_SIZE_IN_BYTES +
-                ' bytes'
+            'The size in bytes of the namespace for storing the aggregated data ("' + databaseName + '" plus "' + 
+            sthConfig.COLLECTION_PREFIX + collectionName4Events + '.aggr", ' + 
+            getNamespaceSizeInBytes(databaseName, collectionName4Events) + ' bytes)' + ' is bigger than ' + 
+            MAX_NAMESPACE_SIZE_IN_BYTES + ' bytes'
         );
         return null;
     } else {

--- a/lib/database/model/sthDatabaseWritableStream.js
+++ b/lib/database/model/sthDatabaseWritableStream.js
@@ -31,12 +31,12 @@ var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
 var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
 
 var STHWritableStream = function(databaseConnection, databaseName, collectionName, count) {
-  stream.Writable.call(this, { objectMode: true });
-  this.databaseConnection = databaseConnection;
-  this.databaseName = databaseName;
-  this.collectionName = collectionName;
-  this.originalCount = count;
-  this.count = 0;
+    stream.Writable.call(this, { objectMode: true });
+    this.databaseConnection = databaseConnection;
+    this.databaseName = databaseName;
+    this.collectionName = collectionName;
+    this.originalCount = count;
+    this.count = 0;
 };
 
 STHWritableStream.prototype = Object.create(stream.Writable.prototype);
@@ -48,29 +48,29 @@ STHWritableStream.prototype = Object.create(stream.Writable.prototype);
  * @param  {Function} callback   The callback
  */
 function updateRawData(doc, collection, callback) {
-  /*jshint validthis: true */
-  var self = this;
-  var docId = _.cloneDeep(doc);
-  delete docId._id;
-  delete docId.attrValue;
-  delete doc._id;
-  collection.update(
-    docId,
-    doc,
-    {
-      upsert: true,
-      writeConcern: {
-        w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-      }
-    },
-    function (err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      self.emit('progress', { total: self.originalCount, count: ++self.count});
-      process.nextTick(callback);
-    }
-  );
+    /*jshint validthis: true */
+    var self = this;
+    var docId = _.cloneDeep(doc);
+    delete docId._id;
+    delete docId.attrValue;
+    delete doc._id;
+    collection.update(
+        docId,
+        doc,
+        {
+            upsert: true,
+            writeConcern: {
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
+            },
+        },
+        function(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            self.emit('progress', { total: self.originalCount, count: ++self.count });
+            process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -79,12 +79,12 @@ function updateRawData(doc, collection, callback) {
  * @return {Object}       The MondoDB find() query
  */
 function getQuery(docId) {
-  var query = {};
-  var properties = Object.keys(docId._id);
-  properties.forEach(function(property) {
-    query['_id.'+ property] = docId._id[property];
-  });
-  return query;
+    var query = {};
+    var properties = Object.keys(docId._id);
+    properties.forEach(function(property) {
+        query['_id.' + property] = docId._id[property];
+    });
+    return query;
 }
 
 /**
@@ -94,9 +94,9 @@ function getQuery(docId) {
  * @param  {Object} targetPoint   The point from the target collection where the data will be combined
  */
 function mixTextualAggregation(originalPoint, targetPoint) {
-  Object.keys(originalPoint.occur).forEach(function(originalTag) {
-    targetPoint.occur[originalTag] = (targetPoint.occur[originalTag] || 0) + originalPoint.occur[originalTag];
-  });
+    Object.keys(originalPoint.occur).forEach(function(originalTag) {
+        targetPoint.occur[originalTag] = (targetPoint.occur[originalTag] || 0) + originalPoint.occur[originalTag];
+    });
 }
 
 /**
@@ -106,10 +106,10 @@ function mixTextualAggregation(originalPoint, targetPoint) {
  * @param  {Object} targetPoint   The point from the target collection where the data will be combined
  */
 function mixNumericAggregation(originalPoint, targetPoint) {
-  targetPoint.sum += originalPoint.sum;
-  targetPoint.sum2 += originalPoint.sum2;
-  targetPoint.min = Math.min(originalPoint.min, targetPoint.min);
-  targetPoint.max = Math.min(originalPoint.max, targetPoint.max);
+    targetPoint.sum += originalPoint.sum;
+    targetPoint.sum2 += originalPoint.sum2;
+    targetPoint.min = Math.min(originalPoint.min, targetPoint.min);
+    targetPoint.max = Math.min(originalPoint.max, targetPoint.max);
 }
 
 /**
@@ -119,49 +119,51 @@ function mixNumericAggregation(originalPoint, targetPoint) {
  * @param  {Function} callback   The callback
  */
 function updateAggregatedData(doc, collection, callback) {
-  /*jshint validthis: true */
-  var self = this;
-  collection.findOne(getQuery({ _id: doc._id}), function(err, doc2Update) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    if (!doc2Update) {
-      collection.insert(doc, function(){
+    /*jshint validthis: true */
+    var self = this;
+    collection.findOne(getQuery({ _id: doc._id }), function(err, doc2Update) {
         if (err) {
-          return process.nextTick(callback.bind(null, err));
-        }
-        self.emit('progress', {total: self.originalCount, count: ++self.count});
-        process.nextTick(callback);
-      });
-    } else {
-      doc2Update.points.forEach(function(point, index) {
-        doc.points[index].samples += point.samples;
-        if (point.occur) {
-          mixTextualAggregation(point, doc.points[index]);
-        } else {
-          mixNumericAggregation(point, doc.points[index]);
-        }
-      });
-      delete doc._id;
-      collection.update(
-        { _id : doc2Update._id },
-        doc,
-        {
-          upsert: false,
-          writeConcern: {
-            w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-          }
-        },
-        function (err) {
-          if (err) {
             return process.nextTick(callback.bind(null, err));
-          }
-          self.emit('progress', {total: self.originalCount, count: ++self.count});
-          return process.nextTick(callback);
         }
-      );
-    }
-  });
+        if (!doc2Update) {
+            collection.insert(doc, function() {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                self.emit('progress', { total: self.originalCount, count: ++self.count });
+                process.nextTick(callback);
+            });
+        } else {
+            doc2Update.points.forEach(function(point, index) {
+                doc.points[index].samples += point.samples;
+                if (point.occur) {
+                    mixTextualAggregation(point, doc.points[index]);
+                } else {
+                    mixNumericAggregation(point, doc.points[index]);
+                }
+            });
+            delete doc._id;
+            collection.update(
+                { _id: doc2Update._id },
+                doc,
+                {
+                    upsert: false,
+                    writeConcern: {
+                        w: !isNaN(sthConfig.WRITE_CONCERN)
+                            ? parseInt(sthConfig.WRITE_CONCERN, 10)
+                            : sthConfig.WRITE_CONCERN,
+                    },
+                },
+                function(err) {
+                    if (err) {
+                        return process.nextTick(callback.bind(null, err));
+                    }
+                    self.emit('progress', { total: self.originalCount, count: ++self.count });
+                    return process.nextTick(callback);
+                }
+            );
+        }
+    });
 }
 
 /**
@@ -171,12 +173,12 @@ function updateAggregatedData(doc, collection, callback) {
  * @param callback
  */
 function upsert(doc, collection, callback) {
-  /*jshint validthis: true */
-  if (sthDatabase.isAggregated(this.collectionName)) {
-    updateAggregatedData.call(this, doc, collection, callback);
-  } else {
-    updateRawData.call(this, doc, collection, callback);
-  }
+    /*jshint validthis: true */
+    if (sthDatabase.isAggregated(this.collectionName)) {
+        updateAggregatedData.call(this, doc, collection, callback);
+    } else {
+        updateRawData.call(this, doc, collection, callback);
+    }
 }
 
 /**
@@ -187,14 +189,11 @@ function upsert(doc, collection, callback) {
  * @private
  */
 STHWritableStream.prototype._write = function(doc, encoding, callback) {
-  this.db = this.databaseConnection.db(this.databaseName);
-  async.waterfall(
-    [
-      async.apply(this.db.collection.bind(this.db), this.collectionName),
-      async.apply(upsert.bind(this), doc)
-    ],
-    callback
-  );
+    this.db = this.databaseConnection.db(this.databaseName);
+    async.waterfall(
+        [async.apply(this.db.collection.bind(this.db), this.collectionName), async.apply(upsert.bind(this), doc)],
+        callback
+    );
 };
 
 module.exports = STHWritableStream;

--- a/lib/database/model/sthDatabaseWritableStream.js
+++ b/lib/database/model/sthDatabaseWritableStream.js
@@ -60,8 +60,8 @@ function updateRawData(doc, collection, callback) {
         {
             upsert: true,
             writeConcern: {
-                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
-            },
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+            }
         },
         function(err) {
             if (err) {
@@ -151,8 +151,8 @@ function updateAggregatedData(doc, collection, callback) {
                     writeConcern: {
                         w: !isNaN(sthConfig.WRITE_CONCERN)
                             ? parseInt(sthConfig.WRITE_CONCERN, 10)
-                            : sthConfig.WRITE_CONCERN,
-                    },
+                            : sthConfig.WRITE_CONCERN
+                    }
                 },
                 function(err) {
                     if (err) {

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -51,22 +51,22 @@ function getJSONCSVOptions(attrName) {
         fields: [
             {
                 name: 'attrName',
-                label: 'attrName',
+                label: 'attrName'
             },
             {
                 name: 'attrType',
-                label: 'attrType',
+                label: 'attrType'
             },
             {
                 name: 'attrValue',
-                label: 'attrValue',
+                label: 'attrValue'
             },
             {
                 name: 'recvTime',
-                label: 'recvTime',
-            },
+                label: 'recvTime'
+            }
         ],
-        fieldSeparator: ',',
+        fieldSeparator: ','
     };
     jsonCSVOptions.fields[0].filter = function() {
         return attrName;
@@ -102,7 +102,7 @@ function connect(params, callback) {
     mongoClient.connect(
         connectionURL,
         {
-            poolSize: params.poolSize,
+            poolSize: params.poolSize
         },
         function(err, theDB) {
             if (!err) {
@@ -158,7 +158,7 @@ function setRawDataUniqueIndex(collection) {
                 entityType: 1,
                 attrName: 1,
                 attrType: 1,
-                attrValue: 1,
+                attrValue: 1
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
@@ -166,14 +166,14 @@ function setRawDataUniqueIndex(collection) {
                 recvTime: 1,
                 attrName: 1,
                 attrType: 1,
-                attrValue: 1,
+                attrValue: 1
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
             uniqueCompoundIndex = {
                 recvTime: 1,
                 attrType: 1,
-                attrValue: 1,
+                attrValue: 1
             };
             break;
     }
@@ -214,10 +214,10 @@ function setTTLPolicy(collection) {
             if (sthConfig.TRUNCATION_SIZE === 0) {
                 collection.ensureIndex(
                     {
-                        recvTime: 1,
+                        recvTime: 1
                     },
                     {
-                        expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS,
+                        expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS
                     },
                     function(err) {
                         if (err) {
@@ -235,10 +235,10 @@ function setTTLPolicy(collection) {
         } else {
             collection.ensureIndex(
                 {
-                    '_id.origin': 1,
+                    '_id.origin': 1
                 },
                 {
-                    expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS,
+                    expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS
                 },
                 function(err) {
                     if (err) {
@@ -285,14 +285,14 @@ function getCollection(params, options, callback) {
                   servicePath: params.servicePath,
                   entityId: params.entityId,
                   entityType: params.entityType,
-                  attrName: params.attrName,
+                  attrName: params.attrName
               })
             : sthDatabaseNaming.getRawCollectionName({
                   service: params.service,
                   servicePath: params.servicePath,
                   entityId: params.entityId,
                   entityType: params.entityType,
-                  attrName: params.attrName,
+                  attrName: params.attrName
               });
     }
 
@@ -338,7 +338,7 @@ function getCollection(params, options, callback) {
                     var collectionCreationOptions = {
                         capped: true,
                         size: sthConfig.TRUNCATION_SIZE,
-                        max: sthConfig.TRUNCATION_MAX || null,
+                        max: sthConfig.TRUNCATION_MAX || null
                     };
                     return connection.createCollection(collectionName, collectionCreationOptions, createCollectionCB);
                 }
@@ -419,12 +419,12 @@ function getRawData(data, callback) {
             findCondition = {
                 entityId: entityId,
                 entityType: entityType,
-                attrName: attrName,
+                attrName: attrName
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
             findCondition = {
-                attrName: attrName,
+                attrName: attrName
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
@@ -436,15 +436,15 @@ function getRawData(data, callback) {
     if (from && to) {
         recvTimeFilter = {
             $lte: to,
-            $gte: from,
+            $gte: from
         };
     } else if (from) {
         recvTimeFilter = {
-            $gte: from,
+            $gte: from
         };
     } else if (to) {
         recvTimeFilter = {
-            $lte: to,
+            $lte: to
         };
     }
     if (recvTimeFilter) {
@@ -459,7 +459,7 @@ function getRawData(data, callback) {
                 _id: 0,
                 attrType: 1,
                 attrValue: 1,
-                recvTime: 1,
+                recvTime: 1
             })
             .sort({ recvTime: -1 });
         cursor.count(function(err, count) {
@@ -482,7 +482,7 @@ function getRawData(data, callback) {
                 _id: 0,
                 attrType: 1,
                 attrValue: 1,
-                recvTime: 1,
+                recvTime: 1
             })
             .sort({ recvTime: 1 });
         cursor.count(function(err, count) {
@@ -501,7 +501,7 @@ function getRawData(data, callback) {
             _id: 0,
             attrType: 1,
             attrValue: 1,
-            recvTime: 1,
+            recvTime: 1
         });
         cursor.count(function(err, count) {
             totalCount = count;
@@ -713,7 +713,7 @@ function getAggregatedData(data, callback) {
 
     var fieldFilter = {
         'points.offset': 1,
-        'points.samples': 1,
+        'points.samples': 1
     };
     fieldFilter['points.' + aggregatedFunction] = 1;
 
@@ -721,22 +721,22 @@ function getAggregatedData(data, callback) {
     if (from && to) {
         originFilter = {
             $lte: sthUtils.getOrigin(to, resolution),
-            $gte: sthUtils.getOrigin(from, resolution),
+            $gte: sthUtils.getOrigin(from, resolution)
         };
     } else if (from) {
         originFilter = {
-            $gte: sthUtils.getOrigin(from, resolution),
+            $gte: sthUtils.getOrigin(from, resolution)
         };
     } else if (to) {
         originFilter = {
-            $lte: sthUtils.getOrigin(to, resolution),
+            $lte: sthUtils.getOrigin(to, resolution)
         };
     }
 
     if (shouldFilter) {
         var pushAccumulator = {
             offset: '$points.offset',
-            samples: '$points.samples',
+            samples: '$points.samples'
         };
         pushAccumulator[aggregatedFunction] = '$points.' + aggregatedFunction;
 
@@ -747,18 +747,18 @@ function getAggregatedData(data, callback) {
                     '_id.entityId': entityId,
                     '_id.entityType': entityType,
                     '_id.attrName': attrName,
-                    '_id.resolution': resolution,
+                    '_id.resolution': resolution
                 };
                 break;
             case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
                 matchCondition = {
                     '_id.attrName': attrName,
-                    '_id.resolution': resolution,
+                    '_id.resolution': resolution
                 };
                 break;
             case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
                 matchCondition = {
-                    '_id.resolution': resolution,
+                    '_id.resolution': resolution
                 };
                 break;
         }
@@ -774,20 +774,20 @@ function getAggregatedData(data, callback) {
                     entityType: '$_id.entityType',
                     attrName: '$_id.attrName',
                     origin: '$_id.origin',
-                    resolution: '$_id.resolution',
+                    resolution: '$_id.resolution'
                 };
                 break;
             case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
                 groupId = {
                     attrName: '$_id.attrName',
                     origin: '$_id.origin',
-                    resolution: '$_id.resolution',
+                    resolution: '$_id.resolution'
                 };
                 break;
             case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
                 groupId = {
                     origin: '$_id.origin',
-                    resolution: '$_id.resolution',
+                    resolution: '$_id.resolution'
                 };
                 break;
         }
@@ -795,34 +795,34 @@ function getAggregatedData(data, callback) {
         collection.aggregate(
             [
                 {
-                    $match: matchCondition,
+                    $match: matchCondition
                 },
                 {
-                    $project: fieldFilter,
+                    $project: fieldFilter
                 },
                 {
-                    $unwind: '$points',
+                    $unwind: '$points'
                 },
                 {
                     $match: {
                         'points.samples': {
-                            $gt: 0,
-                        },
-                    },
+                            $gt: 0
+                        }
+                    }
                 },
                 {
                     $group: {
                         _id: groupId,
                         points: {
-                            $push: pushAccumulator,
-                        },
-                    },
+                            $push: pushAccumulator
+                        }
+                    }
                 },
                 {
                     $sort: {
-                        '_id.origin': 1,
-                    },
-                },
+                        '_id.origin': 1
+                    }
+                }
             ],
             function(err, resultsArr) {
                 filterResults(resultsArr, {
@@ -830,7 +830,7 @@ function getAggregatedData(data, callback) {
                     from: from,
                     to: to,
                     aggregatedFunction: aggregatedFunction,
-                    shouldFilter: shouldFilter,
+                    shouldFilter: shouldFilter
                 });
                 process.nextTick(callback.bind(null, err, resultsArr));
             }
@@ -845,18 +845,18 @@ function getAggregatedData(data, callback) {
                     '_id.entityId': entityId,
                     '_id.entityType': entityType,
                     '_id.attrName': attrName,
-                    '_id.resolution': resolution,
+                    '_id.resolution': resolution
                 };
                 break;
             case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
                 findCondition = {
                     '_id.attrName': attrName,
-                    '_id.resolution': resolution,
+                    '_id.resolution': resolution
                 };
                 break;
             case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
                 findCondition = {
-                    '_id.resolution': resolution,
+                    '_id.resolution': resolution
                 };
                 break;
         }
@@ -873,7 +873,7 @@ function getAggregatedData(data, callback) {
                     from: from,
                     to: to,
                     aggregatedFunction: aggregatedFunction,
-                    shouldFilter: shouldFilter,
+                    shouldFilter: shouldFilter
                 });
                 process.nextTick(callback.bind(null, err, resultsArr));
             });
@@ -909,7 +909,7 @@ function getAggregateUpdateCondition(data) {
                 '_id.attrName': attrName,
                 '_id.origin': sthUtils.getOrigin(timestamp, resolution),
                 '_id.resolution': resolution,
-                'points.offset': offset,
+                'points.offset': offset
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
@@ -917,14 +917,14 @@ function getAggregateUpdateCondition(data) {
                 '_id.attrName': attrName,
                 '_id.origin': sthUtils.getOrigin(timestamp, resolution),
                 '_id.resolution': resolution,
-                'points.offset': offset,
+                'points.offset': offset
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
             aggregateUpdateCondition = {
                 '_id.origin': sthUtils.getOrigin(timestamp, resolution),
                 '_id.resolution': resolution,
-                'points.offset': offset,
+                'points.offset': offset
             };
             break;
     }
@@ -970,7 +970,7 @@ function getAggregatePrepopulatedData(attrType, attrValue, resolution) {
                 sum: 0,
                 sum2: 0,
                 min: Number.POSITIVE_INFINITY,
-                max: Number.NEGATIVE_INFINITY,
+                max: Number.NEGATIVE_INFINITY
             });
         }
     } else {
@@ -978,7 +978,7 @@ function getAggregatePrepopulatedData(attrType, attrValue, resolution) {
             var entry = {
                 offset: j,
                 samples: 0,
-                occur: {},
+                occur: {}
             };
             points.push(entry);
         }
@@ -998,8 +998,8 @@ function getAggregateUpdate4Insert(attrType, attrValue, resolution) {
     return {
         $setOnInsert: {
             attrType: attrType,
-            points: getAggregatePrepopulatedData(attrType, attrValue, resolution),
-        },
+            points: getAggregatePrepopulatedData(attrType, attrValue, resolution)
+        }
     };
 }
 
@@ -1017,29 +1017,29 @@ function getAggregateUpdate4Update(attrType, attrValue, resolution, recvTime) {
         attrValueAsNumber = parseFloat(attrValue);
         aggregateUpdate4Update = {
             $set: {
-                attrType: attrType,
+                attrType: attrType
             },
             $inc: {
                 'points.$.samples': 1,
                 'points.$.sum': attrValueAsNumber,
-                'points.$.sum2': Math.pow(attrValueAsNumber, 2),
+                'points.$.sum2': Math.pow(attrValueAsNumber, 2)
             },
             $min: {
-                'points.$.min': attrValueAsNumber,
+                'points.$.min': attrValueAsNumber
             },
             $max: {
-                'points.$.max': attrValueAsNumber,
-            },
+                'points.$.max': attrValueAsNumber
+            }
         };
     } else {
         var offset = sthUtils.getOffset(resolution, recvTime);
         aggregateUpdate4Update = {
             $set: {
-                attrType: attrType,
+                attrType: attrType
             },
             $inc: {
-                'points.$.samples': 1,
-            },
+                'points.$.samples': 1
+            }
         };
         escapedAttrValue = attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
         aggregateUpdate4Update.$inc[
@@ -1075,7 +1075,7 @@ function getAggregateUpdate4Removal(data) {
             $inc: {
                 'points.$.samples': -1,
                 'points.$.sum': -escapedAttrValue,
-                'points.$.sum2': -Math.pow(escapedAttrValue, 2),
+                'points.$.sum2': -Math.pow(escapedAttrValue, 2)
             },
             $set: {
                 attrType: attrType,
@@ -1086,18 +1086,18 @@ function getAggregateUpdate4Removal(data) {
                 'points.$.max':
                     notificationInfo.newMaxValues && notificationInfo.newMaxValues[resolution]
                         ? Math.max(parseFloat(notificationInfo.newMaxValues[resolution]), parseFloat(attrValue))
-                        : parseFloat(attrValue),
-            },
+                        : parseFloat(attrValue)
+            }
         };
     } else {
         var offset = sthUtils.getOffset(resolution, timestamp);
         aggregateUpdate4Removal = {
             $set: {
-                attrType: attrType,
+                attrType: attrType
             },
             $inc: {
-                'points.$.samples': -1,
-            },
+                'points.$.samples': -1
+            }
         };
         escapedAttrValue = notificationInfo.updates.attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
         aggregateUpdate4Removal.$inc[
@@ -1133,21 +1133,19 @@ function removePreviouslyAggregatedData(data, callback) {
                 entityType: data.entityType,
                 attrName: data.attrName,
                 resolution: data.resolution,
-                timestamp: data.timestamp,
+                timestamp: data.timestamp
             }),
             getAggregateUpdate4Removal({
                 attrType: data.attrType,
                 attrValue: data.attrValue,
                 notificationInfo: data.notificationInfo,
                 resolution: data.resolution,
-                timestamp: data.timestamp,
+                timestamp: data.timestamp
             }),
             {
                 writeConcern: {
-                    w: !isNaN(sthConfig.WRITE_CONCERN)
-                        ? parseInt(sthConfig.WRITE_CONCERN, 10)
-                        : sthConfig.WRITE_CONCERN,
-                },
+                    w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+                }
             },
             function(err) {
                 if (callback) {
@@ -1181,13 +1179,13 @@ function updateAggregatedData(data, callback) {
             entityType: data.entityType,
             attrName: data.attrName,
             resolution: data.resolution,
-            timestamp: data.timestamp,
+            timestamp: data.timestamp
         }),
         getAggregateUpdate4Update(data.attrType, data.attrValue, data.resolution, data.timestamp),
         {
             writeConcern: {
-                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
-            },
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+            }
         },
         function(err) {
             if (err && callback) {
@@ -1253,14 +1251,14 @@ function storeAggregatedData4Resolution(data, callback) {
             entityType: entityType,
             attrName: attrName,
             resolution: resolution,
-            timestamp: timestamp,
+            timestamp: timestamp
         }),
         getAggregateUpdate4Insert(attrType, attrValue, resolution),
         {
             upsert: true,
             writeConcern: {
-                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
-            },
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+            }
         },
         function(err) {
             if (err && callback) {
@@ -1313,7 +1311,7 @@ function storeAggregatedData(data, callback) {
                 attrValue: attribute.value,
                 resolution: entry,
                 timestamp: timestamp,
-                notificationInfo: notificationInfo,
+                notificationInfo: notificationInfo
             },
             onCompletion
         );
@@ -1333,8 +1331,8 @@ function updateRawData(collection, oldRawData, newRawData, callback) {
         newRawData,
         {
             writeConcern: {
-                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
-            },
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+            }
         },
         function(err) {
             if (callback) {
@@ -1355,8 +1353,8 @@ function insertRawData(collection, newRawData, callback) {
         newRawData,
         {
             writeConcern: {
-                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
-            },
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+            }
         },
         function(err) {
             if (callback) {
@@ -1397,7 +1395,7 @@ function storeRawData(data, callback) {
                 entityType: entityType,
                 attrName: attribute.name,
                 attrType: attribute.type,
-                attrValue: attribute.value,
+                attrValue: attribute.value
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
@@ -1405,14 +1403,14 @@ function storeRawData(data, callback) {
                 recvTime: timestamp,
                 attrName: attribute.name,
                 attrType: attribute.type,
-                attrValue: attribute.value,
+                attrValue: attribute.value
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
             newRawData = {
                 recvTime: timestamp,
                 attrType: attribute.type,
-                attrValue: attribute.value,
+                attrValue: attribute.value
             };
             break;
     }
@@ -1451,8 +1449,8 @@ function getNewMinMaxCondition(data, resolution) {
                 recvTime: {
                     $gte: sthUtils.getOriginStart(timestamp, resolution),
                     $lte: sthUtils.getOriginEnd(timestamp, resolution),
-                    $ne: timestamp,
-                },
+                    $ne: timestamp
+                }
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
@@ -1461,8 +1459,8 @@ function getNewMinMaxCondition(data, resolution) {
                 recvTime: {
                     $gte: sthUtils.getOriginStart(timestamp, resolution),
                     $lte: sthUtils.getOriginEnd(timestamp, resolution),
-                    $ne: timestamp,
-                },
+                    $ne: timestamp
+                }
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
@@ -1470,8 +1468,8 @@ function getNewMinMaxCondition(data, resolution) {
                 recvTime: {
                     $ne: timestamp,
                     $gte: sthUtils.getOriginStart(timestamp, resolution),
-                    $lte: sthUtils.getOriginEnd(timestamp, resolution),
-                },
+                    $lte: sthUtils.getOriginEnd(timestamp, resolution)
+                }
             };
             break;
     }
@@ -1492,7 +1490,7 @@ function getNewMaxValues(data, callback) {
         data.collection
             .find(getNewMinMaxCondition(data, resolution))
             .sort({
-                attrValue: -1,
+                attrValue: -1
             })
             .toArray(function(err, restArray) {
                 if (callback) {
@@ -1531,7 +1529,7 @@ function getNewMinValues(data, callback) {
         data.collection
             .find(getNewMinMaxCondition(data, resolution))
             .sort({
-                attrValue: -1,
+                attrValue: -1
             })
             .toArray(function(err, restArray) {
                 if (callback) {
@@ -1589,7 +1587,7 @@ function generateNotificationInfo(data, searchResult, callback) {
                                 callback.bind(null, err, {
                                     updates: searchResult,
                                     newMinValues: newMinValues,
-                                    newMaxValues: newMaxValues,
+                                    newMaxValues: newMaxValues
                                 })
                             );
                         });
@@ -1636,20 +1634,20 @@ function getNotificationInfo(data, callback) {
                 entityId: entityId,
                 entityType: entityType,
                 attrName: attribute.name,
-                attrType: attribute.type,
+                attrType: attribute.type
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
             findCondition = {
                 recvTime: timestamp,
                 attrName: attribute.name,
-                attrType: attribute.type,
+                attrType: attribute.type
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
             findCondition = {
                 recvTime: timestamp,
-                attrType: attribute.type,
+                attrType: attribute.type
             };
             break;
     }
@@ -1698,7 +1696,7 @@ function getFindCondition4DataRemoval(data, options) {
             if (isAggregated) {
                 findCondition = {
                     '_id.entityId': entityId,
-                    '_id.entityType': entityType,
+                    '_id.entityType': entityType
                 };
                 if (attrName) {
                     findCondition['_id.attrName'] = attrName;
@@ -1706,7 +1704,7 @@ function getFindCondition4DataRemoval(data, options) {
             } else {
                 findCondition = {
                     entityId: entityId,
-                    entityType: entityType,
+                    entityType: entityType
                 };
                 if (attrName) {
                     findCondition.attrName = attrName;
@@ -1716,11 +1714,11 @@ function getFindCondition4DataRemoval(data, options) {
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
             if (isAggregated) {
                 findCondition = {
-                    '_id.attrName': attrName,
+                    '_id.attrName': attrName
                 };
             } else {
                 findCondition = {
-                    attrName: attrName,
+                    attrName: attrName
                 };
             }
             break;
@@ -1754,12 +1752,12 @@ function removeDataFromCollection(data, options, callback) {
             service: service,
             servicePath: servicePath,
             entityId: entityId,
-            entityType: entityType,
+            entityType: entityType
         },
         {
             isAggregated: isAggregated,
             shouldCreate: false,
-            shouldTruncate: false,
+            shouldTruncate: false
         },
         function(err, collection) {
             if (err) {
@@ -1773,8 +1771,8 @@ function removeDataFromCollection(data, options, callback) {
                         writeConcern: {
                             w: !isNaN(sthConfig.WRITE_CONCERN)
                                 ? parseInt(sthConfig.WRITE_CONCERN, 10)
-                                : sthConfig.WRITE_CONCERN,
-                        },
+                                : sthConfig.WRITE_CONCERN
+                        }
                     },
                     callback
                 );
@@ -1810,7 +1808,7 @@ function dropCollectionsFromList(collections, data, options, callback) {
             servicePath: servicePath,
             entityId: entityId,
             entityType: entityType,
-            attrName: attrName,
+            attrName: attrName
         };
 
     var collectionName = isAggregated
@@ -1968,5 +1966,5 @@ module.exports = {
     storeRawData: storeRawData,
     getNotificationInfo: getNotificationInfo,
     removeData: removeData,
-    isAggregated: isAggregated,
+    isAggregated: isAggregated
 };

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -86,13 +86,9 @@ function getJSONCSVOptions(attrName) {
  */
 function connect(params, callback) {
     connectionURL =
-        'mongodb://' +
-        params.authentication +
-        '@' +
-        params.dbURI +
-        '/' +
-        params.database +
-        (params.replicaSet ? '?replicaSet=' + params.replicaSet : '');
+        // prettier-ignore
+        'mongodb://' + params.authentication + '@' + params.dbURI + '/' + params.database + 
+            (params.replicaSet ? '?replicaSet=' + params.replicaSet : '');
 
     sthLogger.info(
         sthConfig.LOGGING_CONTEXT.DB_CONN_OPEN,

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -47,31 +47,31 @@ var db, connectionURL;
  * @return {{fields: *[], fieldSeparator: string}} The options to use
  */
 function getJSONCSVOptions(attrName) {
-  var jsonCSVOptions = {
-    fields: [
-      {
-        name: 'attrName',
-        label: 'attrName'
-      },
-      {
-        name: 'attrType',
-        label: 'attrType'
-      },
-      {
-        name: 'attrValue',
-        label: 'attrValue'
-      },
-      {
-        name: 'recvTime',
-        label: 'recvTime'
-      }
-    ],
-    fieldSeparator: ','
-  };
-  jsonCSVOptions.fields[0].filter = function () {
-    return attrName;
-  };
-  return jsonCSVOptions;
+    var jsonCSVOptions = {
+        fields: [
+            {
+                name: 'attrName',
+                label: 'attrName',
+            },
+            {
+                name: 'attrType',
+                label: 'attrType',
+            },
+            {
+                name: 'attrValue',
+                label: 'attrValue',
+            },
+            {
+                name: 'recvTime',
+                label: 'recvTime',
+            },
+        ],
+        fieldSeparator: ',',
+    };
+    jsonCSVOptions.fields[0].filter = function() {
+        return attrName;
+    };
+    return jsonCSVOptions;
 }
 
 /**
@@ -85,30 +85,37 @@ function getJSONCSVOptions(attrName) {
  * @param {Function} callback A callback to inform about the result of the operation
  */
 function connect(params, callback) {
-  connectionURL = 'mongodb://' + params.authentication + '@' + params.dbURI + '/' + params.database +
-    (params.replicaSet ? '?replicaSet=' + params.replicaSet : '');
+    connectionURL =
+        'mongodb://' +
+        params.authentication +
+        '@' +
+        params.dbURI +
+        '/' +
+        params.database +
+        (params.replicaSet ? '?replicaSet=' + params.replicaSet : '');
 
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_CONN_OPEN,
-    'Establishing connection to the database at %s',
-    connectionURL
-  );
-  mongoClient.connect(connectionURL,
-    {
-      poolSize: params.poolSize
-    },
-    function (err, theDB) {
-      if (!err) {
-        sthLogger.info(
-          sthConfig.LOGGING_CONTEXT.DB_CONN_OPEN,
-          'Connection successfully established to the database at %s',
-          connectionURL
-        );
-      }
-      db = theDB;
-      return process.nextTick(callback.bind(null, err, theDB));
-    }
-  );
+    sthLogger.info(
+        sthConfig.LOGGING_CONTEXT.DB_CONN_OPEN,
+        'Establishing connection to the database at %s',
+        connectionURL
+    );
+    mongoClient.connect(
+        connectionURL,
+        {
+            poolSize: params.poolSize,
+        },
+        function(err, theDB) {
+            if (!err) {
+                sthLogger.info(
+                    sthConfig.LOGGING_CONTEXT.DB_CONN_OPEN,
+                    'Connection successfully established to the database at %s',
+                    connectionURL
+                );
+            }
+            db = theDB;
+            return process.nextTick(callback.bind(null, err, theDB));
+        }
+    );
 }
 
 /**
@@ -117,30 +124,24 @@ function connect(params, callback) {
  *  of the operation
  */
 function closeConnection(callback) {
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE,
-    'Closing the connection to the database...'
-  );
-  if (db) {
-    db.close(function (err) {
-      if (err) {
-        sthLogger.error(
-          sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE,
-          'Error when closing the connection to the database: ' + err);
-      } else {
-        sthLogger.info(
-          sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE,
-          'Connection to MongoDb succesfully closed');
-        db = null;
-      }
-      return process.nextTick(callback.bind(null, err));
-    });
-  } else {
-    sthLogger.info(
-      sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE,
-      'No connection to the database available');
-    return process.nextTick(callback);
-  }
+    sthLogger.info(sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE, 'Closing the connection to the database...');
+    if (db) {
+        db.close(function(err) {
+            if (err) {
+                sthLogger.error(
+                    sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE,
+                    'Error when closing the connection to the database: ' + err
+                );
+            } else {
+                sthLogger.info(sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE, 'Connection to MongoDb succesfully closed');
+                db = null;
+            }
+            return process.nextTick(callback.bind(null, err));
+        });
+    } else {
+        sthLogger.info(sthConfig.LOGGING_CONTEXT.DB_CONN_CLOSE, 'No connection to the database available');
+        return process.nextTick(callback);
+    }
 }
 
 /**
@@ -148,47 +149,42 @@ function closeConnection(callback) {
  * @param {object} collection The raw data collection
  */
 function setRawDataUniqueIndex(collection) {
-  var uniqueCompoundIndex;
-  switch(sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      uniqueCompoundIndex = {
-        'recvTime': 1,
-        'entityId': 1,
-        'entityType': 1,
-        'attrName': 1,
-        'attrType': 1,
-        'attrValue': 1
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      uniqueCompoundIndex = {
-        'recvTime': 1,
-        'attrName': 1,
-        'attrType': 1,
-        'attrValue': 1
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      uniqueCompoundIndex = {
-        'recvTime': 1,
-        'attrType': 1,
-        'attrValue': 1
-      };
-      break;
-  }
-  collection.ensureIndex(
-    uniqueCompoundIndex,
-    { unique: true },
-    function (err) {
-      if (err) {
-        sthLogger.error(
-          sthConfig.LOGGING_CONTEXT.DB_LOG,
-          'Error when creating the unique compound index for collection \'' +
-          collection.s.name + '\': ' + err
-        );
-      }
+    var uniqueCompoundIndex;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            uniqueCompoundIndex = {
+                recvTime: 1,
+                entityId: 1,
+                entityType: 1,
+                attrName: 1,
+                attrType: 1,
+                attrValue: 1,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            uniqueCompoundIndex = {
+                recvTime: 1,
+                attrName: 1,
+                attrType: 1,
+                attrValue: 1,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            uniqueCompoundIndex = {
+                recvTime: 1,
+                attrType: 1,
+                attrValue: 1,
+            };
+            break;
     }
-  );
+    collection.ensureIndex(uniqueCompoundIndex, { unique: true }, function(err) {
+        if (err) {
+            sthLogger.error(
+                sthConfig.LOGGING_CONTEXT.DB_LOG,
+                "Error when creating the unique compound index for collection '" + collection.s.name + "': " + err
+            );
+        }
+    });
 }
 
 /**
@@ -197,12 +193,14 @@ function setRawDataUniqueIndex(collection) {
  * @return {boolean} True is the collection name corresponds to an aggregated data collection. False otherwise.
  */
 function isAggregated(collectionName) {
-  if (collectionName.lastIndexOf('.aggr') === -1 ||
-    collectionName.lastIndexOf('.aggr') !== collectionName.length - '.aggr'.length) {
-    return false;
-  } else {
-    return true;
-  }
+    if (
+        collectionName.lastIndexOf('.aggr') === -1 ||
+        collectionName.lastIndexOf('.aggr') !== collectionName.length - '.aggr'.length
+    ) {
+        return false;
+    } else {
+        return true;
+    }
 }
 
 /**
@@ -210,46 +208,49 @@ function isAggregated(collectionName) {
  * @param {object} collection The collection
  */
 function setTTLPolicy(collection) {
-  // Set the TTL policy if required
-  if (sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS > 0) {
-    if (!isAggregated(collection)) {
-      if (sthConfig.TRUNCATION_SIZE === 0) {
-        collection.ensureIndex(
-          {
-            'recvTime': 1
-          },
-          {
-            expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS
-          }, function (err) {
-            if (err) {
-              sthLogger.error(
-                sthConfig.LOGGING_CONTEXT.DB_LOG,
-                'Error when creating the index for TTL for collection \'' +
-                collection.s.name + '\': ' + err
-              );
+    // Set the TTL policy if required
+    if (sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS > 0) {
+        if (!isAggregated(collection)) {
+            if (sthConfig.TRUNCATION_SIZE === 0) {
+                collection.ensureIndex(
+                    {
+                        recvTime: 1,
+                    },
+                    {
+                        expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS,
+                    },
+                    function(err) {
+                        if (err) {
+                            sthLogger.error(
+                                sthConfig.LOGGING_CONTEXT.DB_LOG,
+                                "Error when creating the index for TTL for collection '" +
+                                    collection.s.name +
+                                    "': " +
+                                    err
+                            );
+                        }
+                    }
+                );
             }
-          }
-        );
-      }
-    } else {
-      collection.ensureIndex(
-        {
-          '_id.origin': 1
-        },
-        {
-          expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS
-        }, function (err) {
-          if (err) {
-            sthLogger.error(
-              sthConfig.LOGGING_CONTEXT.DB_LOG,
-              'Error when creating the index for TTL for collection \'' +
-              collection.s.name + '\': ' + err
+        } else {
+            collection.ensureIndex(
+                {
+                    '_id.origin': 1,
+                },
+                {
+                    expireAfterSeconds: sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS,
+                },
+                function(err) {
+                    if (err) {
+                        sthLogger.error(
+                            sthConfig.LOGGING_CONTEXT.DB_LOG,
+                            "Error when creating the index for TTL for collection '" + collection.s.name + "': " + err
+                        );
+                    }
+                }
             );
-          }
         }
-      );
     }
-  }
 }
 
 /**
@@ -268,96 +269,85 @@ function setTTLPolicy(collection) {
  * @param  {Function} callback The callback
  */
 function getCollection(params, options, callback) {
-  var isAggregated = options.isAggregated,
-    shouldCreate = options.shouldCreate,
-    shouldTruncate = options.shouldTruncate;
+    var isAggregated = options.isAggregated,
+        shouldCreate = options.shouldCreate,
+        shouldTruncate = options.shouldTruncate;
 
-  var databaseName = sthDatabaseNaming.getDatabaseName(params.service);
+    var databaseName = sthDatabaseNaming.getDatabaseName(params.service);
 
-  var collectionName;
-  if (params.collection) {
-    collectionName = params.collection;
-  } else {
-    collectionName = isAggregated ?
-      sthDatabaseNaming.getAggregatedCollectionName(
-        {
-          service: params.service,
-          servicePath: params.servicePath,
-          entityId: params.entityId,
-          entityType: params.entityType,
-          attrName: params.attrName
-        }
-      ) :
-      sthDatabaseNaming.getRawCollectionName(
-        {
-          service: params.service,
-          servicePath: params.servicePath,
-          entityId: params.entityId,
-          entityType: params.entityType,
-          attrName: params.attrName
-        }
-      );
-  }
-
-  if (!collectionName) {
-    var error = boom.badRequest('The collection name could not be generated');
-    return process.nextTick(callback.bind(null, error));
-  }
-
-  // Switch to the right database
-  var connection = db.db(databaseName);
-
-  function createCollectionCB(err, collection) {
-    if (err) {
-      if (err.message === 'collection already exists') {
-        // We have observed that although leaving the strict option to the default value, sometimes
-        //  we get a 'collection already exists' error when executing connection.db#createCollection()
-        connection.collection(collectionName, {strict: true},
-          function (err, collection) {
-            return callback(err, collection);
-          }
-        );
-      } else {
-        return callback(err, collection);
-      }
-    } else if (collection && !isAggregated) {
-      setRawDataUniqueIndex(collection);
-      if (shouldTruncate) {
-        setTTLPolicy(collection);
-      }
-      return callback(err, collection);
+    var collectionName;
+    if (params.collection) {
+        collectionName = params.collection;
     } else {
-      return callback(err, collection);
+        collectionName = isAggregated
+            ? sthDatabaseNaming.getAggregatedCollectionName({
+                  service: params.service,
+                  servicePath: params.servicePath,
+                  entityId: params.entityId,
+                  entityType: params.entityType,
+                  attrName: params.attrName,
+              })
+            : sthDatabaseNaming.getRawCollectionName({
+                  service: params.service,
+                  servicePath: params.servicePath,
+                  entityId: params.entityId,
+                  entityType: params.entityType,
+                  attrName: params.attrName,
+              });
     }
-  }
 
-  connection.collection(collectionName, {strict: true},
-    function (err, collection) {
-      if (err &&
-        (err.message === 'Collection ' + collectionName + ' does not exist. Currently in strict mode.') &&
-        shouldCreate) {
-        if (shouldTruncate && !isAggregated) {
-          // Set the size removal policy if required
-          if (sthConfig.TRUNCATION_SIZE > 0) {
-            var collectionCreationOptions = {
-              capped: true,
-              size: sthConfig.TRUNCATION_SIZE,
-              max: sthConfig.TRUNCATION_MAX || null
-            };
-            return connection.createCollection(collectionName,
-              collectionCreationOptions,
-              createCollectionCB
-            );
-          }
-        }
-        connection.createCollection(collectionName,
-          createCollectionCB
-        );
-      } else {
-        return callback(err, collection);
-      }
+    if (!collectionName) {
+        var error = boom.badRequest('The collection name could not be generated');
+        return process.nextTick(callback.bind(null, error));
     }
-  );
+
+    // Switch to the right database
+    var connection = db.db(databaseName);
+
+    function createCollectionCB(err, collection) {
+        if (err) {
+            if (err.message === 'collection already exists') {
+                // We have observed that although leaving the strict option to the default value, sometimes
+                //  we get a 'collection already exists' error when executing connection.db#createCollection()
+                connection.collection(collectionName, { strict: true }, function(err, collection) {
+                    return callback(err, collection);
+                });
+            } else {
+                return callback(err, collection);
+            }
+        } else if (collection && !isAggregated) {
+            setRawDataUniqueIndex(collection);
+            if (shouldTruncate) {
+                setTTLPolicy(collection);
+            }
+            return callback(err, collection);
+        } else {
+            return callback(err, collection);
+        }
+    }
+
+    connection.collection(collectionName, { strict: true }, function(err, collection) {
+        if (
+            err &&
+            err.message === 'Collection ' + collectionName + ' does not exist. Currently in strict mode.' &&
+            shouldCreate
+        ) {
+            if (shouldTruncate && !isAggregated) {
+                // Set the size removal policy if required
+                if (sthConfig.TRUNCATION_SIZE > 0) {
+                    var collectionCreationOptions = {
+                        capped: true,
+                        size: sthConfig.TRUNCATION_SIZE,
+                        max: sthConfig.TRUNCATION_MAX || null,
+                    };
+                    return connection.createCollection(collectionName, collectionCreationOptions, createCollectionCB);
+                }
+            }
+            connection.createCollection(collectionName, createCollectionCB);
+        } else {
+            return callback(err, collection);
+        }
+    });
 }
 
 /**
@@ -368,14 +358,16 @@ function getCollection(params, options, callback) {
  * @param {function} callback THe callback
  */
 function save2File(attrName, stream, fileName, callback) {
-  var tempDir = ROOT_PATH + path.sep + sthConfig.TEMPORAL_DIR;
-  if (!fs.existsSync(tempDir) ||
-    (fs.existsSync(tempDir) && !fs.statSync(tempDir).isDirectory())) {
-    mkdirp.sync(tempDir);
-  }
+    var tempDir = ROOT_PATH + path.sep + sthConfig.TEMPORAL_DIR;
+    if (!fs.existsSync(tempDir) || (fs.existsSync(tempDir) && !fs.statSync(tempDir).isDirectory())) {
+        mkdirp.sync(tempDir);
+    }
 
-  var outputFile = fs.createWriteStream(tempDir + path.sep + fileName, {encoding: 'utf8'});
-  stream.pipe(jsoncsv.csv(getJSONCSVOptions(attrName))).pipe(outputFile).on('finish', callback);
+    var outputFile = fs.createWriteStream(tempDir + path.sep + fileName, { encoding: 'utf8' });
+    stream
+        .pipe(jsoncsv.csv(getJSONCSVOptions(attrName)))
+        .pipe(outputFile)
+        .on('finish', callback);
 }
 
 /**
@@ -385,10 +377,13 @@ function save2File(attrName, stream, fileName, callback) {
  * @param {function} callback The callback
  */
 function generateCSV(attrName, stream, callback) {
-  var fileName = attrName + '-' + Date.now() + '.csv';
-  save2File(attrName, stream, fileName,
-    callback.bind(null, null,
-      ROOT_PATH + path.sep + sthConfig.TEMPORAL_DIR + path.sep + fileName));
+    var fileName = attrName + '-' + Date.now() + '.csv';
+    save2File(
+        attrName,
+        stream,
+        fileName,
+        callback.bind(null, null, ROOT_PATH + path.sep + sthConfig.TEMPORAL_DIR + path.sep + fileName)
+    );
 }
 
 /**
@@ -407,123 +402,118 @@ function generateCSV(attrName, stream, callback) {
  * @param {Function} callback Callback to inform about any possible error or results
  */
 function getRawData(data, callback) {
-  var collection = data.collection,
-    entityId = data.entityId,
-    entityType = data.entityType,
-    attrName = data.attrName,
-    lastN = data.lastN,
-    hLimit = data.hLimit,
-    hOffset = data.hOffset,
-    from = data.from,
-    to = data.to,
-    filetype = data.filetype;
+    var collection = data.collection,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attrName,
+        lastN = data.lastN,
+        hLimit = data.hLimit,
+        hOffset = data.hOffset,
+        from = data.from,
+        to = data.to,
+        filetype = data.filetype;
 
-  var findCondition;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      findCondition = {
-        'entityId': entityId,
-        'entityType': entityType,
-        'attrName': attrName
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      findCondition = {
-        'attrName': attrName
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      findCondition = {};
-      break;
-  }
+    var findCondition;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            findCondition = {
+                entityId: entityId,
+                entityType: entityType,
+                attrName: attrName,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            findCondition = {
+                attrName: attrName,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            findCondition = {};
+            break;
+    }
 
-  var recvTimeFilter;
-  if (from && to) {
-    recvTimeFilter = {
-      $lte: to,
-      $gte: from
-    };
-  } else if (from) {
-    recvTimeFilter = {
-      $gte: from
-    };
-  } else if (to) {
-    recvTimeFilter = {
-      $lte: to
-    };
-  }
-  if (recvTimeFilter) {
-    findCondition.recvTime = recvTimeFilter;
-  }
+    var recvTimeFilter;
+    if (from && to) {
+        recvTimeFilter = {
+            $lte: to,
+            $gte: from,
+        };
+    } else if (from) {
+        recvTimeFilter = {
+            $gte: from,
+        };
+    } else if (to) {
+        recvTimeFilter = {
+            $lte: to,
+        };
+    }
+    if (recvTimeFilter) {
+        findCondition.recvTime = recvTimeFilter;
+    }
 
-  var cursor;
-  var totalCount=0;
-  if (lastN || lastN === 0) {
-    cursor = collection.find(
-      findCondition,
-      {
-        _id: 0,
-        attrType: 1,
-        attrValue: 1,
-        recvTime: 1
-      }
-    ).sort({'recvTime': -1});
-    cursor.count(function(err, count) {
-      totalCount=count;
-    });
-    cursor = cursor.limit(lastN);
-    if (filetype === 'csv') {
-      generateCSV(attrName, cursor.stream(), callback);
-    } else {
-      cursor.toArray(function (err, results) {
-        if (!err) {
-          results.reverse();
+    var cursor;
+    var totalCount = 0;
+    if (lastN || lastN === 0) {
+        cursor = collection
+            .find(findCondition, {
+                _id: 0,
+                attrType: 1,
+                attrValue: 1,
+                recvTime: 1,
+            })
+            .sort({ recvTime: -1 });
+        cursor.count(function(err, count) {
+            totalCount = count;
+        });
+        cursor = cursor.limit(lastN);
+        if (filetype === 'csv') {
+            generateCSV(attrName, cursor.stream(), callback);
+        } else {
+            cursor.toArray(function(err, results) {
+                if (!err) {
+                    results.reverse();
+                }
+                return process.nextTick(callback.bind(null, err, results, totalCount));
+            });
         }
-        return process.nextTick(callback.bind(null, err, results, totalCount));
-      });
-    }
-  } else if (hOffset || hLimit) {
-    cursor = collection.find(
-      findCondition,
-      {
-        _id: 0,
-        attrType: 1,
-        attrValue: 1,
-        recvTime: 1
-      }
-    ).sort({'recvTime': 1});
-    cursor.count(function(err, count) {
-      totalCount=count;
-    });
-    cursor = cursor.skip(hOffset || 0).limit(hLimit || 0);
-    if (filetype === 'cvs') {
-      generateCSV(attrName, cursor.stream(), callback);
+    } else if (hOffset || hLimit) {
+        cursor = collection
+            .find(findCondition, {
+                _id: 0,
+                attrType: 1,
+                attrValue: 1,
+                recvTime: 1,
+            })
+            .sort({ recvTime: 1 });
+        cursor.count(function(err, count) {
+            totalCount = count;
+        });
+        cursor = cursor.skip(hOffset || 0).limit(hLimit || 0);
+        if (filetype === 'cvs') {
+            generateCSV(attrName, cursor.stream(), callback);
+        } else {
+            cursor.toArray(function(err, results) {
+                return process.nextTick(callback.bind(null, err, results, totalCount));
+            });
+        }
     } else {
-      cursor.toArray(function (err, results) {
-        return process.nextTick(callback.bind(null, err, results, totalCount));
-      });
+        cursor = collection.find(findCondition, {
+            _id: 0,
+            attrType: 1,
+            attrValue: 1,
+            recvTime: 1,
+        });
+        cursor.count(function(err, count) {
+            totalCount = count;
+        });
+        if (filetype === 'csv') {
+            generateCSV(attrName, cursor.stream(), callback);
+        } else {
+            cursor.toArray(function(err, results) {
+                return process.nextTick(callback.bind(null, err, results, totalCount));
+            });
+        }
     }
-  } else {
-    cursor = collection.find(
-      findCondition,
-      {
-        _id: 0,
-        attrType: 1,
-        attrValue: 1,
-        recvTime: 1
-      }
-    );
-    cursor.count(function(err, count) {
-      totalCount=count;
-    });
-    if (filetype === 'csv') {
-      generateCSV(attrName, cursor.stream(), callback);
-    } else {
-      cursor.toArray(function (err, results) {
-        return process.nextTick(callback.bind(null, err, results, totalCount));
-      });
-    }
-  }
 }
 
 /**
@@ -534,22 +524,22 @@ function getRawData(data, callback) {
  * @param shouldFilter A flag indicating if results have been filtered out
  */
 function filterPointFromBeginning(points, i, aggregatedFunction, shouldFilter) {
-  if (shouldFilter) {
-    points.splice(i, 1);
-    i--;
-  } else {
-    points[i].samples = 0;
-    if (aggregatedFunction === 'occur') {
-      points[i].occur = {};
-    } else if (aggregatedFunction === 'min') {
-      points[i].min = Number.POSITIVE_INFINITY;
-    } else if (aggregatedFunction === 'max') {
-      points[i].max = Number.NEGATIVE_INFINITY;
+    if (shouldFilter) {
+        points.splice(i, 1);
+        i--;
     } else {
-      points[i][aggregatedFunction] = 0;
+        points[i].samples = 0;
+        if (aggregatedFunction === 'occur') {
+            points[i].occur = {};
+        } else if (aggregatedFunction === 'min') {
+            points[i].min = Number.POSITIVE_INFINITY;
+        } else if (aggregatedFunction === 'max') {
+            points[i].max = Number.NEGATIVE_INFINITY;
+        } else {
+            points[i][aggregatedFunction] = 0;
+        }
     }
-  }
-  return i;
+    return i;
 }
 
 /**
@@ -560,21 +550,21 @@ function filterPointFromBeginning(points, i, aggregatedFunction, shouldFilter) {
  * @param shouldFilter A flag indicating if the results should be filtered
  */
 function filterResultsFromBeginning(results, minOffset, aggregatedFunction, shouldFilter) {
-  var points = results[0].points;
-  for (var i = 0; i < points.length; i++) {
-    if (points[i]) {
-      if (points[i].offset < minOffset) {
-        if (points[i].samples) {
-          i = filterPointFromBeginning(points, i, aggregatedFunction, shouldFilter);
+    var points = results[0].points;
+    for (var i = 0; i < points.length; i++) {
+        if (points[i]) {
+            if (points[i].offset < minOffset) {
+                if (points[i].samples) {
+                    i = filterPointFromBeginning(points, i, aggregatedFunction, shouldFilter);
+                }
+            } else {
+                break;
+            }
         }
-      } else {
-        break;
-      }
     }
-  }
-  if (!points.length) {
-    results.splice(0, 1);
-  }
+    if (!points.length) {
+        results.splice(0, 1);
+    }
 }
 
 /**
@@ -585,20 +575,20 @@ function filterResultsFromBeginning(results, minOffset, aggregatedFunction, shou
  * @param shouldFilter A flag indicating if results have been filtered out
  */
 function filterPointFromEnd(points, i, aggregatedFunction, shouldFilter) {
-  if (shouldFilter) {
-    points.splice(i, 1);
-  } else {
-    points[i].samples = 0;
-    if (aggregatedFunction === 'occur') {
-      points[i].occur = {};
-    } else if (aggregatedFunction === 'min') {
-      points[i].min = Number.POSITIVE_INFINITY;
-    } else if (aggregatedFunction === 'max') {
-      points[i].max = Number.NEGATIVE_INFINITY;
+    if (shouldFilter) {
+        points.splice(i, 1);
     } else {
-      points[i][aggregatedFunction] = 0;
+        points[i].samples = 0;
+        if (aggregatedFunction === 'occur') {
+            points[i].occur = {};
+        } else if (aggregatedFunction === 'min') {
+            points[i].min = Number.POSITIVE_INFINITY;
+        } else if (aggregatedFunction === 'max') {
+            points[i].max = Number.NEGATIVE_INFINITY;
+        } else {
+            points[i][aggregatedFunction] = 0;
+        }
     }
-  }
 }
 
 /**
@@ -609,21 +599,21 @@ function filterPointFromEnd(points, i, aggregatedFunction, shouldFilter) {
  * @param shouldFilter A flag indicating if the results should be filtered
  */
 function filterResultsFromEnd(results, maxOffset, aggregatedFunction, shouldFilter) {
-  var points = results[results.length - 1].points;
-  for (var i = points.length - 1; i >= 0; i--) {
-    if (points[i]) {
-      if (points[i].offset > maxOffset) {
-        if (points[i].samples) {
-          filterPointFromEnd(points, i, aggregatedFunction, shouldFilter);
+    var points = results[results.length - 1].points;
+    for (var i = points.length - 1; i >= 0; i--) {
+        if (points[i]) {
+            if (points[i].offset > maxOffset) {
+                if (points[i].samples) {
+                    filterPointFromEnd(points, i, aggregatedFunction, shouldFilter);
+                }
+            } else {
+                break;
+            }
         }
-      } else {
-        break;
-      }
     }
-  }
-  if (!points.length) {
-    results.splice(results.length - 1, 1);
-  }
+    if (!points.length) {
+        results.splice(results.length - 1, 1);
+    }
 }
 
 /**
@@ -638,60 +628,62 @@ function filterResultsFromEnd(results, maxOffset, aggregatedFunction, shouldFilt
  *  - shouldFilter: Flag indicating if null results should be filtered
  */
 function filterResults(results, options) {
-  var resolution = options.resolution,
-    from = options.from,
-    to = options.to,
-    aggregatedFunction = options.aggregatedFunction,
-    shouldFilter = options.shouldFilter;
+    var resolution = options.resolution,
+        from = options.from,
+        to = options.to,
+        aggregatedFunction = options.aggregatedFunction,
+        shouldFilter = options.shouldFilter;
 
-  if (!results.length) {
-    return;
-  }
+    if (!results.length) {
+        return;
+    }
 
-  if (from &&
-    results[0]._id.origin.getTime() === sthUtils.getOrigin(from, resolution).getTime()) {
-    var minOffset;
-    switch (resolution) {
-      case sthConfig.RESOLUTION.SECOND:
-        minOffset = from.getUTCSeconds();
-        break;
-      case sthConfig.RESOLUTION.MINUTE:
-        minOffset = from.getUTCMinutes();
-        break;
-      case sthConfig.RESOLUTION.HOUR:
-        minOffset = from.getUTCHours();
-        break;
-      case sthConfig.RESOLUTION.DAY:
-        minOffset = from.getUTCDate();
-        break;
-      case sthConfig.RESOLUTION.MONTH:
-        minOffset = from.getUTCMonth();
-        break;
+    if (from && results[0]._id.origin.getTime() === sthUtils.getOrigin(from, resolution).getTime()) {
+        var minOffset;
+        switch (resolution) {
+            case sthConfig.RESOLUTION.SECOND:
+                minOffset = from.getUTCSeconds();
+                break;
+            case sthConfig.RESOLUTION.MINUTE:
+                minOffset = from.getUTCMinutes();
+                break;
+            case sthConfig.RESOLUTION.HOUR:
+                minOffset = from.getUTCHours();
+                break;
+            case sthConfig.RESOLUTION.DAY:
+                minOffset = from.getUTCDate();
+                break;
+            case sthConfig.RESOLUTION.MONTH:
+                minOffset = from.getUTCMonth();
+                break;
+        }
+        filterResultsFromBeginning(results, minOffset, aggregatedFunction, shouldFilter);
     }
-    filterResultsFromBeginning(results, minOffset, aggregatedFunction, shouldFilter);
-  }
-  if (results.length && to &&
-    results[results.length - 1]._id.origin.getTime() === sthUtils.getOrigin(to, resolution).getTime()) {
-    var maxOffset;
-    switch (resolution) {
-      case sthConfig.RESOLUTION.SECOND:
-        maxOffset = to.getUTCSeconds();
-        break;
-      case sthConfig.RESOLUTION.MINUTE:
-        maxOffset = to.getUTCMinutes();
-        break;
-      case sthConfig.RESOLUTION.HOUR:
-        maxOffset = to.getUTCHours();
-        break;
-      case sthConfig.RESOLUTION.DAY:
-        maxOffset = to.getUTCDate();
-        break;
-      case sthConfig.RESOLUTION.MONTH:
-        maxOffset = to.getUTCMonth();
-        break;
+    if (
+        results.length &&
+        to &&
+        results[results.length - 1]._id.origin.getTime() === sthUtils.getOrigin(to, resolution).getTime()
+    ) {
+        var maxOffset;
+        switch (resolution) {
+            case sthConfig.RESOLUTION.SECOND:
+                maxOffset = to.getUTCSeconds();
+                break;
+            case sthConfig.RESOLUTION.MINUTE:
+                maxOffset = to.getUTCMinutes();
+                break;
+            case sthConfig.RESOLUTION.HOUR:
+                maxOffset = to.getUTCHours();
+                break;
+            case sthConfig.RESOLUTION.DAY:
+                maxOffset = to.getUTCDate();
+                break;
+            case sthConfig.RESOLUTION.MONTH:
+                maxOffset = to.getUTCMonth();
+                break;
+        }
+        filterResultsFromEnd(results, maxOffset, aggregatedFunction, shouldFilter);
     }
-    filterResultsFromEnd(results, maxOffset, aggregatedFunction, shouldFilter);
-  }
 }
 
 /**
@@ -709,188 +701,183 @@ function filterResults(results, options) {
  * @param {Function} callback Callback to inform about any possible error or results
  */
 function getAggregatedData(data, callback) {
-  var collection = data.collection,
-    entityId = data.entityId,
-    entityType = data.entityType,
-    attrName = data.attrName,
-    aggregatedFunction = data.aggregatedFunction,
-    resolution = data.resolution,
-    from = data.from,
-    to = data.to,
-    shouldFilter = data.shouldFilter;
+    var collection = data.collection,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attrName,
+        aggregatedFunction = data.aggregatedFunction,
+        resolution = data.resolution,
+        from = data.from,
+        to = data.to,
+        shouldFilter = data.shouldFilter;
 
-  var fieldFilter = {
-    'points.offset': 1,
-    'points.samples': 1
-  };
-  fieldFilter['points.' + aggregatedFunction] = 1;
-
-  var originFilter;
-  if (from && to) {
-    originFilter = {
-      $lte: sthUtils.getOrigin(to, resolution),
-      $gte: sthUtils.getOrigin(from, resolution)
+    var fieldFilter = {
+        'points.offset': 1,
+        'points.samples': 1,
     };
-  } else if (from) {
-    originFilter = {
-      $gte: sthUtils.getOrigin(from, resolution)
-    };
-  } else if (to) {
-    originFilter = {
-      $lte: sthUtils.getOrigin(to, resolution)
-    };
-  }
+    fieldFilter['points.' + aggregatedFunction] = 1;
 
-  if (shouldFilter) {
-    var pushAccumulator = {
-      offset: '$points.offset',
-      samples: '$points.samples'
-    };
-    pushAccumulator[aggregatedFunction] = '$points.' + aggregatedFunction;
-
-    var matchCondition;
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-        matchCondition = {
-          '_id.entityId': entityId,
-          '_id.entityType': entityType,
-          '_id.attrName': attrName,
-          '_id.resolution': resolution
+    var originFilter;
+    if (from && to) {
+        originFilter = {
+            $lte: sthUtils.getOrigin(to, resolution),
+            $gte: sthUtils.getOrigin(from, resolution),
         };
-        break;
-      case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-        matchCondition = {
-          '_id.attrName': attrName,
-          '_id.resolution': resolution
+    } else if (from) {
+        originFilter = {
+            $gte: sthUtils.getOrigin(from, resolution),
         };
-        break;
-      case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-        matchCondition = {
-          '_id.resolution': resolution
+    } else if (to) {
+        originFilter = {
+            $lte: sthUtils.getOrigin(to, resolution),
         };
-        break;
-    }
-    if (originFilter) {
-      matchCondition['_id.origin'] = originFilter;
     }
 
-    var groupId;
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-        groupId = {
-          entityId: '$_id.entityId',
-          entityType: '$_id.entityType',
-          attrName: '$_id.attrName',
-          origin: '$_id.origin',
-          resolution: '$_id.resolution'
+    if (shouldFilter) {
+        var pushAccumulator = {
+            offset: '$points.offset',
+            samples: '$points.samples',
         };
-        break;
-      case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-        groupId = {
-          attrName: '$_id.attrName',
-          origin: '$_id.origin',
-          resolution: '$_id.resolution'
-        };
-        break;
-      case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-        groupId = {
-          origin: '$_id.origin',
-          resolution: '$_id.resolution'
-        };
-        break;
-    }
+        pushAccumulator[aggregatedFunction] = '$points.' + aggregatedFunction;
 
-    collection.aggregate([
-      {
-        $match: matchCondition
-      },
-      {
-        $project: fieldFilter
-      },
-      {
-        $unwind: '$points'
-      },
-      {
-        $match: {
-          'points.samples': {
-            $gt: 0
-          }
+        var matchCondition;
+        switch (sthConfig.DATA_MODEL) {
+            case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                matchCondition = {
+                    '_id.entityId': entityId,
+                    '_id.entityType': entityType,
+                    '_id.attrName': attrName,
+                    '_id.resolution': resolution,
+                };
+                break;
+            case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                matchCondition = {
+                    '_id.attrName': attrName,
+                    '_id.resolution': resolution,
+                };
+                break;
+            case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                matchCondition = {
+                    '_id.resolution': resolution,
+                };
+                break;
         }
-      },
-      {
-        $group: {
-          _id: groupId,
-          points: {
-            $push: pushAccumulator
-          }
+        if (originFilter) {
+            matchCondition['_id.origin'] = originFilter;
         }
-      },
-      {
-        $sort: {
-          '_id.origin': 1
-        }
-      }
-    ], function (err, resultsArr) {
-      filterResults(
-        resultsArr,
-        {
-          resolution: resolution,
-          from: from,
-          to: to,
-          aggregatedFunction: aggregatedFunction,
-          shouldFilter: shouldFilter
-        }
-      );
-      process.nextTick(callback.bind(null, err, resultsArr));
-    });
-  } else {
-    // Get the aggregated data from the database
-    // Return the data in ascending order based on the origin
-    var findCondition;
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-        findCondition = {
-          '_id.entityId': entityId,
-          '_id.entityType': entityType,
-          '_id.attrName': attrName,
-          '_id.resolution': resolution
-        };
-        break;
-      case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-        findCondition = {
-          '_id.attrName': attrName,
-          '_id.resolution': resolution
-        };
-        break;
-      case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-        findCondition = {
-          '_id.resolution': resolution
-        };
-        break;
-    }
-    if (originFilter) {
-      findCondition['_id.origin'] = originFilter;
-    }
 
-    collection.find(
-      findCondition,
-      fieldFilter
-    ).sort({'_id.origin': 1}).toArray(
-      function (err, resultsArr) {
-        filterResults(
-          resultsArr,
-          {
-            resolution: resolution,
-            from: from,
-            to: to,
-            aggregatedFunction: aggregatedFunction,
-            shouldFilter: shouldFilter
-          }
+        var groupId;
+        switch (sthConfig.DATA_MODEL) {
+            case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                groupId = {
+                    entityId: '$_id.entityId',
+                    entityType: '$_id.entityType',
+                    attrName: '$_id.attrName',
+                    origin: '$_id.origin',
+                    resolution: '$_id.resolution',
+                };
+                break;
+            case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                groupId = {
+                    attrName: '$_id.attrName',
+                    origin: '$_id.origin',
+                    resolution: '$_id.resolution',
+                };
+                break;
+            case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                groupId = {
+                    origin: '$_id.origin',
+                    resolution: '$_id.resolution',
+                };
+                break;
+        }
+
+        collection.aggregate(
+            [
+                {
+                    $match: matchCondition,
+                },
+                {
+                    $project: fieldFilter,
+                },
+                {
+                    $unwind: '$points',
+                },
+                {
+                    $match: {
+                        'points.samples': {
+                            $gt: 0,
+                        },
+                    },
+                },
+                {
+                    $group: {
+                        _id: groupId,
+                        points: {
+                            $push: pushAccumulator,
+                        },
+                    },
+                },
+                {
+                    $sort: {
+                        '_id.origin': 1,
+                    },
+                },
+            ],
+            function(err, resultsArr) {
+                filterResults(resultsArr, {
+                    resolution: resolution,
+                    from: from,
+                    to: to,
+                    aggregatedFunction: aggregatedFunction,
+                    shouldFilter: shouldFilter,
+                });
+                process.nextTick(callback.bind(null, err, resultsArr));
+            }
         );
-        process.nextTick(callback.bind(null, err, resultsArr));
-      }
-    );
-  }
+    } else {
+        // Get the aggregated data from the database
+        // Return the data in ascending order based on the origin
+        var findCondition;
+        switch (sthConfig.DATA_MODEL) {
+            case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                findCondition = {
+                    '_id.entityId': entityId,
+                    '_id.entityType': entityType,
+                    '_id.attrName': attrName,
+                    '_id.resolution': resolution,
+                };
+                break;
+            case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                findCondition = {
+                    '_id.attrName': attrName,
+                    '_id.resolution': resolution,
+                };
+                break;
+            case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                findCondition = {
+                    '_id.resolution': resolution,
+                };
+                break;
+        }
+        if (originFilter) {
+            findCondition['_id.origin'] = originFilter;
+        }
+
+        collection
+            .find(findCondition, fieldFilter)
+            .sort({ '_id.origin': 1 })
+            .toArray(function(err, resultsArr) {
+                filterResults(resultsArr, {
+                    resolution: resolution,
+                    from: from,
+                    to: to,
+                    aggregatedFunction: aggregatedFunction,
+                    shouldFilter: shouldFilter,
+                });
+                process.nextTick(callback.bind(null, err, resultsArr));
+            });
+    }
 }
 
 /**
@@ -905,43 +892,43 @@ function getAggregatedData(data, callback) {
  * @returns {Object} The update condition
  */
 function getAggregateUpdateCondition(data) {
-  var entityId = data.entityId,
-    entityType = data.entityType,
-    attrName = data.attrName,
-    resolution = data.resolution,
-    timestamp = data.timestamp;
+    var entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attrName,
+        resolution = data.resolution,
+        timestamp = data.timestamp;
 
-  var offset = sthUtils.getOffset(resolution, timestamp);
+    var offset = sthUtils.getOffset(resolution, timestamp);
 
-  var aggregateUpdateCondition;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      aggregateUpdateCondition = {
-        '_id.entityId': entityId,
-        '_id.entityType': entityType,
-        '_id.attrName': attrName,
-        '_id.origin': sthUtils.getOrigin(timestamp, resolution),
-        '_id.resolution': resolution,
-        'points.offset': offset
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      aggregateUpdateCondition = {
-        '_id.attrName': attrName,
-        '_id.origin': sthUtils.getOrigin(timestamp, resolution),
-        '_id.resolution': resolution,
-        'points.offset': offset
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      aggregateUpdateCondition = {
-        '_id.origin': sthUtils.getOrigin(timestamp, resolution),
-        '_id.resolution': resolution,
-        'points.offset': offset
-      };
-      break;
-  }
-  return aggregateUpdateCondition;
+    var aggregateUpdateCondition;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            aggregateUpdateCondition = {
+                '_id.entityId': entityId,
+                '_id.entityType': entityType,
+                '_id.attrName': attrName,
+                '_id.origin': sthUtils.getOrigin(timestamp, resolution),
+                '_id.resolution': resolution,
+                'points.offset': offset,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            aggregateUpdateCondition = {
+                '_id.attrName': attrName,
+                '_id.origin': sthUtils.getOrigin(timestamp, resolution),
+                '_id.resolution': resolution,
+                'points.offset': offset,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            aggregateUpdateCondition = {
+                '_id.origin': sthUtils.getOrigin(timestamp, resolution),
+                '_id.resolution': resolution,
+                'points.offset': offset,
+            };
+            break;
+    }
+    return aggregateUpdateCondition;
 }
 
 /**
@@ -951,53 +938,53 @@ function getAggregateUpdateCondition(data) {
  * @param {string} resolution The resolution
  */
 function getAggregatePrepopulatedData(attrType, attrValue, resolution) {
-  var points = [],
-    totalValues,
-    offsetOrigin = 0;
+    var points = [],
+        totalValues,
+        offsetOrigin = 0;
 
-  switch (resolution) {
-    case sthConfig.RESOLUTION.SECOND:
-      totalValues = 60;
-      break;
-    case sthConfig.RESOLUTION.MINUTE:
-      totalValues = 60;
-      break;
-    case sthConfig.RESOLUTION.HOUR:
-      totalValues = 24;
-      break;
-    case sthConfig.RESOLUTION.DAY:
-      offsetOrigin = 1;
-      totalValues = 32;
-      break;
-    case sthConfig.RESOLUTION.MONTH:
-      offsetOrigin = 1;
-      totalValues = 13;
-      break;
-  }
-
-  if (sthUtils.getAggregationType(attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
-    for (var i = offsetOrigin; i < totalValues; i++) {
-      points.push({
-        offset: i,
-        samples: 0,
-        sum: 0,
-        sum2: 0,
-        min: Number.POSITIVE_INFINITY,
-        max: Number.NEGATIVE_INFINITY
-      });
+    switch (resolution) {
+        case sthConfig.RESOLUTION.SECOND:
+            totalValues = 60;
+            break;
+        case sthConfig.RESOLUTION.MINUTE:
+            totalValues = 60;
+            break;
+        case sthConfig.RESOLUTION.HOUR:
+            totalValues = 24;
+            break;
+        case sthConfig.RESOLUTION.DAY:
+            offsetOrigin = 1;
+            totalValues = 32;
+            break;
+        case sthConfig.RESOLUTION.MONTH:
+            offsetOrigin = 1;
+            totalValues = 13;
+            break;
     }
-  } else {
-    for (var j = offsetOrigin; j < totalValues; j++) {
-      var entry = {
-        offset: j,
-        samples: 0,
-        occur: {}
-      };
-      points.push(entry);
-    }
-  }
 
-  return points;
+    if (sthUtils.getAggregationType(attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
+        for (var i = offsetOrigin; i < totalValues; i++) {
+            points.push({
+                offset: i,
+                samples: 0,
+                sum: 0,
+                sum2: 0,
+                min: Number.POSITIVE_INFINITY,
+                max: Number.NEGATIVE_INFINITY,
+            });
+        }
+    } else {
+        for (var j = offsetOrigin; j < totalValues; j++) {
+            var entry = {
+                offset: j,
+                samples: 0,
+                occur: {},
+            };
+            points.push(entry);
+        }
+    }
+
+    return points;
 }
 
 /**
@@ -1008,12 +995,12 @@ function getAggregatePrepopulatedData(attrType, attrValue, resolution) {
  * @returns {Object} The update operation
  */
 function getAggregateUpdate4Insert(attrType, attrValue, resolution) {
-  return {
-    '$setOnInsert': {
-      attrType: attrType,
-      points: getAggregatePrepopulatedData(attrType, attrValue, resolution)
-    }
-  };
+    return {
+        $setOnInsert: {
+            attrType: attrType,
+            points: getAggregatePrepopulatedData(attrType, attrValue, resolution),
+        },
+    };
 }
 
 /**
@@ -1025,43 +1012,44 @@ function getAggregateUpdate4Insert(attrType, attrValue, resolution) {
  * @returns {Object} The update operation
  */
 function getAggregateUpdate4Update(attrType, attrValue, resolution, recvTime) {
-  var aggregateUpdate4Update,
-    attrValueAsNumber,
-    escapedAttrValue;
-  if (sthUtils.getAggregationType(attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
-    attrValueAsNumber = parseFloat(attrValue);
-    aggregateUpdate4Update = {
-      '$set': {
-        'attrType': attrType
-      },
-      '$inc': {
-        'points.$.samples': 1,
-        'points.$.sum': attrValueAsNumber,
-        'points.$.sum2': Math.pow(attrValueAsNumber, 2)
-      },
-      '$min': {
-        'points.$.min': attrValueAsNumber
-      },
-      '$max': {
-        'points.$.max': attrValueAsNumber
-      }
-    };
-  } else {
-    var offset = sthUtils.getOffset(resolution, recvTime);
-    aggregateUpdate4Update = {
-      '$set': {
-        'attrType': attrType
-      },
-      '$inc': {
-        'points.$.samples': 1
-      }
-    };
-    escapedAttrValue = attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
-    aggregateUpdate4Update.$inc['points.' +
-    (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
-    '.occur.' + escapedAttrValue] = 1;
-  }
-  return aggregateUpdate4Update;
+    var aggregateUpdate4Update, attrValueAsNumber, escapedAttrValue;
+    if (sthUtils.getAggregationType(attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
+        attrValueAsNumber = parseFloat(attrValue);
+        aggregateUpdate4Update = {
+            $set: {
+                attrType: attrType,
+            },
+            $inc: {
+                'points.$.samples': 1,
+                'points.$.sum': attrValueAsNumber,
+                'points.$.sum2': Math.pow(attrValueAsNumber, 2),
+            },
+            $min: {
+                'points.$.min': attrValueAsNumber,
+            },
+            $max: {
+                'points.$.max': attrValueAsNumber,
+            },
+        };
+    } else {
+        var offset = sthUtils.getOffset(resolution, recvTime);
+        aggregateUpdate4Update = {
+            $set: {
+                attrType: attrType,
+            },
+            $inc: {
+                'points.$.samples': 1,
+            },
+        };
+        escapedAttrValue = attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
+        aggregateUpdate4Update.$inc[
+            'points.' +
+                (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
+                '.occur.' +
+                escapedAttrValue
+        ] = 1;
+    }
+    return aggregateUpdate4Update;
 }
 
 /**
@@ -1075,46 +1063,51 @@ function getAggregateUpdate4Update(attrType, attrValue, resolution, recvTime) {
  * @returns {Object} The update operation
  */
 function getAggregateUpdate4Removal(data) {
-  var attrType = data.attrType,
-      attrValue = data.attrValue,
-      notificationInfo = data.notificationInfo,
-      resolution = data.resolution,
-      timestamp = data.timestamp;
-  var aggregateUpdate4Removal,
-    escapedAttrValue = parseFloat(notificationInfo.updates.attrValue);
-  if (sthUtils.getAggregationType(notificationInfo.updates.attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
-    aggregateUpdate4Removal = {
-      '$inc': {
-        'points.$.samples': -1,
-        'points.$.sum': -escapedAttrValue,
-        'points.$.sum2': -Math.pow(escapedAttrValue, 2)
-      },
-      '$set': {
-        'attrType': attrType,
-        'points.$.min': (notificationInfo.newMinValues && notificationInfo.newMinValues[resolution]) ?
-          Math.min(parseFloat(notificationInfo.newMinValues[resolution]), parseFloat(attrValue)) :
-          parseFloat(attrValue),
-        'points.$.max': (notificationInfo.newMaxValues && notificationInfo.newMaxValues[resolution]) ?
-          Math.max(parseFloat(notificationInfo.newMaxValues[resolution]), parseFloat(attrValue)) :
-          parseFloat(attrValue)
-      }
-    };
-  } else {
-    var offset = sthUtils.getOffset(resolution, timestamp);
-    aggregateUpdate4Removal = {
-      '$set': {
-        'attrType': attrType
-      },
-      '$inc': {
-        'points.$.samples': -1
-      }
-    };
-    escapedAttrValue = notificationInfo.updates.attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
-    aggregateUpdate4Removal.$inc['points.' +
-      (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
-      '.occur.' + escapedAttrValue] = -1;
-  }
-  return aggregateUpdate4Removal;
+    var attrType = data.attrType,
+        attrValue = data.attrValue,
+        notificationInfo = data.notificationInfo,
+        resolution = data.resolution,
+        timestamp = data.timestamp;
+    var aggregateUpdate4Removal,
+        escapedAttrValue = parseFloat(notificationInfo.updates.attrValue);
+    if (sthUtils.getAggregationType(notificationInfo.updates.attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
+        aggregateUpdate4Removal = {
+            $inc: {
+                'points.$.samples': -1,
+                'points.$.sum': -escapedAttrValue,
+                'points.$.sum2': -Math.pow(escapedAttrValue, 2),
+            },
+            $set: {
+                attrType: attrType,
+                'points.$.min':
+                    notificationInfo.newMinValues && notificationInfo.newMinValues[resolution]
+                        ? Math.min(parseFloat(notificationInfo.newMinValues[resolution]), parseFloat(attrValue))
+                        : parseFloat(attrValue),
+                'points.$.max':
+                    notificationInfo.newMaxValues && notificationInfo.newMaxValues[resolution]
+                        ? Math.max(parseFloat(notificationInfo.newMaxValues[resolution]), parseFloat(attrValue))
+                        : parseFloat(attrValue),
+            },
+        };
+    } else {
+        var offset = sthUtils.getOffset(resolution, timestamp);
+        aggregateUpdate4Removal = {
+            $set: {
+                attrType: attrType,
+            },
+            $inc: {
+                'points.$.samples': -1,
+            },
+        };
+        escapedAttrValue = notificationInfo.updates.attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
+        aggregateUpdate4Removal.$inc[
+            'points.' +
+                (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
+                '.occur.' +
+                escapedAttrValue
+        ] = -1;
+    }
+    return aggregateUpdate4Removal;
 }
 
 /**
@@ -1132,39 +1125,39 @@ function getAggregateUpdate4Removal(data) {
  * @param {Function} callback Function to call once the operation completes
  */
 function removePreviouslyAggregatedData(data, callback) {
-  // Undo the previously aggregated data if any
-  if (data.notificationInfo.updates) {
-    data.collection.update(
-      getAggregateUpdateCondition(
-        {
-          entityId: data.entityId,
-          entityType: data.entityType,
-          attrName: data.attrName,
-          resolution: data.resolution,
-          timestamp: data.timestamp
-        }
-      ),
-      getAggregateUpdate4Removal({
-        attrType: data.attrType,
-        attrValue: data.attrValue,
-        notificationInfo: data.notificationInfo,
-        resolution: data.resolution,
-        timestamp: data.timestamp
-      }),
-      {
-        writeConcern: {
-          w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-        }
-      },
-      function (err) {
-        if (callback) {
-          process.nextTick(callback.bind(null, err));
-        }
-      }
-    );
-  } else {
-    return process.nextTick(callback);
-  }
+    // Undo the previously aggregated data if any
+    if (data.notificationInfo.updates) {
+        data.collection.update(
+            getAggregateUpdateCondition({
+                entityId: data.entityId,
+                entityType: data.entityType,
+                attrName: data.attrName,
+                resolution: data.resolution,
+                timestamp: data.timestamp,
+            }),
+            getAggregateUpdate4Removal({
+                attrType: data.attrType,
+                attrValue: data.attrValue,
+                notificationInfo: data.notificationInfo,
+                resolution: data.resolution,
+                timestamp: data.timestamp,
+            }),
+            {
+                writeConcern: {
+                    w: !isNaN(sthConfig.WRITE_CONCERN)
+                        ? parseInt(sthConfig.WRITE_CONCERN, 10)
+                        : sthConfig.WRITE_CONCERN,
+                },
+            },
+            function(err) {
+                if (callback) {
+                    process.nextTick(callback.bind(null, err));
+                }
+            }
+        );
+    } else {
+        return process.nextTick(callback);
+    }
 }
 
 /**
@@ -1182,29 +1175,27 @@ function removePreviouslyAggregatedData(data, callback) {
  * @param {Function} callback Function to call once the operation completes
  */
 function updateAggregatedData(data, callback) {
-  data.collection.update(
-    getAggregateUpdateCondition(
-      {
-        entityId: data.entityId,
-        entityType: data.entityType,
-        attrName: data.attrName,
-        resolution: data.resolution,
-        timestamp: data.timestamp
-      }
-    ),
-    getAggregateUpdate4Update(data.attrType, data.attrValue, data.resolution, data.timestamp),
-    {
-      writeConcern: {
-        w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-      }
-    },
-    function (err) {
-      if (err && callback) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      removePreviouslyAggregatedData(data, callback);
-    }
-  );
+    data.collection.update(
+        getAggregateUpdateCondition({
+            entityId: data.entityId,
+            entityType: data.entityType,
+            attrName: data.attrName,
+            resolution: data.resolution,
+            timestamp: data.timestamp,
+        }),
+        getAggregateUpdate4Update(data.attrType, data.attrValue, data.resolution, data.timestamp),
+        {
+            writeConcern: {
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
+            },
+        },
+        function(err) {
+            if (err && callback) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            removePreviouslyAggregatedData(data, callback);
+        }
+    );
 }
 
 /**
@@ -1222,16 +1213,16 @@ function updateAggregatedData(data, callback) {
  * @param {Function} callback Function to call once the operation completes
  */
 function storeAggregatedData4Resolution(data, callback) {
-  var collection = data.collection,
-    entityId = data.entityId,
-    entityType = data.entityType,
-    attrName = data.attrName,
-    attrType = data.attrType,
-    attrValue = data.attrValue,
-    resolution = data.resolution,
-    timestamp = data.timestamp;
+    var collection = data.collection,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attrName,
+        attrType = data.attrType,
+        attrValue = data.attrValue,
+        resolution = data.resolution,
+        timestamp = data.timestamp;
 
-  /*
+    /*
    Currently the MongoDB $ positional update operator cannot be combined with upserts
      (see http://docs.mongodb.org/manual/reference/operator/update/positional/#upsert).
    This issue is known and currently under study: https://jira.mongodb.org/browse/SERVER-3326
@@ -1254,33 +1245,31 @@ function storeAggregatedData4Resolution(data, callback) {
      );
   */
 
-  // Prepopulate the aggregated data collection if there is no entry for the concrete
-  //  origin and resolution.
-  collection.update(
-    getAggregateUpdateCondition(
-      {
-        entityId: entityId,
-        entityType: entityType,
-        attrName: attrName,
-        resolution: resolution,
-        timestamp: timestamp
-      }
-    ),
-    getAggregateUpdate4Insert(attrType, attrValue, resolution),
-    {
-      upsert: true,
-      writeConcern: {
-        w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-      }
-    },
-    function (err) {
-      if (err && callback) {
-        return process.nextTick(callback.bind(null, err));
-      } else {
-        updateAggregatedData(data, callback);
-      }
-    }
-  );
+    // Prepopulate the aggregated data collection if there is no entry for the concrete
+    //  origin and resolution.
+    collection.update(
+        getAggregateUpdateCondition({
+            entityId: entityId,
+            entityType: entityType,
+            attrName: attrName,
+            resolution: resolution,
+            timestamp: timestamp,
+        }),
+        getAggregateUpdate4Insert(attrType, attrValue, resolution),
+        {
+            upsert: true,
+            writeConcern: {
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
+            },
+        },
+        function(err) {
+            if (err && callback) {
+                return process.nextTick(callback.bind(null, err));
+            } else {
+                updateAggregatedData(data, callback);
+            }
+        }
+    );
 }
 
 /**
@@ -1294,42 +1283,41 @@ function storeAggregatedData4Resolution(data, callback) {
  * @param {Function} callback Function to call once the operation completes
  */
 function storeAggregatedData(data, callback) {
-  var counter = 0,
-    error;
+    var counter = 0,
+        error;
 
-  var collection = data.collection,
-    recvTime = data.recvTime,
-    entityId = data.entityId,
-    entityType = data.entityType,
-    attribute = data.attribute,
-    notificationInfo = data.notificationInfo;
+    var collection = data.collection,
+        recvTime = data.recvTime,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attribute = data.attribute,
+        notificationInfo = data.notificationInfo;
 
-
-  function onCompletion(err) {
-    error = error || err;
-    if (++counter === sthConfig.AGGREGATION_BY.length) {
-      callback(error);
+    function onCompletion(err) {
+        error = error || err;
+        if (++counter === sthConfig.AGGREGATION_BY.length) {
+            callback(error);
+        }
     }
-  }
 
-  var timestamp = sthUtils.getAttributeTimestamp(attribute, recvTime);
+    var timestamp = sthUtils.getAttributeTimestamp(attribute, recvTime);
 
-  sthConfig.AGGREGATION_BY.forEach(function (entry) {
-    storeAggregatedData4Resolution(
-      {
-        collection: collection,
-        entityId: entityId,
-        entityType: entityType,
-        attrName: attribute.name,
-        attrType: attribute.type,
-        attrValue: attribute.value,
-        resolution: entry,
-        timestamp: timestamp,
-        notificationInfo: notificationInfo
-      },
-      onCompletion
-    );
-  });
+    sthConfig.AGGREGATION_BY.forEach(function(entry) {
+        storeAggregatedData4Resolution(
+            {
+                collection: collection,
+                entityId: entityId,
+                entityType: entityType,
+                attrName: attribute.name,
+                attrType: attribute.type,
+                attrValue: attribute.value,
+                resolution: entry,
+                timestamp: timestamp,
+                notificationInfo: notificationInfo,
+            },
+            onCompletion
+        );
+    });
 }
 
 /**
@@ -1340,20 +1328,20 @@ function storeAggregatedData(data, callback) {
  * @param callback The callback to notify once the processing completes
  */
 function updateRawData(collection, oldRawData, newRawData, callback) {
-  collection.update(
-    oldRawData,
-    newRawData,
-    {
-      writeConcern: {
-        w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-      }
-    },
-    function (err) {
-      if (callback) {
-        process.nextTick(callback.bind(null, err));
-      }
-    }
-  );
+    collection.update(
+        oldRawData,
+        newRawData,
+        {
+            writeConcern: {
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
+            },
+        },
+        function(err) {
+            if (callback) {
+                process.nextTick(callback.bind(null, err));
+            }
+        }
+    );
 }
 
 /**
@@ -1363,19 +1351,19 @@ function updateRawData(collection, oldRawData, newRawData, callback) {
  * @param callback The callback to notify once the processing completes
  */
 function insertRawData(collection, newRawData, callback) {
-  collection.insert(
-    newRawData,
-    {
-      writeConcern: {
-        w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
-      }
-    },
-    function (err) {
-      if (callback) {
-        process.nextTick(callback.bind(null, err));
-      }
-    }
-  );
+    collection.insert(
+        newRawData,
+        {
+            writeConcern: {
+                w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN,
+            },
+        },
+        function(err) {
+            if (callback) {
+                process.nextTick(callback.bind(null, err));
+            }
+        }
+    );
 }
 
 /**
@@ -1391,50 +1379,50 @@ function insertRawData(collection, newRawData, callback) {
  * @param {Function} callback Function to call once the operation completes
  */
 function storeRawData(data, callback) {
-  var collection = data.collection,
-      recvTime = data.recvTime,
-      entityId = data.entityId,
-      entityType = data.entityType,
-      attribute = data.attribute,
-      notificationInfo = data.notificationInfo;
+    var collection = data.collection,
+        recvTime = data.recvTime,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attribute = data.attribute,
+        notificationInfo = data.notificationInfo;
 
-  var timestamp = sthUtils.getAttributeTimestamp(attribute, recvTime);
+    var timestamp = sthUtils.getAttributeTimestamp(attribute, recvTime);
 
-  var newRawData;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      newRawData = {
-        recvTime: timestamp,
-        entityId: entityId,
-        entityType: entityType,
-        attrName: attribute.name,
-        attrType: attribute.type,
-        attrValue: attribute.value
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      newRawData = {
-        recvTime: timestamp,
-        attrName: attribute.name,
-        attrType: attribute.type,
-        attrValue: attribute.value
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      newRawData = {
-        recvTime: timestamp,
-        attrType: attribute.type,
-        attrValue: attribute.value
-      };
-      break;
-  }
+    var newRawData;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            newRawData = {
+                recvTime: timestamp,
+                entityId: entityId,
+                entityType: entityType,
+                attrName: attribute.name,
+                attrType: attribute.type,
+                attrValue: attribute.value,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            newRawData = {
+                recvTime: timestamp,
+                attrName: attribute.name,
+                attrType: attribute.type,
+                attrValue: attribute.value,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            newRawData = {
+                recvTime: timestamp,
+                attrType: attribute.type,
+                attrValue: attribute.value,
+            };
+            break;
+    }
 
-  if (notificationInfo && notificationInfo.updates) {
-    // The raw data to store is a raw data update
-    updateRawData(collection, notificationInfo.updates, newRawData, callback);
-  } else {
-    insertRawData(collection, newRawData, callback);
-  }
+    if (notificationInfo && notificationInfo.updates) {
+        // The raw data to store is a raw data update
+        updateRawData(collection, notificationInfo.updates, newRawData, callback);
+    } else {
+        insertRawData(collection, newRawData, callback);
+    }
 }
 
 /**
@@ -1448,46 +1436,46 @@ function storeRawData(data, callback) {
  * @return {object} The find() condition to use to get the new minimum and maximum values after some raw data update
  */
 function getNewMinMaxCondition(data, resolution) {
-  var entityId = data.entityId,
-      entityType = data.entityType,
-      attrName = data.attribute.name,
-      timestamp = data.timestamp;
+    var entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attribute.name,
+        timestamp = data.timestamp;
 
-  var findCondition;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      findCondition = {
-        entityId: entityId,
-        entityType: entityType,
-        attrName: attrName,
-        recvTime: {
-          $gte: sthUtils.getOriginStart(timestamp, resolution),
-          $lte: sthUtils.getOriginEnd(timestamp, resolution),
-          $ne: timestamp
-        }
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      findCondition = {
-        attrName: attrName,
-        recvTime: {
-          $gte: sthUtils.getOriginStart(timestamp, resolution),
-          $lte: sthUtils.getOriginEnd(timestamp, resolution),
-          $ne: timestamp
-        }
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      findCondition = {
-        recvTime: {
-          $ne: timestamp,
-          $gte: sthUtils.getOriginStart(timestamp, resolution),
-          $lte: sthUtils.getOriginEnd(timestamp, resolution)
-        }
-      };
-      break;
-  }
-  return findCondition;
+    var findCondition;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            findCondition = {
+                entityId: entityId,
+                entityType: entityType,
+                attrName: attrName,
+                recvTime: {
+                    $gte: sthUtils.getOriginStart(timestamp, resolution),
+                    $lte: sthUtils.getOriginEnd(timestamp, resolution),
+                    $ne: timestamp,
+                },
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            findCondition = {
+                attrName: attrName,
+                recvTime: {
+                    $gte: sthUtils.getOriginStart(timestamp, resolution),
+                    $lte: sthUtils.getOriginEnd(timestamp, resolution),
+                    $ne: timestamp,
+                },
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            findCondition = {
+                recvTime: {
+                    $ne: timestamp,
+                    $gte: sthUtils.getOriginStart(timestamp, resolution),
+                    $lte: sthUtils.getOriginEnd(timestamp, resolution),
+                },
+            };
+            break;
+    }
+    return findCondition;
 }
 
 /**
@@ -1500,35 +1488,33 @@ function getNewMinMaxCondition(data, resolution) {
  * @param callback The callback to notify in case of error or once the new maximum value has been calculated
  */
 function getNewMaxValues(data, callback) {
-  function getNewMaxValue(data, resolution, callback) {
-    data.collection.find(
-      getNewMinMaxCondition(data, resolution)
-    ).sort(
-      {
-        attrValue: -1
-      }
-    ).toArray(
-      function (err, restArray) {
-        if (callback) {
-          return process.nextTick(
-            callback.bind(null, err, (restArray && restArray.length) ? restArray[0].attrValue : null));
-        }
-      }
-    );
-  }
-  var getNewMaxValue4Resolutions = {};
-  for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-    getNewMaxValue4Resolutions[sthConfig.AGGREGATION_BY[i]] =
-      getNewMaxValue.bind(null, data, sthConfig.AGGREGATION_BY[i]);
-  }
-  async.parallel(
-    getNewMaxValue4Resolutions,
-    function (err, result) {
-      if (callback) {
-        return process.nextTick(callback.bind(null, err, result));
-      }
+    function getNewMaxValue(data, resolution, callback) {
+        data.collection
+            .find(getNewMinMaxCondition(data, resolution))
+            .sort({
+                attrValue: -1,
+            })
+            .toArray(function(err, restArray) {
+                if (callback) {
+                    return process.nextTick(
+                        callback.bind(null, err, restArray && restArray.length ? restArray[0].attrValue : null)
+                    );
+                }
+            });
     }
-  );
+    var getNewMaxValue4Resolutions = {};
+    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+        getNewMaxValue4Resolutions[sthConfig.AGGREGATION_BY[i]] = getNewMaxValue.bind(
+            null,
+            data,
+            sthConfig.AGGREGATION_BY[i]
+        );
+    }
+    async.parallel(getNewMaxValue4Resolutions, function(err, result) {
+        if (callback) {
+            return process.nextTick(callback.bind(null, err, result));
+        }
+    });
 }
 
 /**
@@ -1541,35 +1527,33 @@ function getNewMaxValues(data, callback) {
  * @param callback The callback to notify in case of error or once the new maximum value has been calculated
  */
 function getNewMinValues(data, callback) {
-  function getNewMinValue(data, resolution, callback) {
-    data.collection.find(
-      getNewMinMaxCondition(data, resolution)
-    ).sort(
-      {
-        attrValue: -1
-      }
-    ).toArray(
-      function (err, restArray) {
-        if (callback) {
-          return process.nextTick(
-            callback.bind(null, err, (restArray && restArray.length) ? restArray[0].attrValue : null));
-        }
-      }
-    );
-  }
-  var getNewMinValue4Resolutions = {};
-  for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-    getNewMinValue4Resolutions[sthConfig.AGGREGATION_BY[i]] =
-      getNewMinValue.bind(null, data, sthConfig.AGGREGATION_BY[i]);
-  }
-  async.parallel(
-    getNewMinValue4Resolutions,
-    function (err, result) {
-      if (callback) {
-        return process.nextTick(callback.bind(null, err, result));
-      }
+    function getNewMinValue(data, resolution, callback) {
+        data.collection
+            .find(getNewMinMaxCondition(data, resolution))
+            .sort({
+                attrValue: -1,
+            })
+            .toArray(function(err, restArray) {
+                if (callback) {
+                    return process.nextTick(
+                        callback.bind(null, err, restArray && restArray.length ? restArray[0].attrValue : null)
+                    );
+                }
+            });
     }
-  );
+    var getNewMinValue4Resolutions = {};
+    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+        getNewMinValue4Resolutions[sthConfig.AGGREGATION_BY[i]] = getNewMinValue.bind(
+            null,
+            data,
+            sthConfig.AGGREGATION_BY[i]
+        );
+    }
+    async.parallel(getNewMinValue4Resolutions, function(err, result) {
+        if (callback) {
+            return process.nextTick(callback.bind(null, err, result));
+        }
+    });
 }
 
 /**
@@ -1585,38 +1569,42 @@ function getNewMinValues(data, callback) {
  * @param {Function} callback Function to call once the operation completes
  */
 function generateNotificationInfo(data, searchResult, callback) {
-  if (searchResult) {
-    if (_.isEqual(searchResult.attrValue, data.attribute.value)) {
-      // The notification is already registered
-      return process.nextTick(callback.bind(null, null, {exists: searchResult}));
+    if (searchResult) {
+        if (_.isEqual(searchResult.attrValue, data.attribute.value)) {
+            // The notification is already registered
+            return process.nextTick(callback.bind(null, null, { exists: searchResult }));
+        } else {
+            // The notification is an already existent data update
+            if (sthUtils.getAggregationType(searchResult.attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
+                getNewMaxValues(data, function(err, newMaxValues) {
+                    if (err && callback) {
+                        return process.nextTick(callback.bind(null, err, { updates: searchResult }));
+                    }
+                    if (newMaxValues) {
+                        getNewMinValues(data, function(err, newMinValues) {
+                            if (err && callback) {
+                                return process.nextTick(callback.bind(null, err, { updates: searchResult }));
+                            }
+                            return process.nextTick(
+                                callback.bind(null, err, {
+                                    updates: searchResult,
+                                    newMinValues: newMinValues,
+                                    newMaxValues: newMaxValues,
+                                })
+                            );
+                        });
+                    } else {
+                        return process.nextTick(callback.bind(null, err, { updates: searchResult }));
+                    }
+                });
+            } else {
+                return process.nextTick(callback.bind(null, null, { updates: searchResult }));
+            }
+        }
     } else {
-      // The notification is an already existent data update
-      if (sthUtils.getAggregationType(searchResult.attrValue) === sthConfig.AGGREGATIONS.NUMERIC) {
-        getNewMaxValues(data, function (err, newMaxValues) {
-          if (err && callback) {
-            return process.nextTick(callback.bind(null, err, {updates: searchResult}));
-          }
-          if (newMaxValues) {
-            getNewMinValues(data, function (err, newMinValues) {
-              if (err && callback) {
-                return process.nextTick(callback.bind(null, err, {updates: searchResult}));
-              }
-              return process.nextTick(
-                callback.bind(
-                  null, err, {updates: searchResult, newMinValues: newMinValues, newMaxValues: newMaxValues}));
-            });
-          } else {
-            return process.nextTick(callback.bind(null, err, {updates: searchResult}));
-          }
-        });
-      } else {
-        return process.nextTick(callback.bind(null, null, {updates: searchResult}));
-      }
+        // The notification is an new data insertion
+        return process.nextTick(callback.bind(null, null, { inserts: true }));
     }
-  } else {
-    // The notification is an new data insertion
-    return process.nextTick(callback.bind(null, null, {inserts: true}));
-  }
 }
 
 /**
@@ -1631,50 +1619,47 @@ function generateNotificationInfo(data, searchResult, callback) {
  * @param {Function} callback Function to call once the operation completes
  */
 function getNotificationInfo(data, callback) {
-  var collection = data.collection,
-    recvTime = data.recvTime,
-    entityId = data.entityId,
-    entityType = data.entityType,
-    attribute = data.attribute;
+    var collection = data.collection,
+        recvTime = data.recvTime,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attribute = data.attribute;
 
-  var timestamp = sthUtils.getAttributeTimestamp(attribute, recvTime);
-  data.timestamp = timestamp;
+    var timestamp = sthUtils.getAttributeTimestamp(attribute, recvTime);
+    data.timestamp = timestamp;
 
-  var findCondition;
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      findCondition = {
-        recvTime: timestamp,
-        entityId: entityId,
-        entityType: entityType,
-        attrName: attribute.name,
-        attrType: attribute.type
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      findCondition = {
-        recvTime: timestamp,
-        attrName: attribute.name,
-        attrType: attribute.type
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      findCondition = {
-        recvTime: timestamp,
-        attrType: attribute.type
-      };
-      break;
-  }
-
-  collection.findOne(
-    findCondition,
-    function (err, result) {
-      if (err && callback) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      generateNotificationInfo(data, result, callback);
+    var findCondition;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            findCondition = {
+                recvTime: timestamp,
+                entityId: entityId,
+                entityType: entityType,
+                attrName: attribute.name,
+                attrType: attribute.type,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            findCondition = {
+                recvTime: timestamp,
+                attrName: attribute.name,
+                attrType: attribute.type,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            findCondition = {
+                recvTime: timestamp,
+                attrType: attribute.type,
+            };
+            break;
     }
-  );
+
+    collection.findOne(findCondition, function(err, result) {
+        if (err && callback) {
+            return process.nextTick(callback.bind(null, err));
+        }
+        generateNotificationInfo(data, result, callback);
+    });
 }
 
 /**
@@ -1684,7 +1669,7 @@ function getNotificationInfo(data, callback) {
  * @param {function} callback The callback to call with error or the result of the operation
  */
 function dropCollection(collectionName, service, callback) {
-  db.db(sthDatabaseNaming.getDatabaseName(service)).dropCollection(collectionName, callback);
+    db.db(sthDatabaseNaming.getDatabaseName(service)).dropCollection(collectionName, callback);
 }
 
 /**
@@ -1702,45 +1687,45 @@ function dropCollection(collectionName, service, callback) {
  * @return {object} The find condition to apply for data removal
  */
 function getFindCondition4DataRemoval(data, options) {
-  var entityId = data.entityId,
-      entityType = data.entityType,
-      attrName = data.attrName,
-      isAggregated = options.isAggregated,
-      findCondition;
+    var entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attrName,
+        isAggregated = options.isAggregated,
+        findCondition;
 
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      if (isAggregated) {
-        findCondition = {
-          '_id.entityId': entityId,
-          '_id.entityType': entityType
-        };
-        if (attrName) {
-          findCondition['_id.attrName'] = attrName;
-        }
-      } else {
-        findCondition = {
-          entityId: entityId,
-          entityType: entityType
-        };
-        if (attrName) {
-          findCondition.attrName = attrName;
-        }
-      }
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      if (isAggregated) {
-        findCondition = {
-          '_id.attrName': attrName
-        };
-      } else {
-        findCondition = {
-          attrName: attrName
-        };
-      }
-      break;
-  }
-  return findCondition;
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            if (isAggregated) {
+                findCondition = {
+                    '_id.entityId': entityId,
+                    '_id.entityType': entityType,
+                };
+                if (attrName) {
+                    findCondition['_id.attrName'] = attrName;
+                }
+            } else {
+                findCondition = {
+                    entityId: entityId,
+                    entityType: entityType,
+                };
+                if (attrName) {
+                    findCondition.attrName = attrName;
+                }
+            }
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            if (isAggregated) {
+                findCondition = {
+                    '_id.attrName': attrName,
+                };
+            } else {
+                findCondition = {
+                    attrName: attrName,
+                };
+            }
+            break;
+    }
+    return findCondition;
 }
 
 /**
@@ -1758,42 +1743,44 @@ function getFindCondition4DataRemoval(data, options) {
  * @param callback The callback to call with possible errors and the result of the operation
  */
 function removeDataFromCollection(data, options, callback) {
-  var service = data.service,
-      servicePath = data.servicePath,
-      entityId = data.entityId,
-      entityType = data.entityType,
-      isAggregated = options.isAggregated;
+    var service = data.service,
+        servicePath = data.servicePath,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        isAggregated = options.isAggregated;
 
-  getCollection(
-    {
-      service: service,
-      servicePath: servicePath,
-      entityId: entityId,
-      entityType: entityType
-    },
-    {
-      isAggregated: isAggregated,
-      shouldCreate: false,
-      shouldTruncate: false
-    },
-    function (err, collection) {
-      if (err) {
-        if (callback) {
-          return process.nextTick(callback.bind(null, err));
-        }
-      } else {
-        collection.remove(
-          getFindCondition4DataRemoval(data, options),
-          {
-            writeConcern: {
-              w: !isNaN(sthConfig.WRITE_CONCERN) ? parseInt(sthConfig.WRITE_CONCERN, 10) : sthConfig.WRITE_CONCERN
+    getCollection(
+        {
+            service: service,
+            servicePath: servicePath,
+            entityId: entityId,
+            entityType: entityType,
+        },
+        {
+            isAggregated: isAggregated,
+            shouldCreate: false,
+            shouldTruncate: false,
+        },
+        function(err, collection) {
+            if (err) {
+                if (callback) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+            } else {
+                collection.remove(
+                    getFindCondition4DataRemoval(data, options),
+                    {
+                        writeConcern: {
+                            w: !isNaN(sthConfig.WRITE_CONCERN)
+                                ? parseInt(sthConfig.WRITE_CONCERN, 10)
+                                : sthConfig.WRITE_CONCERN,
+                        },
+                    },
+                    callback
+                );
             }
-          },
-          callback
-        );
-      }
-    }
-  );
+        }
+    );
 }
 
 /**
@@ -1812,49 +1799,52 @@ function removeDataFromCollection(data, options, callback) {
  * @param callback The callback to call with possible errors and the result of the operation
  */
 function dropCollectionsFromList(collections, data, options, callback) {
-  var service = data.service,
-      servicePath = data.servicePath,
-      entityId = data.entityId,
-      entityType = data.entityType,
-      attrName = data.attrName,
-      isAggregated = options.isAggregated,
-      collectionNameOptions = {
-        service: service,
-        servicePath: servicePath,
-        entityId: entityId,
-        entityType: entityType,
-        attrName: attrName
-      };
+    var service = data.service,
+        servicePath = data.servicePath,
+        entityId = data.entityId,
+        entityType = data.entityType,
+        attrName = data.attrName,
+        isAggregated = options.isAggregated,
+        collectionNameOptions = {
+            service: service,
+            servicePath: servicePath,
+            entityId: entityId,
+            entityType: entityType,
+            attrName: attrName,
+        };
 
-  var collectionName = isAggregated ?
-    sthDatabaseNaming.getAggregatedCollectionName(collectionNameOptions) :
-    sthDatabaseNaming.getRawCollectionName(collectionNameOptions);
+    var collectionName = isAggregated
+        ? sthDatabaseNaming.getAggregatedCollectionName(collectionNameOptions)
+        : sthDatabaseNaming.getRawCollectionName(collectionNameOptions);
 
-  var dropCollectionFunctions = [];
-  collections.forEach(function (collection) {
-    if (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH ||
-      (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && entityId) ||
-      (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && attrName)) {
-      if (collection.collectionName === collectionName) {
-        dropCollectionFunctions.push(async.apply(dropCollection, collection.collectionName, service));
-      }
-    } else if (isAggregated) {
-      if (collection.collectionName.indexOf('.aggr') >= 0 &&
-        collection.collectionName.indexOf(collectionName.slice(0, collectionName.indexOf('undefined'))) >= 0) {
-        dropCollectionFunctions.push(async.apply(dropCollection, collection.collectionName, service));
-      }
-    } else {
-      if (collection.collectionName.indexOf('.aggr') < 0 &&
-        collection.collectionName.indexOf(collectionName.slice(0, collectionName.indexOf('undefined'))) >= 0) {
-        dropCollectionFunctions.push(async.apply(dropCollection, collection.collectionName, service));
-      }
-    }
-  });
+    var dropCollectionFunctions = [];
+    collections.forEach(function(collection) {
+        if (
+            sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH ||
+            (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && entityId) ||
+            (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && attrName)
+        ) {
+            if (collection.collectionName === collectionName) {
+                dropCollectionFunctions.push(async.apply(dropCollection, collection.collectionName, service));
+            }
+        } else if (isAggregated) {
+            if (
+                collection.collectionName.indexOf('.aggr') >= 0 &&
+                collection.collectionName.indexOf(collectionName.slice(0, collectionName.indexOf('undefined'))) >= 0
+            ) {
+                dropCollectionFunctions.push(async.apply(dropCollection, collection.collectionName, service));
+            }
+        } else {
+            if (
+                collection.collectionName.indexOf('.aggr') < 0 &&
+                collection.collectionName.indexOf(collectionName.slice(0, collectionName.indexOf('undefined'))) >= 0
+            ) {
+                dropCollectionFunctions.push(async.apply(dropCollection, collection.collectionName, service));
+            }
+        }
+    });
 
-  async.parallel(
-    dropCollectionFunctions,
-    callback
-  );
+    async.parallel(dropCollectionFunctions, callback);
 }
 
 /**
@@ -1872,19 +1862,19 @@ function dropCollectionsFromList(collections, data, options, callback) {
  * @param callback The callback to call with possible errors and the result of the operation
  */
 function removeDataDroppingCollections(data, options, callback) {
-  var service = data.service,
-      databaseName = sthDatabaseNaming.getDatabaseName(service),
-      database = db.db(databaseName);
+    var service = data.service,
+        databaseName = sthDatabaseNaming.getDatabaseName(service),
+        database = db.db(databaseName);
 
-  database.collections(function (err, collections) {
-    if (err) {
-      if (callback) {
-        return process.nextTick(callback.bind(null, err));
-      }
-    } else {
-      dropCollectionsFromList(collections, data, options, callback);
-    }
-  });
+    database.collections(function(err, collections) {
+        if (err) {
+            if (callback) {
+                return process.nextTick(callback.bind(null, err));
+            }
+        } else {
+            dropCollectionsFromList(collections, data, options, callback);
+        }
+    });
 }
 
 /**
@@ -1899,13 +1889,15 @@ function removeDataDroppingCollections(data, options, callback) {
  * @param callback The callback to call with error or the result of the operation
  */
 function removeRawData(data, callback) {
-  if ((sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH &&
-    (data.entityId || data.attrName)) ||
-    (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && data.attrName)) {
-    removeDataFromCollection(data, {isAggregated: false}, callback);
-  } else {
-    removeDataDroppingCollections(data, {isAggregated: false}, callback);
-  }
+    if (
+        (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH &&
+            (data.entityId || data.attrName)) ||
+        (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && data.attrName)
+    ) {
+        removeDataFromCollection(data, { isAggregated: false }, callback);
+    } else {
+        removeDataDroppingCollections(data, { isAggregated: false }, callback);
+    }
 }
 
 /**
@@ -1920,13 +1912,15 @@ function removeRawData(data, callback) {
  * @param callback The callback to call with error or the result of the operation
  */
 function removeAggregatedData(data, callback) {
-  if ((sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH &&
-    (data.entityId || data.attrName)) ||
-    (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && data.attrName)) {
-    removeDataFromCollection(data, {isAggregated: true}, callback);
-  } else {
-    removeDataDroppingCollections(data, {isAggregated: true}, callback);
-  }
+    if (
+        (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH &&
+            (data.entityId || data.attrName)) ||
+        (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY && data.attrName)
+    ) {
+        removeDataFromCollection(data, { isAggregated: true }, callback);
+    } else {
+        removeDataDroppingCollections(data, { isAggregated: true }, callback);
+    }
 }
 
 /**
@@ -1941,48 +1935,38 @@ function removeAggregatedData(data, callback) {
  * @param callback The callback to call with error or the result of the operation
  */
 function removeData(data, callback) {
-  var dataRemovalFunctions = [];
-  if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH) {
-    dataRemovalFunctions.push(
-      async.apply(removeRawData, data),
-      async.apply(removeAggregatedData, data)
-    );
-  } else if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_RAW) {
-    dataRemovalFunctions.push(
-      async.apply(removeRawData, data)
-    );
-  } else if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_AGGREGATED) {
-    dataRemovalFunctions.push(
-      async.apply(removeAggregatedData, data)
-    );
-  }
-  async.parallel(
-    dataRemovalFunctions,
-    callback
-  );
+    var dataRemovalFunctions = [];
+    if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH) {
+        dataRemovalFunctions.push(async.apply(removeRawData, data), async.apply(removeAggregatedData, data));
+    } else if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_RAW) {
+        dataRemovalFunctions.push(async.apply(removeRawData, data));
+    } else if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_AGGREGATED) {
+        dataRemovalFunctions.push(async.apply(removeAggregatedData, data));
+    }
+    async.parallel(dataRemovalFunctions, callback);
 }
 
 module.exports = {
-  get driver() {
-    return mongoClient;
-  },
-  get connectionURL() {
-    return connectionURL;
-  },
-  get connection() {
-    return db;
-  },
-  connect: connect,
-  closeConnection: closeConnection,
-  getCollection: getCollection,
-  getRawData: getRawData,
-  getAggregatedData: getAggregatedData,
-  getAggregateUpdateCondition: getAggregateUpdateCondition,
-  getAggregatePrepopulatedData: getAggregatePrepopulatedData,
-  storeAggregatedData: storeAggregatedData,
-  storeAggregatedData4Resolution: storeAggregatedData4Resolution,
-  storeRawData: storeRawData,
-  getNotificationInfo: getNotificationInfo,
-  removeData: removeData,
-  isAggregated: isAggregated
+    get driver() {
+        return mongoClient;
+    },
+    get connectionURL() {
+        return connectionURL;
+    },
+    get connection() {
+        return db;
+    },
+    connect: connect,
+    closeConnection: closeConnection,
+    getCollection: getCollection,
+    getRawData: getRawData,
+    getAggregatedData: getAggregatedData,
+    getAggregateUpdateCondition: getAggregateUpdateCondition,
+    getAggregatePrepopulatedData: getAggregatePrepopulatedData,
+    storeAggregatedData: storeAggregatedData,
+    storeAggregatedData4Resolution: storeAggregatedData4Resolution,
+    storeRawData: storeRawData,
+    getNotificationInfo: getNotificationInfo,
+    removeData: removeData,
+    isAggregated: isAggregated,
 };

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -217,12 +217,11 @@ function setTTLPolicy(collection) {
                     },
                     function(err) {
                         if (err) {
+                            // prettier-ignore
                             sthLogger.error(
-                                sthConfig.LOGGING_CONTEXT.DB_LOG,
-                                "Error when creating the index for TTL for collection '" +
-                                    collection.s.name +
-                                    "': " +
-                                    err
+                                sthConfig.LOGGING_CONTEXT.DB_LOG, 
+                                "Error when creating the index for TTL for collection '" + collection.s.name + "': " + 
+                                err
                             );
                         }
                     }
@@ -1038,12 +1037,10 @@ function getAggregateUpdate4Update(attrType, attrValue, resolution, recvTime) {
             }
         };
         escapedAttrValue = attrValue.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
-        aggregateUpdate4Update.$inc[
-            'points.' +
-                (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
-                '.occur.' +
-                escapedAttrValue
-        ] = 1;
+        // prettier-ignore
+        aggregateUpdate4Update.$inc[ 'points.' +
+            (offset - (resolution === 'day' || resolution === 'month' || resolution === 'year' ? 1 : 0)) +
+            '.occur.' + escapedAttrValue] = 1;
     }
     return aggregateUpdate4Update;
 }
@@ -1483,11 +1480,10 @@ function getNewMinMaxCondition(data, resolution) {
  */
 function getNewMaxValues(data, callback) {
     function getNewMaxValue(data, resolution, callback) {
+        // prettier-ignore
         data.collection
             .find(getNewMinMaxCondition(data, resolution))
-            .sort({
-                attrValue: -1
-            })
+            .sort({ attrValue: -1 })
             .toArray(function(err, restArray) {
                 if (callback) {
                     return process.nextTick(
@@ -1522,11 +1518,10 @@ function getNewMaxValues(data, callback) {
  */
 function getNewMinValues(data, callback) {
     function getNewMinValue(data, resolution, callback) {
+        // prettier-ignore
         data.collection
             .find(getNewMinMaxCondition(data, resolution))
-            .sort({
-                attrValue: -1
-            })
+            .sort({ attrValue: -1 })
             .toArray(function(err, restArray) {
                 if (callback) {
                     return process.nextTick(

--- a/lib/errors/sthErrors.js
+++ b/lib/errors/sthErrors.js
@@ -30,5 +30,5 @@ function MandatoryOptionNotFound(message) {
 MandatoryOptionNotFound.prototype = Object.create(Error.prototype);
 
 module.exports = {
-    MandatoryOptionNotFound: MandatoryOptionNotFound,
+    MandatoryOptionNotFound: MandatoryOptionNotFound
 };

--- a/lib/errors/sthErrors.js
+++ b/lib/errors/sthErrors.js
@@ -24,11 +24,11 @@
 'use strict';
 
 function MandatoryOptionNotFound(message) {
-  Error.call(this, message);
-  this.code = 'MANDATORY_OPTION_NOT_FOUND';
+    Error.call(this, message);
+    this.code = 'MANDATORY_OPTION_NOT_FOUND';
 }
 MandatoryOptionNotFound.prototype = Object.create(Error.prototype);
 
 module.exports = {
-  MandatoryOptionNotFound: MandatoryOptionNotFound
+    MandatoryOptionNotFound: MandatoryOptionNotFound,
 };

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -50,12 +50,12 @@ function getRawData(request, reply) {
             servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
             entityId: request.params.entityId,
             entityType: request.params.entityType,
-            attrName: request.params.attrName,
+            attrName: request.params.attrName
         },
         {
             isAggregated: false,
             shouldCreate: false,
-            shouldTruncate: false,
+            shouldTruncate: false
         },
         function(err, collection) {
             if (err) {
@@ -93,7 +93,7 @@ function getRawData(request, reply) {
                         hOffset: request.query.hOffset,
                         from: request.query.dateFrom,
                         to: request.query.dateTo,
-                        filetype: request.query.filetype,
+                        filetype: request.query.filetype
                     },
                     function(err, result, totalCount) {
                         if (err) {
@@ -189,12 +189,12 @@ function getAggregatedData(request, reply) {
             servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
             entityId: request.params.entityId,
             entityType: request.params.entityType,
-            attrName: request.params.attrName,
+            attrName: request.params.attrName
         },
         {
             isAggregated: true,
             shouldCreate: false,
-            shouldTruncate: false,
+            shouldTruncate: false
         },
         function(err, collection) {
             if (err) {
@@ -230,7 +230,7 @@ function getAggregatedData(request, reply) {
                         resolution: request.query.aggrPeriod,
                         from: request.query.dateFrom,
                         to: request.query.dateTo,
-                        shouldFilter: sthConfig.FILTER_OUT_EMPTY,
+                        shouldFilter: sthConfig.FILTER_OUT_EMPTY
                     },
                     function(err, result) {
                         if (err) {
@@ -311,7 +311,7 @@ function getDataHandler(request, reply) {
                 error = boom.badRequest(message);
                 error.output.payload.validation = {
                     source: 'query',
-                    keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod', 'count'],
+                    keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod', 'count']
                 };
                 return reply(error);
             }
@@ -331,7 +331,7 @@ function getDataHandler(request, reply) {
         error = boom.badRequest(message);
         error.output.payload.validation = {
             source: 'query',
-            keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod', 'count'],
+            keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod', 'count']
         };
         return reply(error);
     }

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -40,163 +40,137 @@ var encodeRFC5987 = require('rfc5987-value-chars').encode;
  * @param {Function} reply   Hapi's reply function
  */
 function getRawData(request, reply) {
-  var response;
+    var response;
 
-  sthLogger.debug(
-    request.sth.context,
-    'Getting access to the raw data collection for retrieval...'
-  );
+    sthLogger.debug(request.sth.context, 'Getting access to the raw data collection for retrieval...');
 
-  sthDatabase.getCollection(
-    {
-      service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
-      servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
-      entityId: request.params.entityId,
-      entityType: request.params.entityType,
-      attrName: request.params.attrName
-    },
-    {
-      isAggregated: false,
-      shouldCreate: false,
-      shouldTruncate: false
-    },
-    function (err, collection) {
-      if (err) {
-        // The collection does not exist, reply with en empty response
-        sthLogger.warn(
-          request.sth.context,
-          'Error when getting the raw data collection for retrieval (the collection \'%s\' may not exist)',
-          collection
-        );
-
-        sthLogger.debug(
-          request.sth.context,
-          'Responding with no points'
-        );
-        var emptyResponse = sthServerUtils.getEmptyResponse();
-        var ngsiPayload = sthServerUtils.getNGSIPayload(
-          request.params.entityId,
-          request.params.entityType,
-          request.params.attrName,
-          emptyResponse);
-        response = reply(ngsiPayload);
-        sthServerUtils.addFiwareCorrelator(request, response);
-        if (request.query.count) {
-          sthServerUtils.addFiwareTotalCount(0, response);
-        }
-      } else {
-        sthLogger.debug(
-          request.sth.context,
-          'The raw data collection for retrieval exists'
-        );
-
-        sthDatabase.getRawData(
-          {
-            collection: collection,
+    sthDatabase.getCollection(
+        {
+            service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
+            servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
             entityId: request.params.entityId,
             entityType: request.params.entityType,
             attrName: request.params.attrName,
-            lastN: request.query.lastN,
-            hLimit: request.query.hLimit,
-            hOffset: request.query.hOffset,
-            from: request.query.dateFrom,
-            to: request.query.dateTo,
-            filetype: request.query.filetype
-          },
-          function (err, result, totalCount) {
+        },
+        {
+            isAggregated: false,
+            shouldCreate: false,
+            shouldTruncate: false,
+        },
+        function(err, collection) {
             if (err) {
-              // Error when getting the raw data
-              sthLogger.error(
-                request.sth.context,
-                'Error when getting raw data from collection \'%s\'',
-                collection
-              );
-              sthLogger.debug(
-                request.sth.context,
-                'Responding with 500 - Internal Error'
-              );
-              response = reply(err);
-            } else if (!result || !(result.length || result instanceof stream)) {
-              // No raw data available for the request
-              sthLogger.debug(
-                request.sth.context,
-                'No raw data available for the request: ' + request.url.path
-              );
-
-              sthLogger.debug(
-                request.sth.context,
-                'Responding with no points'
-              );
-              response = reply(
-                sthServerUtils.getNGSIPayload(
-                  request.params.entityId,
-                  request.params.entityType,
-                  request.params.attrName,
-                  sthServerUtils.getEmptyResponse()
-                )
-              );
-            } else {
-              if (result instanceof stream) {
-                sthLogger.debug(
-                  request.sth.context,
-                  'Responding with a stream of docs'
-                );
-                response = reply(new stream.Readable().wrap(result));
-              } else if (typeof(result) === 'string') {
-                sthLogger.debug(
-                  request.sth.context,
-                  'Responding with file \'' + result + '\''
-                );
-                response = reply.file(result);
-                var fileName = result.substring(result.lastIndexOf(path.sep) + 1);
-                response.header('Content-Disposition', 'attachment; filename*= utf-8\'\'' + encodeRFC5987(fileName));
-                response.once('finish', function () {
-                  sthLogger.debug(
+                // The collection does not exist, reply with en empty response
+                sthLogger.warn(
                     request.sth.context,
-                    'Removing file \'' + result + '\''
-                  );
-                  fs.unlink(result, function (err) {
-                    if (!err) {
-                      sthLogger.debug(
-                        request.sth.context,
-                        'File \'' + result + '\' successfully removed'
-                      );
-                    } else {
-                      sthLogger.warn(
-                        request.sth.context,
-                        'Error when removing file \'' + result + '\': ' + err
-                      );
-                    }
-                  });
-                });
-              } else {
-                sthLogger.debug(
-                  request.sth.context,
-                  'Responding with %s docs',
-                  result.length
+                    "Error when getting the raw data collection for retrieval (the collection '%s' may not exist)",
+                    collection
                 );
-                response = reply(
-                  sthServerUtils.getNGSIPayload(
+
+                sthLogger.debug(request.sth.context, 'Responding with no points');
+                var emptyResponse = sthServerUtils.getEmptyResponse();
+                var ngsiPayload = sthServerUtils.getNGSIPayload(
                     request.params.entityId,
                     request.params.entityType,
                     request.params.attrName,
-                    result));
-              }
+                    emptyResponse
+                );
+                response = reply(ngsiPayload);
+                sthServerUtils.addFiwareCorrelator(request, response);
+                if (request.query.count) {
+                    sthServerUtils.addFiwareTotalCount(0, response);
+                }
+            } else {
+                sthLogger.debug(request.sth.context, 'The raw data collection for retrieval exists');
+
+                sthDatabase.getRawData(
+                    {
+                        collection: collection,
+                        entityId: request.params.entityId,
+                        entityType: request.params.entityType,
+                        attrName: request.params.attrName,
+                        lastN: request.query.lastN,
+                        hLimit: request.query.hLimit,
+                        hOffset: request.query.hOffset,
+                        from: request.query.dateFrom,
+                        to: request.query.dateTo,
+                        filetype: request.query.filetype,
+                    },
+                    function(err, result, totalCount) {
+                        if (err) {
+                            // Error when getting the raw data
+                            sthLogger.error(
+                                request.sth.context,
+                                "Error when getting raw data from collection '%s'",
+                                collection
+                            );
+                            sthLogger.debug(request.sth.context, 'Responding with 500 - Internal Error');
+                            response = reply(err);
+                        } else if (!result || !(result.length || result instanceof stream)) {
+                            // No raw data available for the request
+                            sthLogger.debug(
+                                request.sth.context,
+                                'No raw data available for the request: ' + request.url.path
+                            );
+
+                            sthLogger.debug(request.sth.context, 'Responding with no points');
+                            response = reply(
+                                sthServerUtils.getNGSIPayload(
+                                    request.params.entityId,
+                                    request.params.entityType,
+                                    request.params.attrName,
+                                    sthServerUtils.getEmptyResponse()
+                                )
+                            );
+                        } else {
+                            if (result instanceof stream) {
+                                sthLogger.debug(request.sth.context, 'Responding with a stream of docs');
+                                response = reply(new stream.Readable().wrap(result));
+                            } else if (typeof result === 'string') {
+                                sthLogger.debug(request.sth.context, "Responding with file '" + result + "'");
+                                response = reply.file(result);
+                                var fileName = result.substring(result.lastIndexOf(path.sep) + 1);
+                                response.header(
+                                    'Content-Disposition',
+                                    "attachment; filename*= utf-8''" + encodeRFC5987(fileName)
+                                );
+                                response.once('finish', function() {
+                                    sthLogger.debug(request.sth.context, "Removing file '" + result + "'");
+                                    fs.unlink(result, function(err) {
+                                        if (!err) {
+                                            sthLogger.debug(
+                                                request.sth.context,
+                                                "File '" + result + "' successfully removed"
+                                            );
+                                        } else {
+                                            sthLogger.warn(
+                                                request.sth.context,
+                                                "Error when removing file '" + result + "': " + err
+                                            );
+                                        }
+                                    });
+                                });
+                            } else {
+                                sthLogger.debug(request.sth.context, 'Responding with %s docs', result.length);
+                                response = reply(
+                                    sthServerUtils.getNGSIPayload(
+                                        request.params.entityId,
+                                        request.params.entityType,
+                                        request.params.attrName,
+                                        result
+                                    )
+                                );
+                            }
+                        }
+                        sthServerUtils.addFiwareCorrelator(request, response);
+                        if (request.query.count) {
+                            sthLogger.debug(request.sth.context, 'totalCount %j', totalCount);
+                            sthServerUtils.addFiwareTotalCount(totalCount, response);
+                        }
+                    }
+                );
             }
-            sthServerUtils.addFiwareCorrelator(request, response);
-            if (request.query.count) {
-              sthLogger.debug(
-                request.sth.context,
-                'totalCount %j',
-                totalCount
-              );
-              sthServerUtils.addFiwareTotalCount(totalCount, response);
-            }
-          }
-        );
-      }
-    }
-  );
+        }
+    );
 }
 
 /**
@@ -205,116 +179,102 @@ function getRawData(request, reply) {
  * @param {Function} reply   Hapi's reply function
  */
 function getAggregatedData(request, reply) {
-  var response;
+    var response;
 
-  sthLogger.debug(
-    request.sth.context,
-    'Getting access to the aggregated data collection for retrieval...'
-  );
+    sthLogger.debug(request.sth.context, 'Getting access to the aggregated data collection for retrieval...');
 
-  sthDatabase.getCollection(
-    {
-      service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
-      servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
-      entityId: request.params.entityId,
-      entityType: request.params.entityType,
-      attrName: request.params.attrName
-    },
-    {
-      isAggregated: true,
-      shouldCreate: false,
-      shouldTruncate: false
-    },
-    function (err, collection) {
-      if (err) {
-        // The collection does not exist, reply with en empty response
-        sthLogger.warn(
-          request.sth.context,
-          'Error when getting the aggregated data collection for retrieval (the collection \'%s\' may not exist)',
-          collection
-        );
-
-        sthLogger.debug(
-          request.sth.context,
-          'Responding with no points'
-        );
-        var emptyResponse = sthServerUtils.getEmptyResponse();
-        var ngsiPayload = sthServerUtils.getNGSIPayload(
-          request.params.entityId,
-          request.params.entityType,
-          request.params.attrName,
-          emptyResponse);
-        response = reply(ngsiPayload);
-        sthServerUtils.addFiwareCorrelator(request, response);
-      } else {
-        sthLogger.debug(
-          request.sth.context,
-          'The aggregated data collection for retrieval exists'
-        );
-
-        sthDatabase.getAggregatedData(
-          {
-            collection: collection,
+    sthDatabase.getCollection(
+        {
+            service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
+            servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
             entityId: request.params.entityId,
             entityType: request.params.entityType,
             attrName: request.params.attrName,
-            aggregatedFunction: request.query.aggrMethod,
-            resolution: request.query.aggrPeriod,
-            from: request.query.dateFrom,
-            to: request.query.dateTo,
-            shouldFilter: sthConfig.FILTER_OUT_EMPTY
-          },
-          function (err, result) {
+        },
+        {
+            isAggregated: true,
+            shouldCreate: false,
+            shouldTruncate: false,
+        },
+        function(err, collection) {
             if (err) {
-              // Error when getting the aggregated data
-              sthLogger.error(
-                request.sth.context,
-                'Error when getting aggregated data from collection \'%s\'',
-                collection
-              );
-              sthLogger.debug(
-                request.sth.context,
-                'Responding with 500 - Internal Error'
-              );
-              response = reply(err);
-            } else if (!result || !result.length) {
-              // No aggregated data available for the request
-              sthLogger.debug(
-                request.sth.context,
-                'No aggregated data available for the request: ' + request.url.path
-              );
+                // The collection does not exist, reply with en empty response
+                sthLogger.warn(
+                    request.sth.context,
+                    'Error when getting the aggregated data collection for retrieval' +
+                        // Overly long line.
+                        " (the collection '%s' may not exist)",
+                    collection
+                );
 
-              sthLogger.debug(
-                request.sth.context,
-                'Responding with no points'
-              );
-              response = reply(
-                sthServerUtils.getNGSIPayload(
-                  request.params.entityId,
-                  request.params.entityType,
-                  request.params.attrName,
-                  sthServerUtils.getEmptyResponse()
-                )
-              );
+                sthLogger.debug(request.sth.context, 'Responding with no points');
+                var emptyResponse = sthServerUtils.getEmptyResponse();
+                var ngsiPayload = sthServerUtils.getNGSIPayload(
+                    request.params.entityId,
+                    request.params.entityType,
+                    request.params.attrName,
+                    emptyResponse
+                );
+                response = reply(ngsiPayload);
+                sthServerUtils.addFiwareCorrelator(request, response);
             } else {
-              sthLogger.debug(
-                request.sth.context,
-                'Responding with %s docs',
-                result.length
-              );
-              response = reply(
-                sthServerUtils.getNGSIPayload(
-                  request.params.entityId,
-                  request.params.entityType,
-                  request.params.attrName,
-                  result));
+                sthLogger.debug(request.sth.context, 'The aggregated data collection for retrieval exists');
+
+                sthDatabase.getAggregatedData(
+                    {
+                        collection: collection,
+                        entityId: request.params.entityId,
+                        entityType: request.params.entityType,
+                        attrName: request.params.attrName,
+                        aggregatedFunction: request.query.aggrMethod,
+                        resolution: request.query.aggrPeriod,
+                        from: request.query.dateFrom,
+                        to: request.query.dateTo,
+                        shouldFilter: sthConfig.FILTER_OUT_EMPTY,
+                    },
+                    function(err, result) {
+                        if (err) {
+                            // Error when getting the aggregated data
+                            sthLogger.error(
+                                request.sth.context,
+                                "Error when getting aggregated data from collection '%s'",
+                                collection
+                            );
+                            sthLogger.debug(request.sth.context, 'Responding with 500 - Internal Error');
+                            response = reply(err);
+                        } else if (!result || !result.length) {
+                            // No aggregated data available for the request
+                            sthLogger.debug(
+                                request.sth.context,
+                                'No aggregated data available for the request: ' + request.url.path
+                            );
+
+                            sthLogger.debug(request.sth.context, 'Responding with no points');
+                            response = reply(
+                                sthServerUtils.getNGSIPayload(
+                                    request.params.entityId,
+                                    request.params.entityType,
+                                    request.params.attrName,
+                                    sthServerUtils.getEmptyResponse()
+                                )
+                            );
+                        } else {
+                            sthLogger.debug(request.sth.context, 'Responding with %s docs', result.length);
+                            response = reply(
+                                sthServerUtils.getNGSIPayload(
+                                    request.params.entityId,
+                                    request.params.entityType,
+                                    request.params.attrName,
+                                    result
+                                )
+                            );
+                        }
+                        sthServerUtils.addFiwareCorrelator(request, response);
+                    }
+                );
             }
-            sthServerUtils.addFiwareCorrelator(request, response);
-          }
-        );
-      }
-    }
-  );
+        }
+    );
 }
 
 /**
@@ -323,59 +283,58 @@ function getAggregatedData(request, reply) {
  * @param {Function} reply   The reply() function of the hapi server
  */
 function getDataHandler(request, reply) {
-  request.sth = request.sth || {};
-  request.sth.context = sthServerUtils.getContext(request);
-  var message, error;
-  sthLogger.debug(
-    request.sth.context,
-    request.method.toUpperCase() + ' ' + request.url.path
-  );
+    request.sth = request.sth || {};
+    request.sth.context = sthServerUtils.getContext(request);
+    var message, error;
+    sthLogger.debug(request.sth.context, request.method.toUpperCase() + ' ' + request.url.path);
 
-  if ((request.query.lastN || request.query.lastN === 0) ||
-    ((request.query.hLimit || request.query.hLimit === 0) &&
-    (request.query.hOffset || request.query.hOffset === 0)) ||
-    (request.query.filetype && request.query.filetype.toLowerCase() === 'csv')) {
-    // Raw data is requested
-    // Check & ensure hLimit<=lastN<=config.maxPageSize.
-    if (request.query.hLimit || request.query.lastN) {
-        if ( (request.query.lastN && request.query.lastN > sthConfig.MAX_PAGE_SIZE) ||
-             (request.query.hLimit && request.query.hLimit > sthConfig.MAX_PAGE_SIZE) ||
-             (request.query.hLimit && request.query.lastN && request.query.hLimit > request.query.lastN ) ){
-            message = 'hLimit <= lastN <= config.maxPageSize';
-            sthLogger.warn(
-              request.sth.context,
-              request.method.toUpperCase() + ' ' + request.url.path +
-                ', error=' + message
-            );
-            error = boom.badRequest(message);
-            error.output.payload.validation = {
-              source: 'query',
-              keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod',
-                     'aggrPeriod', 'count']
-            };
-            return reply(error);
+    if (
+        request.query.lastN ||
+        request.query.lastN === 0 ||
+        ((request.query.hLimit || request.query.hLimit === 0) &&
+            (request.query.hOffset || request.query.hOffset === 0)) ||
+        (request.query.filetype && request.query.filetype.toLowerCase() === 'csv')
+    ) {
+        // Raw data is requested
+        // Check & ensure hLimit<=lastN<=config.maxPageSize.
+        if (request.query.hLimit || request.query.lastN) {
+            if (
+                (request.query.lastN && request.query.lastN > sthConfig.MAX_PAGE_SIZE) ||
+                (request.query.hLimit && request.query.hLimit > sthConfig.MAX_PAGE_SIZE) ||
+                (request.query.hLimit && request.query.lastN && request.query.hLimit > request.query.lastN)
+            ) {
+                message = 'hLimit <= lastN <= config.maxPageSize';
+                sthLogger.warn(
+                    request.sth.context,
+                    request.method.toUpperCase() + ' ' + request.url.path + ', error=' + message
+                );
+                error = boom.badRequest(message);
+                error.output.payload.validation = {
+                    source: 'query',
+                    keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod', 'count'],
+                };
+                return reply(error);
+            }
         }
+        getRawData(request, reply);
+    } else if (request.query.aggrMethod && request.query.aggrPeriod) {
+        // Aggregated data is requested
+        getAggregatedData(request, reply);
+    } else {
+        message =
+            'A combination of the following query params is required: lastN, hLimit and hOffset, ' +
+            'filetype, or aggrMethod and aggrPeriod';
+        sthLogger.warn(
+            request.sth.context,
+            request.method.toUpperCase() + ' ' + request.url.path + ', error=' + message
+        );
+        error = boom.badRequest(message);
+        error.output.payload.validation = {
+            source: 'query',
+            keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod', 'count'],
+        };
+        return reply(error);
     }
-    getRawData(request, reply);
-  } else if (request.query.aggrMethod && request.query.aggrPeriod) {
-    // Aggregated data is requested
-    getAggregatedData(request, reply);
-  } else {
-    message = 'A combination of the following query params is required: lastN, hLimit and hOffset, ' +
-      'filetype, or aggrMethod and aggrPeriod';
-    sthLogger.warn(
-      request.sth.context,
-      request.method.toUpperCase() + ' ' + request.url.path +
-        ', error=' + message
-    );
-    error = boom.badRequest(message);
-    error.output.payload.validation = {
-      source: 'query',
-      keys: ['lastN', 'hLimit', 'hOffset', 'filetype', 'aggrMethod', 'aggrPeriod',
-             'count']
-    };
-    return reply(error);
-  }
 }
 
 module.exports = getDataHandler;

--- a/lib/server/handlers/sthGetLogLevelHandler.js
+++ b/lib/server/handlers/sthGetLogLevelHandler.js
@@ -33,9 +33,9 @@ var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils');
  * @return {String}       The response to sent back to the client including the logging level
  */
 function getLogLevelResponse(level) {
-  /* jshint quotmark: true */
+    /* jshint quotmark: true */
     return {
-      "level": level
+        level: level,
     };
 }
 
@@ -45,25 +45,19 @@ function getLogLevelResponse(level) {
  * @param reply hapi's server reply() function
  */
 function getLogLevelHandler(request, reply) {
-  var response;
+    var response;
 
-  request.sth = request.sth || {};
-  request.sth.context = sthServerUtils.getContext(request);
+    request.sth = request.sth || {};
+    request.sth.context = sthServerUtils.getContext(request);
 
-  sthLogger.debug(
-    request.sth.context,
-    request.method.toUpperCase() + ' ' + request.url.path
-  );
+    sthLogger.debug(request.sth.context, request.method.toUpperCase() + ' ' + request.url.path);
 
-  var level = sthLogger.getLevel();
+    var level = sthLogger.getLevel();
 
-  sthLogger.info(
-    request.sth.context,
-    'Responding with logging level: ' + level
-  );
+    sthLogger.info(request.sth.context, 'Responding with logging level: ' + level);
 
-  response = reply(getLogLevelResponse(level));
-  sthServerUtils.addFiwareCorrelator(request, response);
+    response = reply(getLogLevelResponse(level));
+    sthServerUtils.addFiwareCorrelator(request, response);
 }
 
 module.exports = getLogLevelHandler;

--- a/lib/server/handlers/sthGetLogLevelHandler.js
+++ b/lib/server/handlers/sthGetLogLevelHandler.js
@@ -35,7 +35,7 @@ var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils');
 function getLogLevelResponse(level) {
     /* jshint quotmark: true */
     return {
-        level: level,
+        level: level
     };
 }
 

--- a/lib/server/handlers/sthGetVersionHandler.js
+++ b/lib/server/handlers/sthGetVersionHandler.js
@@ -32,8 +32,8 @@ var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils');
  * @param {Function} reply   The reply() function provided by the hapi server
  */
 function getVersionHandler(request, reply) {
-  var message = sthUtils.getVersion();
-  return reply(message);
+    var message = sthUtils.getVersion();
+    return reply(message);
 }
 
 module.exports = getVersionHandler;

--- a/lib/server/handlers/sthNotFoundHandler.js
+++ b/lib/server/handlers/sthNotFoundHandler.js
@@ -33,17 +33,17 @@ var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils');
  * @param  {Function} reply   The hapi() function provided by the hapi server
  */
 function notFoundHandler(request, reply) {
-  var response;
+    var response;
 
-  request.sth = request.sth || {};
-  request.sth.context = sthServerUtils.getContext(request);
+    request.sth = request.sth || {};
+    request.sth.context = sthServerUtils.getContext(request);
 
-  sthLogger.warn(
-    request.sth.context,
-    '404 - Not Found route for the request: ' + request.method.toUpperCase() + ' ' + request.url.path
-  );
-  response = reply({'statusCode': 404, 'error': 'Not Found'}).code(404);
-  sthServerUtils.addFiwareCorrelator(request, response);
+    sthLogger.warn(
+        request.sth.context,
+        '404 - Not Found route for the request: ' + request.method.toUpperCase() + ' ' + request.url.path
+    );
+    response = reply({ statusCode: 404, error: 'Not Found' }).code(404);
+    sthServerUtils.addFiwareCorrelator(request, response);
 }
 
 module.exports = notFoundHandler;

--- a/lib/server/handlers/sthNotificationHandler.js
+++ b/lib/server/handlers/sthNotificationHandler.js
@@ -36,15 +36,17 @@ var boom = require('boom');
  * @return {number}                  The total number of attributes to be processed
  */
 function getTotalAttributes(contextResponses) {
-  var totalAttributes = 0;
-  for (var l1 = 0; l1 < contextResponses.length; l1++) {
-    if (contextResponses[l1].contextElement &&
-      contextResponses[l1].contextElement.attributes &&
-      Array.isArray(contextResponses[l1].contextElement.attributes)) {
-      totalAttributes += contextResponses[l1].contextElement.attributes.length;
+    var totalAttributes = 0;
+    for (var l1 = 0; l1 < contextResponses.length; l1++) {
+        if (
+            contextResponses[l1].contextElement &&
+            contextResponses[l1].contextElement.attributes &&
+            Array.isArray(contextResponses[l1].contextElement.attributes)
+        ) {
+            totalAttributes += contextResponses[l1].contextElement.attributes.length;
+        }
     }
-  }
-  return totalAttributes;
+    return totalAttributes;
 }
 
 /**
@@ -57,70 +59,61 @@ function getTotalAttributes(contextResponses) {
  * @return {object}            Information about the notification
  */
 function getNotificationInfo(data, callback) {
-  var request = data.request,
-    contextElement = data.contextElement,
-    attribute = data.attribute,
-    recvTime = data.recvTime;
+    var request = data.request,
+        contextElement = data.contextElement,
+        attribute = data.attribute,
+        recvTime = data.recvTime;
 
-  var service = request.headers[sthConfig.HEADER.FIWARE_SERVICE];
-  var servicePath = request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH];
+    var service = request.headers[sthConfig.HEADER.FIWARE_SERVICE];
+    var servicePath = request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH];
 
-  // Get the collection
-  sthDatabase.getCollection(
-    {
-      service: service,
-      servicePath: servicePath,
-      entityId: contextElement.id,
-      entityType: contextElement.type,
-      attrName: attribute.name
-    },
-    {
-      isAggregated: false,
-      shouldCreate: false,
-      shouldTruncate: false
-    },
-    function (err, collection) {
-      if (err) {
-        var result;
-        // There was an error when getting the collection, it probably does not exist
-        sthLogger.debug(
-          request.sth.context,
-          'Error when getting the collection: ' + JSON.stringify(err)
-        );
-        if (err.name === 'MongoError' && err.message.indexOf('does not exist. Currently in strict mode')) {
-          result = {inserts: true};
-          process.nextTick(callback.bind(null, null, result));
-        } else {
-          process.nextTick(callback.bind(null, err));
-        }
-      } else {
-        // The collection exists
-        sthLogger.debug(
-          request.sth.context,
-          'The collection exists'
-        );
-
-        sthDatabase.getNotificationInfo(
-          {
-            collection: collection,
-            recvTime: recvTime,
+    // Get the collection
+    sthDatabase.getCollection(
+        {
+            service: service,
+            servicePath: servicePath,
             entityId: contextElement.id,
             entityType: contextElement.type,
-            attribute: attribute
-          },
-          function (err, result) {
+            attrName: attribute.name,
+        },
+        {
+            isAggregated: false,
+            shouldCreate: false,
+            shouldTruncate: false,
+        },
+        function(err, collection) {
             if (err) {
-              sthLogger.error(
-                request.sth.context,
-                'Error when getting the notification info'
-              );
+                var result;
+                // There was an error when getting the collection, it probably does not exist
+                sthLogger.debug(request.sth.context, 'Error when getting the collection: ' + JSON.stringify(err));
+                if (err.name === 'MongoError' && err.message.indexOf('does not exist. Currently in strict mode')) {
+                    result = { inserts: true };
+                    process.nextTick(callback.bind(null, null, result));
+                } else {
+                    process.nextTick(callback.bind(null, err));
+                }
+            } else {
+                // The collection exists
+                sthLogger.debug(request.sth.context, 'The collection exists');
+
+                sthDatabase.getNotificationInfo(
+                    {
+                        collection: collection,
+                        recvTime: recvTime,
+                        entityId: contextElement.id,
+                        entityType: contextElement.type,
+                        attribute: attribute,
+                    },
+                    function(err, result) {
+                        if (err) {
+                            sthLogger.error(request.sth.context, 'Error when getting the notification info');
+                        }
+                        process.nextTick(callback.bind(null, err, result));
+                    }
+                );
             }
-            process.nextTick(callback.bind(null, err, result));
-          }
-        );
-      }
-    }
-  );
+        }
+    );
 }
 
 /**
@@ -138,98 +131,82 @@ function getNotificationInfo(data, callback) {
  *  @param {Function} callback The callback to notify that the operation has completed with error or successfully
  */
 function storeRawData(data, reply, callback) {
-  var request = data.request,
-    contextElement = data.contextElement,
-    attribute = data.attribute,
-    recvTime = data.recvTime,
-    notificationInfo = data.notificationInfo,
-    counterObj = data.counterObj,
-    totalTasks = data.totalTasks,
-    response;
+    var request = data.request,
+        contextElement = data.contextElement,
+        attribute = data.attribute,
+        recvTime = data.recvTime,
+        notificationInfo = data.notificationInfo,
+        counterObj = data.counterObj,
+        totalTasks = data.totalTasks,
+        response;
 
-  var service = request.headers[sthConfig.HEADER.FIWARE_SERVICE];
-  var servicePath = request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH];
+    var service = request.headers[sthConfig.HEADER.FIWARE_SERVICE];
+    var servicePath = request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH];
 
-  sthLogger.debug(
-    request.sth.context,
-    'Getting access to the raw data collection for storing...'
-  );
+    sthLogger.debug(request.sth.context, 'Getting access to the raw data collection for storing...');
 
-  sthDatabase.getCollection(
-    {
-      service: service,
-      servicePath: servicePath,
-      entityId: contextElement.id,
-      entityType: contextElement.type,
-      attrName: attribute.name
-    },
-    {
-      isAggregated: false,
-      shouldCreate: true,
-      shouldTruncate: true
-    },
-    function (err, collection) {
-      if (err) {
-        // There was an error when getting the collection
-        sthLogger.error(
-          request.sth.context,
-          'Error when getting the raw data collection for storing:' + err
-        );
-        if (++counterObj.counter === totalTasks) {
-          response = reply(err);
-          sthServerUtils.addFiwareCorrelator(request, response);
-        }
-        process.nextTick(callback.bind(null, err));
-      } else {
-        // The collection exists
-        sthLogger.debug(
-          request.sth.context,
-          'The raw data collection for storing exists'
-        );
-
-        if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_RAW ||
-          sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH) {
-          sthDatabase.storeRawData(
-            {
-              collection: collection,
-              recvTime: recvTime,
-              entityId: contextElement.id,
-              entityType: contextElement.type,
-              attribute: attribute,
-              notificationInfo: notificationInfo
-            },
-            function (err) {
-              if (err) {
-                if (err.code === 11000 && err.message.indexOf('duplicate key error') >= 0) {
-                  sthLogger.debug(
-                    request.sth.context,
-                    'Error when storing the raw data: ' + err
-                  );
-                } else {
-                  sthLogger.error(
-                    request.sth.context,
-                    'Error when storing the raw data: ' + err
-                  );
+    sthDatabase.getCollection(
+        {
+            service: service,
+            servicePath: servicePath,
+            entityId: contextElement.id,
+            entityType: contextElement.type,
+            attrName: attribute.name,
+        },
+        {
+            isAggregated: false,
+            shouldCreate: true,
+            shouldTruncate: true,
+        },
+        function(err, collection) {
+            if (err) {
+                // There was an error when getting the collection
+                sthLogger.error(request.sth.context, 'Error when getting the raw data collection for storing:' + err);
+                if (++counterObj.counter === totalTasks) {
+                    response = reply(err);
+                    sthServerUtils.addFiwareCorrelator(request, response);
                 }
-              } else {
-                sthLogger.debug(
-                  request.sth.context,
-                  'Raw data successfully stored'
-                );
-              }
-              if (++counterObj.counter === totalTasks) {
-                response = reply(err);
-                sthServerUtils.addFiwareCorrelator(request, response);
-              }
-              process.nextTick(callback.bind(null, err));
+                process.nextTick(callback.bind(null, err));
+            } else {
+                // The collection exists
+                sthLogger.debug(request.sth.context, 'The raw data collection for storing exists');
+
+                if (
+                    sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_RAW ||
+                    sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH
+                ) {
+                    sthDatabase.storeRawData(
+                        {
+                            collection: collection,
+                            recvTime: recvTime,
+                            entityId: contextElement.id,
+                            entityType: contextElement.type,
+                            attribute: attribute,
+                            notificationInfo: notificationInfo,
+                        },
+                        function(err) {
+                            if (err) {
+                                if (err.code === 11000 && err.message.indexOf('duplicate key error') >= 0) {
+                                    sthLogger.debug(request.sth.context, 'Error when storing the raw data: ' + err);
+                                } else {
+                                    sthLogger.error(request.sth.context, 'Error when storing the raw data: ' + err);
+                                }
+                            } else {
+                                sthLogger.debug(request.sth.context, 'Raw data successfully stored');
+                            }
+                            if (++counterObj.counter === totalTasks) {
+                                response = reply(err);
+                                sthServerUtils.addFiwareCorrelator(request, response);
+                            }
+                            process.nextTick(callback.bind(null, err));
+                        }
+                    );
+                } else {
+                    process.nextTick(callback);
+                }
             }
-          );
-        } else {
-          process.nextTick(callback);
         }
-      }
-    }
-  );
+    );
 }
 
 /**
@@ -246,87 +223,74 @@ function storeRawData(data, reply, callback) {
  *  @param {Function} reply The hapi() function provided by the hapi server
  */
 function storeAggregatedData(data, reply) {
-  var request = data.request,
-      contextElement = data.contextElement,
-      attribute = data.attribute,
-      recvTime = data.recvTime,
-      notificationInfo = data.notificationInfo,
-      counterObj = data.counterObj,
-      totalTasks = data.totalTasks,
-      response;
+    var request = data.request,
+        contextElement = data.contextElement,
+        attribute = data.attribute,
+        recvTime = data.recvTime,
+        notificationInfo = data.notificationInfo,
+        counterObj = data.counterObj,
+        totalTasks = data.totalTasks,
+        response;
 
-  var service = request.headers[sthConfig.HEADER.FIWARE_SERVICE];
-  var servicePath = request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH];
+    var service = request.headers[sthConfig.HEADER.FIWARE_SERVICE];
+    var servicePath = request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH];
 
-  sthLogger.debug(
-    request.sth.context,
-    'Getting access to the aggregated data collection for storing...'
-  );
+    sthLogger.debug(request.sth.context, 'Getting access to the aggregated data collection for storing...');
 
-  sthDatabase.getCollection(
-    {
-      service: service,
-      servicePath: servicePath,
-      entityId: contextElement.id,
-      entityType: contextElement.type,
-      attrName: attribute.name
-    },
-    {
-      isAggregated: true,
-      shouldCreate: true,
-      shouldTruncate: true
-    },
-    function (err, collection) {
-      if (err) {
-        // There was an error when getting the collection
-        sthLogger.error(
-          request.sth.context,
-          'Error when getting the aggregated data collection for storing'
-        );
-        if (++counterObj.counter === totalTasks) {
-          response = reply(err);
-          sthServerUtils.addFiwareCorrelator(request, response);
-        }
-      } else {
-        // The collection exists
-        sthLogger.debug(
-          request.sth.context,
-          'The aggregated data collection for storing exists'
-        );
+    sthDatabase.getCollection(
+        {
+            service: service,
+            servicePath: servicePath,
+            entityId: contextElement.id,
+            entityType: contextElement.type,
+            attrName: attribute.name,
+        },
+        {
+            isAggregated: true,
+            shouldCreate: true,
+            shouldTruncate: true,
+        },
+        function(err, collection) {
+            if (err) {
+                // There was an error when getting the collection
+                sthLogger.error(request.sth.context, 'Error when getting the aggregated data collection for storing');
+                if (++counterObj.counter === totalTasks) {
+                    response = reply(err);
+                    sthServerUtils.addFiwareCorrelator(request, response);
+                }
+            } else {
+                // The collection exists
+                sthLogger.debug(request.sth.context, 'The aggregated data collection for storing exists');
 
-        if (sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_AGGREGATED ||
-          sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH) {
-          sthDatabase.storeAggregatedData(
-            {
-              collection: collection,
-              recvTime: recvTime,
-              entityId: contextElement.id,
-              entityType: contextElement.type,
-              attribute: attribute,
-              notificationInfo: notificationInfo
-            },
-            function (err) {
-              if (err) {
-                sthLogger.error(
-                  request.sth.context,
-                  'Error when storing the aggregated data'
-                );
-              } else {
-                sthLogger.debug(
-                  request.sth.context,
-                  'Aggregated data successfully stored'
-                );
-              }
-              if (++counterObj.counter === totalTasks) {
-                response = reply(err);
-                sthServerUtils.addFiwareCorrelator(request, response);
-              }
+                if (
+                    sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.ONLY_AGGREGATED ||
+                    sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH
+                ) {
+                    sthDatabase.storeAggregatedData(
+                        {
+                            collection: collection,
+                            recvTime: recvTime,
+                            entityId: contextElement.id,
+                            entityType: contextElement.type,
+                            attribute: attribute,
+                            notificationInfo: notificationInfo,
+                        },
+                        function(err) {
+                            if (err) {
+                                sthLogger.error(request.sth.context, 'Error when storing the aggregated data');
+                            } else {
+                                sthLogger.debug(request.sth.context, 'Aggregated data successfully stored');
+                            }
+                            if (++counterObj.counter === totalTasks) {
+                                response = reply(err);
+                                sthServerUtils.addFiwareCorrelator(request, response);
+                            }
+                        }
+                    );
+                }
             }
-          );
         }
-      }
-    }
-  );
+    );
 }
 
 /**
@@ -344,67 +308,55 @@ function storeAggregatedData(data, reply) {
  * @param {function} hapi's reply function
  */
 function processAttribute(data, reply) {
-  var attribute = data.attribute,
-      isAggregatableValue = true;
-  if (!attribute.value ||
-    (typeof(attribute.value) !== 'string' && typeof(attribute.value) !== 'number') ||
-    (sthConfig.IGNORE_BLANK_SPACES && typeof(attribute.value) === 'string' &&
-    attribute.value.trim() === '')) {
-    sthLogger.warn(
-      data.request.sth.context,
-      'Attribute value not aggregatable: ' + JSON.stringify(attribute.value)
-    );
-    isAggregatableValue = false;
-  }
-
-  getNotificationInfo(
-    data,
-    function onNotificationInfo(err, result) {
-      data.notificationInfo = result;
-
-      if (!err && !result.exists) {
-        // Store the raw data into the database
-        storeRawData(data, reply, function (err) {
-          if (err) {
-            if (err.code === 11000 && err.message.indexOf('duplicate key error') >= 0) {
-              sthLogger.debug(
-                data.request.sth.context,
-                'Ignoring the notification since already registered'
-              );
-              err = null;
-            }
-            if (++data.counterObj.counter === data.totalTasks) {
-              reply(err);
-            }
-          } else if (isAggregatableValue) {
-            // Store the aggregated data into the database
-            storeAggregatedData(data, reply);
-          } else {
-            if (++data.counterObj.counter === data.totalTasks) {
-              reply();
-            }
-          }
-        });
-      } else {
-        if (err) {
-          sthLogger.debug(
+    var attribute = data.attribute,
+        isAggregatableValue = true;
+    if (
+        !attribute.value ||
+        (typeof attribute.value !== 'string' && typeof attribute.value !== 'number') ||
+        (sthConfig.IGNORE_BLANK_SPACES && typeof attribute.value === 'string' && attribute.value.trim() === '')
+    ) {
+        sthLogger.warn(
             data.request.sth.context,
-            'Error when getting the notification information: ' + err
-          );
-        } else if (result.exists) {
-          sthLogger.debug(
-            data.request.sth.context,
-            'Ignoring the notification since already registered'
-          );
-        }
-        data.counterObj.counter += sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH ?
-          2 : 1;
-        if (data.counterObj.counter === data.totalTasks) {
-          reply(err);
-        }
-      }
+            'Attribute value not aggregatable: ' + JSON.stringify(attribute.value)
+        );
+        isAggregatableValue = false;
     }
-  );
+
+    getNotificationInfo(data, function onNotificationInfo(err, result) {
+        data.notificationInfo = result;
+
+        if (!err && !result.exists) {
+            // Store the raw data into the database
+            storeRawData(data, reply, function(err) {
+                if (err) {
+                    if (err.code === 11000 && err.message.indexOf('duplicate key error') >= 0) {
+                        sthLogger.debug(data.request.sth.context, 'Ignoring the notification since already registered');
+                        err = null;
+                    }
+                    if (++data.counterObj.counter === data.totalTasks) {
+                        reply(err);
+                    }
+                } else if (isAggregatableValue) {
+                    // Store the aggregated data into the database
+                    storeAggregatedData(data, reply);
+                } else {
+                    if (++data.counterObj.counter === data.totalTasks) {
+                        reply();
+                    }
+                }
+            });
+        } else {
+            if (err) {
+                sthLogger.debug(data.request.sth.context, 'Error when getting the notification information: ' + err);
+            } else if (result.exists) {
+                sthLogger.debug(data.request.sth.context, 'Ignoring the notification since already registered');
+            }
+            data.counterObj.counter += sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH ? 2 : 1;
+            if (data.counterObj.counter === data.totalTasks) {
+                reply(err);
+            }
+        }
+    });
 }
 
 /**
@@ -415,55 +367,56 @@ function processAttribute(data, reply) {
  * @param {Function} reply    The reply function provided by the hapi server
  */
 function processNotification(recvTime, request, reply) {
-  var contextElement, attributes;
+    var contextElement, attributes;
 
-  // An object is needed since Javascript implements calls-by-sharing
-  //  (see http://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing) and the counter is shared between
-  //  rawAggregatedData() and storeAggregatedData() functions to let them synchronize
-  var counterObj = {
-    counter: 0
-  };
+    // An object is needed since Javascript implements calls-by-sharing
+    //  (see http://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing) and the counter is shared between
+    //  rawAggregatedData() and storeAggregatedData() functions to let them synchronize
+    var counterObj = {
+        counter: 0,
+    };
 
-  var contextResponses = request.payload.contextResponses;
+    var contextResponses = request.payload.contextResponses;
 
-  var totalAttributes = getTotalAttributes(contextResponses);
+    var totalAttributes = getTotalAttributes(contextResponses);
 
-  var totalTasks = sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH ?
-    (2 * totalAttributes) : (1 * totalAttributes);
+    var totalTasks =
+        sthConfig.SHOULD_STORE === sthConfig.DATA_TO_STORE.BOTH ? 2 * totalAttributes : 1 * totalAttributes;
 
-  if (totalAttributes === 0) {
-    var message = 'At least one attribute with an aggregatable value should be included in the notification';
-    sthLogger.warn(
-      request.sth.context,
-      request.method.toUpperCase() + ' ' + request.url.path +
-      ', error=' + message
-    );
-    var error = boom.badRequest(message);
-    error.output.payload.validation = {source: 'payload', keys: ['attributes']};
-    return reply(error);
-  }
-
-  for (var i = 0; i < contextResponses.length; i++) {
-    if (contextResponses[i].contextElement &&
-      contextResponses[i].contextElement.attributes &&
-      Array.isArray(contextResponses[i].contextElement.attributes)) {
-      contextElement = contextResponses[i].contextElement;
-      attributes = contextElement.attributes;
-      for (var j = 0; j < attributes.length; j++) {
-        processAttribute(
-          {
-            request: request,
-            contextElement: contextElement,
-            attribute: attributes[j],
-            recvTime: recvTime,
-            counterObj: counterObj,
-            totalTasks: totalTasks
-          },
-          reply
+    if (totalAttributes === 0) {
+        var message = 'At least one attribute with an aggregatable value should be included in the notification';
+        sthLogger.warn(
+            request.sth.context,
+            request.method.toUpperCase() + ' ' + request.url.path + ', error=' + message
         );
-      }
+        var error = boom.badRequest(message);
+        error.output.payload.validation = { source: 'payload', keys: ['attributes'] };
+        return reply(error);
     }
-  }
+
+    for (var i = 0; i < contextResponses.length; i++) {
+        if (
+            contextResponses[i].contextElement &&
+            contextResponses[i].contextElement.attributes &&
+            Array.isArray(contextResponses[i].contextElement.attributes)
+        ) {
+            contextElement = contextResponses[i].contextElement;
+            attributes = contextElement.attributes;
+            for (var j = 0; j < attributes.length; j++) {
+                processAttribute(
+                    {
+                        request: request,
+                        contextElement: contextElement,
+                        attribute: attributes[j],
+                        recvTime: recvTime,
+                        counterObj: counterObj,
+                        totalTasks: totalTasks,
+                    },
+                    reply
+                );
+            }
+        }
+    }
 }
 
 /**
@@ -472,20 +425,19 @@ function processNotification(recvTime, request, reply) {
  * @param {Function} reply   The reply() function provided by the hapi server
  */
 function notificationHandler(request, reply) {
-  var recvTime = new Date();
+    var recvTime = new Date();
 
-  request.sth = request.sth || {};
-  request.sth.context = sthServerUtils.getContext(request);
+    request.sth = request.sth || {};
+    request.sth.context = sthServerUtils.getContext(request);
 
-  sthLogger.debug(
-    request.sth.context,
-    request.method.toUpperCase() + ' ' + request.url.path + ' with payload: ' + JSON.stringify(request.payload)
-  );
+    sthLogger.debug(
+        request.sth.context,
+        request.method.toUpperCase() + ' ' + request.url.path + ' with payload: ' + JSON.stringify(request.payload)
+    );
 
-  if (request.payload && request.payload.contextResponses &&
-    Array.isArray(request.payload.contextResponses)) {
-    processNotification(recvTime, request, reply);
-  }
+    if (request.payload && request.payload.contextResponses && Array.isArray(request.payload.contextResponses)) {
+        processNotification(recvTime, request, reply);
+    }
 }
 
 module.exports = notificationHandler;

--- a/lib/server/handlers/sthNotificationHandler.js
+++ b/lib/server/handlers/sthNotificationHandler.js
@@ -74,12 +74,12 @@ function getNotificationInfo(data, callback) {
             servicePath: servicePath,
             entityId: contextElement.id,
             entityType: contextElement.type,
-            attrName: attribute.name,
+            attrName: attribute.name
         },
         {
             isAggregated: false,
             shouldCreate: false,
-            shouldTruncate: false,
+            shouldTruncate: false
         },
         function(err, collection) {
             if (err) {
@@ -102,7 +102,7 @@ function getNotificationInfo(data, callback) {
                         recvTime: recvTime,
                         entityId: contextElement.id,
                         entityType: contextElement.type,
-                        attribute: attribute,
+                        attribute: attribute
                     },
                     function(err, result) {
                         if (err) {
@@ -151,12 +151,12 @@ function storeRawData(data, reply, callback) {
             servicePath: servicePath,
             entityId: contextElement.id,
             entityType: contextElement.type,
-            attrName: attribute.name,
+            attrName: attribute.name
         },
         {
             isAggregated: false,
             shouldCreate: true,
-            shouldTruncate: true,
+            shouldTruncate: true
         },
         function(err, collection) {
             if (err) {
@@ -182,7 +182,7 @@ function storeRawData(data, reply, callback) {
                             entityId: contextElement.id,
                             entityType: contextElement.type,
                             attribute: attribute,
-                            notificationInfo: notificationInfo,
+                            notificationInfo: notificationInfo
                         },
                         function(err) {
                             if (err) {
@@ -243,12 +243,12 @@ function storeAggregatedData(data, reply) {
             servicePath: servicePath,
             entityId: contextElement.id,
             entityType: contextElement.type,
-            attrName: attribute.name,
+            attrName: attribute.name
         },
         {
             isAggregated: true,
             shouldCreate: true,
-            shouldTruncate: true,
+            shouldTruncate: true
         },
         function(err, collection) {
             if (err) {
@@ -273,7 +273,7 @@ function storeAggregatedData(data, reply) {
                             entityId: contextElement.id,
                             entityType: contextElement.type,
                             attribute: attribute,
-                            notificationInfo: notificationInfo,
+                            notificationInfo: notificationInfo
                         },
                         function(err) {
                             if (err) {
@@ -373,7 +373,7 @@ function processNotification(recvTime, request, reply) {
     //  (see http://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing) and the counter is shared between
     //  rawAggregatedData() and storeAggregatedData() functions to let them synchronize
     var counterObj = {
-        counter: 0,
+        counter: 0
     };
 
     var contextResponses = request.payload.contextResponses;
@@ -410,7 +410,7 @@ function processNotification(recvTime, request, reply) {
                         attribute: attributes[j],
                         recvTime: recvTime,
                         counterObj: counterObj,
-                        totalTasks: totalTasks,
+                        totalTasks: totalTasks
                     },
                     reply
                 );

--- a/lib/server/handlers/sthRemoveDataHandler.js
+++ b/lib/server/handlers/sthRemoveDataHandler.js
@@ -66,7 +66,7 @@ function removeDataHandler(request, reply) {
             servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
             entityId: request.params && request.params.entityId,
             entityType: request.params && request.params.entityType,
-            attrName: request.params && request.params.attrName,
+            attrName: request.params && request.params.attrName
         },
         function(err) {
             if (err) {

--- a/lib/server/handlers/sthRemoveDataHandler.js
+++ b/lib/server/handlers/sthRemoveDataHandler.js
@@ -35,11 +35,16 @@ var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
  * @return {String}         The description of the received request including the data included in it
  */
 function getRequestDescription(request) {
-  return 'service (' + request.headers[sthConfig.HEADER.FIWARE_SERVICE] +
-    '), service path (' + request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH] + ')' +
-    (request.params.entityId ? ', entity id (' + request.params.entityId + ')' : '') +
-    (request.params.entityType ? ', entity type (' + request.params.entityType  + ')' : '') +
-    (request.params.attrName ? ', attribute name (' + request.params.attrName  + ')' : '');
+    return (
+        'service (' +
+        request.headers[sthConfig.HEADER.FIWARE_SERVICE] +
+        '), service path (' +
+        request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH] +
+        ')' +
+        (request.params.entityId ? ', entity id (' + request.params.entityId + ')' : '') +
+        (request.params.entityType ? ', entity type (' + request.params.entityType + ')' : '') +
+        (request.params.attrName ? ', attribute name (' + request.params.attrName + ')' : '')
+    );
 }
 
 /**
@@ -48,54 +53,48 @@ function getRequestDescription(request) {
  * @param {Function} reply   The hapi() function provided by the hapi server
  */
 function removeDataHandler(request, reply) {
-  var response;
+    var response;
 
-  request.sth = request.sth || {};
-  request.sth.context = sthServerUtils.getContext(request);
+    request.sth = request.sth || {};
+    request.sth.context = sthServerUtils.getContext(request);
 
-  sthLogger.debug(
-    request.sth.context,
-    request.method.toUpperCase() + ' ' + request.url.path
-  );
+    sthLogger.debug(request.sth.context, request.method.toUpperCase() + ' ' + request.url.path);
 
-  sthDatabase.removeData(
-    {
-      service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
-      servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
-      entityId: request.params && request.params.entityId,
-      entityType: request.params && request.params.entityType,
-      attrName: request.params && request.params.attrName
-    },
-    function(err) {
-      if (err) {
-        if (err.name === 'MongoError' && err.message.indexOf('does not exist. Currently in strict mode')) {
-          // There is no associated data for the provided service, service path and entity
-          sthLogger.debug(
-            request.sth.context,
-            'No data associated to the provided ' + getRequestDescription(request) + ' available'
-          );
-          // Reply with no error
-          response = reply();
-          response.code(204);
-        } else {
-          sthLogger.warn(
-            request.sth.context,
-            'Error when removing the data associated to an entity: ' + err
-          );
-          // Reply with error
-          response = reply(err);
+    sthDatabase.removeData(
+        {
+            service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
+            servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
+            entityId: request.params && request.params.entityId,
+            entityType: request.params && request.params.entityType,
+            attrName: request.params && request.params.attrName,
+        },
+        function(err) {
+            if (err) {
+                if (err.name === 'MongoError' && err.message.indexOf('does not exist. Currently in strict mode')) {
+                    // There is no associated data for the provided service, service path and entity
+                    sthLogger.debug(
+                        request.sth.context,
+                        'No data associated to the provided ' + getRequestDescription(request) + ' available'
+                    );
+                    // Reply with no error
+                    response = reply();
+                    response.code(204);
+                } else {
+                    sthLogger.warn(request.sth.context, 'Error when removing the data associated to an entity: ' + err);
+                    // Reply with error
+                    response = reply(err);
+                }
+            } else {
+                sthLogger.debug(
+                    request.sth.context,
+                    'Data associated to the provided ' + getRequestDescription(request) + ' successfully removed'
+                );
+                response = reply();
+                response.code(204);
+            }
+            sthServerUtils.addFiwareCorrelator(request, response);
         }
-      } else {
-        sthLogger.debug(
-          request.sth.context,
-          'Data associated to the provided ' + getRequestDescription(request) + ' successfully removed'
-        );
-        response = reply();
-        response.code(204);
-      }
-      sthServerUtils.addFiwareCorrelator(request, response);
-    }
-  );
+    );
 }
 
 module.exports = removeDataHandler;

--- a/lib/server/handlers/sthRemoveDataHandler.js
+++ b/lib/server/handlers/sthRemoveDataHandler.js
@@ -35,16 +35,12 @@ var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
  * @return {String}         The description of the received request including the data included in it
  */
 function getRequestDescription(request) {
-    return (
-        'service (' +
-        request.headers[sthConfig.HEADER.FIWARE_SERVICE] +
-        '), service path (' +
-        request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH] +
-        ')' +
+    // prettier-ignore
+    return ('service (' + request.headers[sthConfig.HEADER.FIWARE_SERVICE] + '), service path (' +
+        request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH] + ')' +
         (request.params.entityId ? ', entity id (' + request.params.entityId + ')' : '') +
         (request.params.entityType ? ', entity type (' + request.params.entityType + ')' : '') +
-        (request.params.attrName ? ', attribute name (' + request.params.attrName + ')' : '')
-    );
+        (request.params.attrName ? ', attribute name (' + request.params.attrName + ')' : ''));
 }
 
 /**

--- a/lib/server/handlers/sthSetLogLevelHandler.js
+++ b/lib/server/handlers/sthSetLogLevelHandler.js
@@ -33,27 +33,20 @@ var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils');
  * @param reply hapi's server reply() function
  */
 function setLogLevelHandler(request, reply) {
-  var response;
+    var response;
 
-  request.sth = request.sth || {};
-  request.sth.context = sthServerUtils.getContext(request);
+    request.sth = request.sth || {};
+    request.sth.context = sthServerUtils.getContext(request);
 
-  sthLogger.debug(
-    request.sth.context,
-    request.method.toUpperCase() + ' ' + request.url.path
-  );
+    sthLogger.debug(request.sth.context, request.method.toUpperCase() + ' ' + request.url.path);
 
-  var level = (request.query.level.toUpperCase() === 'WARNING') ?
-    'WARN' : request.query.level.toUpperCase();
-  sthLogger.setLevel(level);
+    var level = request.query.level.toUpperCase() === 'WARNING' ? 'WARN' : request.query.level.toUpperCase();
+    sthLogger.setLevel(level);
 
-  sthLogger.info(
-    request.sth.context,
-    'Log level set to: ' + level
-  );
+    sthLogger.info(request.sth.context, 'Log level set to: ' + level);
 
-  response = reply();
-  sthServerUtils.addFiwareCorrelator(request, response);
+    response = reply();
+    sthServerUtils.addFiwareCorrelator(request, response);
 }
 
 module.exports = setLogLevelHandler;

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -49,135 +49,153 @@ var attendedRequests = 0;
  * @param  {Function} callback The callback
  */
 function doStartServer(host, port, callback) {
-  server = new hapi.Server();
+    server = new hapi.Server();
 
-  server.on('log', function (event, tags) {
-    if (tags.load) {
-      sthLogger.warn(
-        sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-        'event=' + JSON.stringify(event)
-      );
-    }
-  });
+    server.on('log', function(event, tags) {
+        if (tags.load) {
+            sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'event=' + JSON.stringify(event));
+        }
+    });
 
-  server.on('request-internal', function (request, event, tags) {
-    if (tags.error) {
-      if (tags.auth || tags.handler || tags.state || tags.payload || tags.validation) {
-        sthLogger.warn(
-          sthServerUtils.getContext(request),
-          request.method.toUpperCase() + ' ' + request.url.path +
-          ', event=' + JSON.stringify(event)
-        );
-      } else {
-        sthLogger.error(
-          sthServerUtils.getContext(request),
-          request.method.toUpperCase() + ' ' + request.url.path +
-          ', event=' + JSON.stringify(event)
-        );
-      }
-    }
-  });
+    server.on('request-internal', function(request, event, tags) {
+        if (tags.error) {
+            if (tags.auth || tags.handler || tags.state || tags.payload || tags.validation) {
+                sthLogger.warn(
+                    sthServerUtils.getContext(request),
+                    request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
+                );
+            } else {
+                sthLogger.error(
+                    sthServerUtils.getContext(request),
+                    request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
+                );
+            }
+        }
+    });
 
-  server.connection({
-    host: host,
-    port: port
-  });
+    server.connection({
+        host: host,
+        port: port,
+    });
 
-  server.route([
-    {
-      method: 'GET',
-      path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
-      handler: sthGetDataHandler,
-      config: {
-        validate: {
-          headers: sthHeaderValidator,
-          query: {
-            lastN: joi.number().integer().greater(-1).optional(),
-            hLimit: joi.number().integer().greater(-1).optional(),
-            hOffset: joi.number().integer().greater(-1).optional(),
-            aggrMethod: joi.string().valid('max', 'min', 'sum', 'sum2', 'occur').optional(),
-            aggrPeriod: joi.string().required().valid('month', 'day', 'hour', 'minute', 'second').optional(),
-            dateFrom: joi.date().optional(),
-            dateTo: joi.date().optional(),
-            filetype: joi.string().optional(),
-            count: joi.boolean().optional()
-          }
-        }
-      }
-    },
-    {
-      method: 'GET',
-      path: '/version',
-      handler: sthGetVersionHandler
-    },
-    {
-      method: 'POST',
-      path: '/notify',
-      handler: sthNotificationHandler,
-      config: {
-        validate: {
-          headers: sthHeaderValidator
-        }
-      }
-    },
-    {
-      method: 'DELETE',
-      path: '/STH/v1/contextEntities',
-      handler: sthRemoveDataHandler,
-      config: {
-        validate: {
-          headers: sthHeaderValidator
-        }
-      }
-    },
-    {
-      method: 'DELETE',
-      path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}',
-      handler: sthRemoveDataHandler,
-      config: {
-        validate: {
-          headers: sthHeaderValidator
-        }
-      }
-    },
-    {
-      method: 'DELETE',
-      path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
-      handler: sthRemoveDataHandler,
-      config: {
-        validate: {
-          headers: sthHeaderValidator
-        }
-      }
-    },
-    {
-      method: 'PUT',
-      path: '/admin/log',
-      handler: sthSetLogLevelHandler,
-      config: {
-        validate: {
-          query: {
-            level: joi.string().insensitive().valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG').required()
-          }
-        }
-      }
-    },
-    {
-      method: 'GET',
-      path: '/admin/log',
-      handler: sthGetLogLevelHandler
-    },
-    {
-      method: '*',
-      path: '/{p*}',
-      handler: sthNotFoundHandler
-    }
-  ]);
+    server.route([
+        {
+            method: 'GET',
+            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
+            handler: sthGetDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator,
+                    query: {
+                        lastN: joi
+                            .number()
+                            .integer()
+                            .greater(-1)
+                            .optional(),
+                        hLimit: joi
+                            .number()
+                            .integer()
+                            .greater(-1)
+                            .optional(),
+                        hOffset: joi
+                            .number()
+                            .integer()
+                            .greater(-1)
+                            .optional(),
+                        aggrMethod: joi
+                            .string()
+                            .valid('max', 'min', 'sum', 'sum2', 'occur')
+                            .optional(),
+                        aggrPeriod: joi
+                            .string()
+                            .required()
+                            .valid('month', 'day', 'hour', 'minute', 'second')
+                            .optional(),
+                        dateFrom: joi.date().optional(),
+                        dateTo: joi.date().optional(),
+                        filetype: joi.string().optional(),
+                        count: joi.boolean().optional(),
+                    },
+                },
+            },
+        },
+        {
+            method: 'GET',
+            path: '/version',
+            handler: sthGetVersionHandler,
+        },
+        {
+            method: 'POST',
+            path: '/notify',
+            handler: sthNotificationHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator,
+                },
+            },
+        },
+        {
+            method: 'DELETE',
+            path: '/STH/v1/contextEntities',
+            handler: sthRemoveDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator,
+                },
+            },
+        },
+        {
+            method: 'DELETE',
+            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}',
+            handler: sthRemoveDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator,
+                },
+            },
+        },
+        {
+            method: 'DELETE',
+            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
+            handler: sthRemoveDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator,
+                },
+            },
+        },
+        {
+            method: 'PUT',
+            path: '/admin/log',
+            handler: sthSetLogLevelHandler,
+            config: {
+                validate: {
+                    query: {
+                        level: joi
+                            .string()
+                            .insensitive()
+                            .valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG')
+                            .required(),
+                    },
+                },
+            },
+        },
+        {
+            method: 'GET',
+            path: '/admin/log',
+            handler: sthGetLogLevelHandler,
+        },
+        {
+            method: '*',
+            path: '/{p*}',
+            handler: sthNotFoundHandler,
+        },
+    ]);
 
-  // Start the server
-  server.start(function (err) {
-    return callback(err, server);
-  });
+    // Start the server
+    server.start(function(err) {
+        return callback(err, server);
+    });
 }
 
 /**
@@ -187,15 +205,12 @@ function doStartServer(host, port, callback) {
  * @param {Function} callback Callback function to notify the result of the operation
  */
 function startServer(host, port, callback) {
-  if (server && server.info && server.info.started) {
-    sthLogger.info(
-      sthConfig.LOGGING_CONTEXT.SERVER_STOP,
-      'STH server already started'
-    );
-    return process.nextTick(callback.bind(null, null, server));
-  } else {
-    doStartServer(host, port, callback);
-  }
+    if (server && server.info && server.info.started) {
+        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'STH server already started');
+        return process.nextTick(callback.bind(null, null, server));
+    } else {
+        doStartServer(host, port, callback);
+    }
 }
 
 /**
@@ -204,26 +219,17 @@ function startServer(host, port, callback) {
  *  of the operation
  */
 function stopServer(callback) {
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.SERVER_STOP,
-    'Stopping the STH server...'
-  );
-  if (server && server.info && server.info.started) {
-    server.stop(function (err) {
-      // Server successfully stopped
-      sthLogger.info(
-        sthConfig.LOGGING_CONTEXT.SERVER_STOP,
-        'hapi server successfully stopped'
-      );
-      return callback(err);
-    });
-  } else {
-    sthLogger.info(
-      sthConfig.LOGGING_CONTEXT.SERVER_STOP,
-      'No hapi server running'
-    );
-    return process.nextTick(callback);
-  }
+    sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'Stopping the STH server...');
+    if (server && server.info && server.info.started) {
+        server.stop(function(err) {
+            // Server successfully stopped
+            sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'hapi server successfully stopped');
+            return callback(err);
+        });
+    } else {
+        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'No hapi server running');
+        return process.nextTick(callback);
+    }
 }
 
 /**
@@ -231,24 +237,24 @@ function stopServer(callback) {
  * @return {{attendedRequests: number}}
  */
 function getKPIs() {
-  return {
-    attendedRequests: attendedRequests
-  };
+    return {
+        attendedRequests: attendedRequests,
+    };
 }
 
 /**
  * Resets the server KPIs
  */
 function resetKPIs() {
-  attendedRequests = 0;
+    attendedRequests = 0;
 }
 
 module.exports = {
-  get server() {
-    return server;
-  },
-  startServer: startServer,
-  stopServer: stopServer,
-  getKPIs: getKPIs,
-  resetKPIs: resetKPIs
+    get server() {
+        return server;
+    },
+    startServer: startServer,
+    stopServer: stopServer,
+    getKPIs: getKPIs,
+    resetKPIs: resetKPIs,
 };

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -75,7 +75,7 @@ function doStartServer(host, port, callback) {
 
     server.connection({
         host: host,
-        port: port,
+        port: port
     });
 
     server.route([
@@ -114,15 +114,15 @@ function doStartServer(host, port, callback) {
                         dateFrom: joi.date().optional(),
                         dateTo: joi.date().optional(),
                         filetype: joi.string().optional(),
-                        count: joi.boolean().optional(),
-                    },
-                },
-            },
+                        count: joi.boolean().optional()
+                    }
+                }
+            }
         },
         {
             method: 'GET',
             path: '/version',
-            handler: sthGetVersionHandler,
+            handler: sthGetVersionHandler
         },
         {
             method: 'POST',
@@ -130,9 +130,9 @@ function doStartServer(host, port, callback) {
             handler: sthNotificationHandler,
             config: {
                 validate: {
-                    headers: sthHeaderValidator,
-                },
-            },
+                    headers: sthHeaderValidator
+                }
+            }
         },
         {
             method: 'DELETE',
@@ -140,9 +140,9 @@ function doStartServer(host, port, callback) {
             handler: sthRemoveDataHandler,
             config: {
                 validate: {
-                    headers: sthHeaderValidator,
-                },
-            },
+                    headers: sthHeaderValidator
+                }
+            }
         },
         {
             method: 'DELETE',
@@ -150,9 +150,9 @@ function doStartServer(host, port, callback) {
             handler: sthRemoveDataHandler,
             config: {
                 validate: {
-                    headers: sthHeaderValidator,
-                },
-            },
+                    headers: sthHeaderValidator
+                }
+            }
         },
         {
             method: 'DELETE',
@@ -160,9 +160,9 @@ function doStartServer(host, port, callback) {
             handler: sthRemoveDataHandler,
             config: {
                 validate: {
-                    headers: sthHeaderValidator,
-                },
-            },
+                    headers: sthHeaderValidator
+                }
+            }
         },
         {
             method: 'PUT',
@@ -175,21 +175,21 @@ function doStartServer(host, port, callback) {
                             .string()
                             .insensitive()
                             .valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG')
-                            .required(),
-                    },
-                },
-            },
+                            .required()
+                    }
+                }
+            }
         },
         {
             method: 'GET',
             path: '/admin/log',
-            handler: sthGetLogLevelHandler,
+            handler: sthGetLogLevelHandler
         },
         {
             method: '*',
             path: '/{p*}',
-            handler: sthNotFoundHandler,
-        },
+            handler: sthNotFoundHandler
+        }
     ]);
 
     // Start the server
@@ -238,7 +238,7 @@ function stopServer(callback) {
  */
 function getKPIs() {
     return {
-        attendedRequests: attendedRequests,
+        attendedRequests: attendedRequests
     };
 }
 
@@ -256,5 +256,5 @@ module.exports = {
     startServer: startServer,
     stopServer: stopServer,
     getKPIs: getKPIs,
-    resetKPIs: resetKPIs,
+    resetKPIs: resetKPIs
 };

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -87,30 +87,18 @@ function doStartServer(host, port, callback) {
                 validate: {
                     headers: sthHeaderValidator,
                     query: {
-                        lastN: joi
-                            .number()
-                            .integer()
-                            .greater(-1)
-                            .optional(),
-                        hLimit: joi
-                            .number()
-                            .integer()
-                            .greater(-1)
-                            .optional(),
-                        hOffset: joi
-                            .number()
-                            .integer()
-                            .greater(-1)
-                            .optional(),
-                        aggrMethod: joi
-                            .string()
-                            .valid('max', 'min', 'sum', 'sum2', 'occur')
-                            .optional(),
-                        aggrPeriod: joi
-                            .string()
-                            .required()
-                            .valid('month', 'day', 'hour', 'minute', 'second')
-                            .optional(),
+                        // prettier-ignore
+                        lastN: joi.number().integer().greater(-1).optional(),
+                        // prettier-ignore
+                        hLimit: joi.number().integer().greater(-1).optional(),
+                        // prettier-ignore
+                        hOffset: joi.number().integer().greater(-1).optional(),
+                        // prettier-ignore
+                        aggrMethod: joi.string().valid(
+                            'max', 'min', 'sum', 'sum2', 'occur').optional(),
+                        // prettier-ignore
+                        aggrPeriod: joi.string().required().valid(
+                            'month', 'day', 'hour', 'minute', 'second').optional(),
                         dateFrom: joi.date().optional(),
                         dateTo: joi.date().optional(),
                         filetype: joi.string().optional(),
@@ -171,11 +159,8 @@ function doStartServer(host, port, callback) {
             config: {
                 validate: {
                     query: {
-                        level: joi
-                            .string()
-                            .insensitive()
-                            .valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG')
-                            .required()
+                        // prettier-ignore
+                        level: joi.string().insensitive().valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG').required()
                     }
                 }
             }

--- a/lib/server/utils/sthServerUtils.js
+++ b/lib/server/utils/sthServerUtils.js
@@ -33,7 +33,7 @@ var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
  * @return {string} The correlator, if any
  */
 function getCorrelator(request) {
-  return request && request.headers[sthConfig.HEADER.CORRELATOR];
+    return request && request.headers[sthConfig.HEADER.CORRELATOR];
 }
 
 /**
@@ -42,7 +42,7 @@ function getCorrelator(request) {
  * @param {object} response The response
  */
 function addFiwareCorrelator(request, response) {
-  response.header(sthConfig.HEADER.CORRELATOR, getCorrelator(request) || request.sth.context.trans);
+    response.header(sthConfig.HEADER.CORRELATOR, getCorrelator(request) || request.sth.context.trans);
 }
 
 /**
@@ -51,7 +51,7 @@ function addFiwareCorrelator(request, response) {
  * @param {object} response The response
  */
 function addFiwareTotalCount(totalCount, response) {
-  response.header(sthConfig.HEADER.FIWARE_TOTAL_COUNT, totalCount);
+    response.header(sthConfig.HEADER.FIWARE_TOTAL_COUNT, totalCount);
 }
 
 /**
@@ -59,7 +59,7 @@ function addFiwareTotalCount(totalCount, response) {
  * @return {string} The generated transaction
  */
 function createTransaction() {
-  return uuid.v4();
+    return uuid.v4();
 }
 
 /**
@@ -68,11 +68,11 @@ function createTransaction() {
  * @return {string} The operation type
  */
 function getOperationType(request) {
-  if (!request) {
-    return sthConfig.OPERATION_TYPE.SERVER_LOG;
-  } else {
-    return sthConfig.OPERATION_TYPE_PREFIX + request.method.toUpperCase();
-  }
+    if (!request) {
+        return sthConfig.OPERATION_TYPE.SERVER_LOG;
+    } else {
+        return sthConfig.OPERATION_TYPE_PREFIX + request.method.toUpperCase();
+    }
 }
 
 /**
@@ -81,7 +81,7 @@ function getOperationType(request) {
  * @returns {Array} An empty array
  */
 function getEmptyResponse() {
-  return [];
+    return [];
 }
 
 /**
@@ -94,28 +94,28 @@ function getEmptyResponse() {
  * @return {Object} The payload using NGSI format
  */
 function getNGSIPayload(entityId, entityType, attrName, payload) {
-  var ngsiResponse = {
-    contextResponses: [
-      {
-        contextElement: {
-          attributes: [
+    var ngsiResponse = {
+        contextResponses: [
             {
-              name: attrName,
-              values: payload
-            }
-          ],
-          id: entityId,
-          isPattern: false,
-          type: entityType
-        },
-        statusCode: {
-          code: '200',
-          reasonPhrase: 'OK'
-        }
-      }
-    ]
-  };
-  return ngsiResponse;
+                contextElement: {
+                    attributes: [
+                        {
+                            name: attrName,
+                            values: payload,
+                        },
+                    ],
+                    id: entityId,
+                    isPattern: false,
+                    type: entityType,
+                },
+                statusCode: {
+                    code: '200',
+                    reasonPhrase: 'OK',
+                },
+            },
+        ],
+    };
+    return ngsiResponse;
 }
 
 /**
@@ -124,23 +124,23 @@ function getNGSIPayload(entityId, entityType, attrName, payload) {
  * @return {Object} The context to be used for logging
  */
 function getContext(request) {
-  var transactionId = createTransaction();
-  return {
-    corr: getCorrelator(request) || transactionId,
-    trans: transactionId,
-    op: getOperationType(request),
-    from: request.headers[sthConfig.HEADER.X_REAL_IP] || 'n/a',
-    srv: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
-    subsrv: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
-    comp: 'STH'
-  };
+    var transactionId = createTransaction();
+    return {
+        corr: getCorrelator(request) || transactionId,
+        trans: transactionId,
+        op: getOperationType(request),
+        from: request.headers[sthConfig.HEADER.X_REAL_IP] || 'n/a',
+        srv: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
+        subsrv: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
+        comp: 'STH',
+    };
 }
 
 module.exports = {
-  addFiwareCorrelator: addFiwareCorrelator,
-  addFiwareTotalCount: addFiwareTotalCount,
-  getContext: getContext,
-  getCorrelator: getCorrelator,
-  getEmptyResponse: getEmptyResponse,
-  getNGSIPayload: getNGSIPayload
+    addFiwareCorrelator: addFiwareCorrelator,
+    addFiwareTotalCount: addFiwareTotalCount,
+    getContext: getContext,
+    getCorrelator: getCorrelator,
+    getEmptyResponse: getEmptyResponse,
+    getNGSIPayload: getNGSIPayload,
 };

--- a/lib/server/utils/sthServerUtils.js
+++ b/lib/server/utils/sthServerUtils.js
@@ -101,19 +101,19 @@ function getNGSIPayload(entityId, entityType, attrName, payload) {
                     attributes: [
                         {
                             name: attrName,
-                            values: payload,
-                        },
+                            values: payload
+                        }
                     ],
                     id: entityId,
                     isPattern: false,
-                    type: entityType,
+                    type: entityType
                 },
                 statusCode: {
                     code: '200',
-                    reasonPhrase: 'OK',
-                },
-            },
-        ],
+                    reasonPhrase: 'OK'
+                }
+            }
+        ]
     };
     return ngsiResponse;
 }
@@ -132,7 +132,7 @@ function getContext(request) {
         from: request.headers[sthConfig.HEADER.X_REAL_IP] || 'n/a',
         srv: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
         subsrv: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
-        comp: 'STH',
+        comp: 'STH'
     };
 }
 
@@ -142,5 +142,5 @@ module.exports = {
     getContext: getContext,
     getCorrelator: getCorrelator,
     getEmptyResponse: getEmptyResponse,
-    getNGSIPayload: getNGSIPayload,
+    getNGSIPayload: getNGSIPayload
 };

--- a/lib/server/validators/sthHeaderValidator.js
+++ b/lib/server/validators/sthHeaderValidator.js
@@ -36,28 +36,30 @@ var boom = require('boom');
  * @return {*} This function does not return anything of interest
  */
 function headerValidator(value, options, next) {
-  var error, message;
+    var error, message;
 
-  if (!value[sthConfig.HEADER.FIWARE_SERVICE]) {
-    message = 'error=child "' + sthConfig.HEADER.FIWARE_SERVICE + '" fails because [' +
-      sthConfig.HEADER.FIWARE_SERVICE + ' is required]';
-    sthLogger.warn(
-      sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-      message
-    );
-    error = boom.badRequest(message);
-    return next(error);
-  } else if (!value[sthConfig.HEADER.FIWARE_SERVICE_PATH]) {
-    message = 'child "' + sthConfig.HEADER.FIWARE_SERVICE_PATH + '" fails because [' +
-      sthConfig.HEADER.FIWARE_SERVICE_PATH + ' is required]';
-    sthLogger.warn(
-      sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-      message
-    );
-    error = boom.badRequest(message);
-    return next(error);
-  }
-  return next();
+    if (!value[sthConfig.HEADER.FIWARE_SERVICE]) {
+        message =
+            'error=child "' +
+            sthConfig.HEADER.FIWARE_SERVICE +
+            '" fails because [' +
+            sthConfig.HEADER.FIWARE_SERVICE +
+            ' is required]';
+        sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, message);
+        error = boom.badRequest(message);
+        return next(error);
+    } else if (!value[sthConfig.HEADER.FIWARE_SERVICE_PATH]) {
+        message =
+            'child "' +
+            sthConfig.HEADER.FIWARE_SERVICE_PATH +
+            '" fails because [' +
+            sthConfig.HEADER.FIWARE_SERVICE_PATH +
+            ' is required]';
+        sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, message);
+        error = boom.badRequest(message);
+        return next(error);
+    }
+    return next();
 }
 
 module.exports = headerValidator;

--- a/lib/server/validators/sthHeaderValidator.js
+++ b/lib/server/validators/sthHeaderValidator.js
@@ -39,22 +39,16 @@ function headerValidator(value, options, next) {
     var error, message;
 
     if (!value[sthConfig.HEADER.FIWARE_SERVICE]) {
-        message =
-            'error=child "' +
-            sthConfig.HEADER.FIWARE_SERVICE +
-            '" fails because [' +
-            sthConfig.HEADER.FIWARE_SERVICE +
-            ' is required]';
+        // prettier-ignore
+        message = 'error=child "' + sthConfig.HEADER.FIWARE_SERVICE + '" fails because [' + 
+            sthConfig.HEADER.FIWARE_SERVICE + ' is required]';
         sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, message);
         error = boom.badRequest(message);
         return next(error);
     } else if (!value[sthConfig.HEADER.FIWARE_SERVICE_PATH]) {
-        message =
-            'child "' +
-            sthConfig.HEADER.FIWARE_SERVICE_PATH +
-            '" fails because [' +
-            sthConfig.HEADER.FIWARE_SERVICE_PATH +
-            ' is required]';
+        // prettier-ignore
+        message = 'child "' + sthConfig.HEADER.FIWARE_SERVICE_PATH + '" fails because [' + 
+            sthConfig.HEADER.FIWARE_SERVICE_PATH + ' is required]';
         sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, message);
         error = boom.badRequest(message);
         return next(error);

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -96,7 +96,7 @@ function startup(callback) {
             dbURI: sthConfig.DB_URI,
             replicaSet: sthConfig.REPLICA_SET,
             database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-            poolSize: sthConfig.POOL_SIZE,
+            poolSize: sthConfig.POOL_SIZE
         },
         function(err) {
             if (err) {
@@ -161,5 +161,5 @@ module.exports = {
     get sthDatabase() {
         return sthDatabase;
     },
-    exitGracefully: exitGracefully,
+    exitGracefully: exitGracefully
 };

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -118,13 +118,10 @@ function startup(callback) {
                         sthServer.server.info.uri
                     );
                     proofOfLifeInterval = setInterval(function() {
-                        sthLogger.info(
-                            sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-                            'Everything OK, ' +
-                                sthServer.getKPIs().attendedRequests +
-                                ' requests attended in the last ' +
-                                sthConfig.PROOF_OF_LIFE_INTERVAL +
-                                's interval'
+                        // prettier-ignore
+                        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'Everything OK, ' + 
+                            sthServer.getKPIs().attendedRequests + ' requests attended in the last ' + 
+                            sthConfig.PROOF_OF_LIFE_INTERVAL + 's interval'
                         );
                         sthServer.resetKPIs();
                     }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -27,11 +27,13 @@ var ROOT_PATH = require('app-root-path');
 var sthLogger = require('logops');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
 var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils.js');
-var sthDatabaseNaming = require(ROOT_PATH + '/lib/database/model/sthDatabaseNaming');
+var sthDatabaseNaming = require(ROOT_PATH +
+  '/lib/database/model/sthDatabaseNaming');
 var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
 var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
 
-var isStarted = false, proofOfLifeInterval;
+var isStarted = false,
+  proofOfLifeInterval;
 
 /**
  * Stops the application stopping the server after completing all the
@@ -44,7 +46,6 @@ function exitGracefully(err, callback) {
     var exitCode = 0;
     if (err) {
       exitCode = 1;
-
     } else {
       sthLogger.info(
         sthConfig.LOGGING_CONTEXT.SHUTDOWN,
@@ -63,12 +64,10 @@ function exitGracefully(err, callback) {
   if (err) {
     var message = err.toString();
     if (message.indexOf('listen EADDRINUSE') !== -1) {
-      message += ' (another STH instance maybe already listening on the same port)';
+      message +=
+        ' (another STH instance maybe already listening on the same port)';
     }
-    sthLogger.error(
-      sthConfig.LOGGING_CONTEXT.SHUTDOWN,
-      message
-    );
+    sthLogger.error(sthConfig.LOGGING_CONTEXT.SHUTDOWN, message);
   }
 
   if (proofOfLifeInterval) {
@@ -106,45 +105,48 @@ function startup(callback) {
       dbURI: sthConfig.DB_URI,
       replicaSet: sthConfig.REPLICA_SET,
       database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-      poolSize: sthConfig.POOL_SIZE
+      poolSize: sthConfig.POOL_SIZE,
     },
-    function (err) {
+    function(err) {
       if (err) {
         // Error when connecting to the MongoDB database
         return exitGracefully(err, callback);
       }
 
       // Start the hapi server
-      sthServer.startServer(
-        sthConfig.STH_HOST, sthConfig.STH_PORT, function (err) {
-          if (err) {
-            sthLogger.error(
-              sthConfig.LOGGING_CONTEXT.SERVER_START,
-              err.toString()
-            );
-            // Error when starting the server
-            return exitGracefully(err, callback);
-          } else {
-            isStarted = true;
+      sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(
+        err
+      ) {
+        if (err) {
+          sthLogger.error(
+            sthConfig.LOGGING_CONTEXT.SERVER_START,
+            err.toString()
+          );
+          // Error when starting the server
+          return exitGracefully(err, callback);
+        } else {
+          isStarted = true;
+          sthLogger.info(
+            sthConfig.LOGGING_CONTEXT.SERVER_START,
+            'Server started at',
+            sthServer.server.info.uri
+          );
+          proofOfLifeInterval = setInterval(function() {
             sthLogger.info(
-              sthConfig.LOGGING_CONTEXT.SERVER_START,
-              'Server started at',
-              sthServer.server.info.uri
+              sthConfig.LOGGING_CONTEXT.SERVER_LOG,
+              'Everything OK, ' +
+                sthServer.getKPIs().attendedRequests +
+                ' requests attended in the last ' +
+                sthConfig.PROOF_OF_LIFE_INTERVAL +
+                's interval'
             );
-            proofOfLifeInterval = setInterval(function () {
-              sthLogger.info(
-                sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-                'Everything OK, ' + sthServer.getKPIs().attendedRequests + ' requests attended in the last ' +
-                sthConfig.PROOF_OF_LIFE_INTERVAL + 's interval'
-              );
-              sthServer.resetKPIs();
-            }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
-            if (callback) {
-              return callback();
-            }
+            sthServer.resetKPIs();
+          }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
+          if (callback) {
+            return callback();
           }
         }
-      );
+      });
     }
   );
 }
@@ -156,12 +158,12 @@ if (!module.parent) {
 }
 
 // In case Control+C is clicked, exit gracefully
-process.on('SIGINT', function () {
+process.on('SIGINT', function() {
   return exitGracefully(null);
 });
 
 // In case of an uncaught exception exists gracefully
-process.on('uncaughtException', function (exception) {
+process.on('uncaughtException', function(exception) {
   return exitGracefully(exception);
 });
 
@@ -173,5 +175,5 @@ module.exports = {
   get sthDatabase() {
     return sthDatabase;
   },
-  exitGracefully: exitGracefully
+  exitGracefully: exitGracefully,
 };

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -27,8 +27,7 @@ var ROOT_PATH = require('app-root-path');
 var sthLogger = require('logops');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
 var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils.js');
-var sthDatabaseNaming = require(ROOT_PATH +
-    '/lib/database/model/sthDatabaseNaming');
+var sthDatabaseNaming = require(ROOT_PATH + '/lib/database/model/sthDatabaseNaming');
 var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
 var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
 
@@ -47,10 +46,7 @@ function exitGracefully(err, callback) {
         if (err) {
             exitCode = 1;
         } else {
-            sthLogger.info(
-                sthConfig.LOGGING_CONTEXT.SHUTDOWN,
-                'Application exited successfully'
-            );
+            sthLogger.info(sthConfig.LOGGING_CONTEXT.SHUTDOWN, 'Application exited successfully');
         }
         if (callback) {
             callback(err);
@@ -64,8 +60,7 @@ function exitGracefully(err, callback) {
     if (err) {
         var message = err.toString();
         if (message.indexOf('listen EADDRINUSE') !== -1) {
-            message +=
-                ' (another STH instance maybe already listening on the same port)';
+            message += ' (another STH instance maybe already listening on the same port)';
         }
         sthLogger.error(sthConfig.LOGGING_CONTEXT.SHUTDOWN, message);
     }
@@ -92,11 +87,7 @@ function startup(callback) {
     }
 
     var version = sthUtils.getVersion();
-    sthLogger.info(
-        sthConfig.LOGGING_CONTEXT.SERVER_START,
-        'Starting up the STH server version %s...',
-        version.version
-    );
+    sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_START, 'Starting up the STH server version %s...', version.version);
 
     // Connect to the MongoDB database
     sthDatabase.connect(
@@ -104,9 +95,7 @@ function startup(callback) {
             authentication: sthConfig.DB_AUTHENTICATION,
             dbURI: sthConfig.DB_URI,
             replicaSet: sthConfig.REPLICA_SET,
-            database: sthDatabaseNaming.getDatabaseName(
-                sthConfig.DEFAULT_SERVICE
-            ),
+            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
             poolSize: sthConfig.POOL_SIZE,
         },
         function(err) {
@@ -116,41 +105,34 @@ function startup(callback) {
             }
 
             // Start the hapi server
-            sthServer.startServer(
-                sthConfig.STH_HOST,
-                sthConfig.STH_PORT,
-                function(err) {
-                    if (err) {
-                        sthLogger.error(
-                            sthConfig.LOGGING_CONTEXT.SERVER_START,
-                            err.toString()
-                        );
-                        // Error when starting the server
-                        return exitGracefully(err, callback);
-                    } else {
-                        isStarted = true;
+            sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(err) {
+                if (err) {
+                    sthLogger.error(sthConfig.LOGGING_CONTEXT.SERVER_START, err.toString());
+                    // Error when starting the server
+                    return exitGracefully(err, callback);
+                } else {
+                    isStarted = true;
+                    sthLogger.info(
+                        sthConfig.LOGGING_CONTEXT.SERVER_START,
+                        'Server started at',
+                        sthServer.server.info.uri
+                    );
+                    proofOfLifeInterval = setInterval(function() {
                         sthLogger.info(
-                            sthConfig.LOGGING_CONTEXT.SERVER_START,
-                            'Server started at',
-                            sthServer.server.info.uri
+                            sthConfig.LOGGING_CONTEXT.SERVER_LOG,
+                            'Everything OK, ' +
+                                sthServer.getKPIs().attendedRequests +
+                                ' requests attended in the last ' +
+                                sthConfig.PROOF_OF_LIFE_INTERVAL +
+                                's interval'
                         );
-                        proofOfLifeInterval = setInterval(function() {
-                            sthLogger.info(
-                                sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-                                'Everything OK, ' +
-                                    sthServer.getKPIs().attendedRequests +
-                                    ' requests attended in the last ' +
-                                    sthConfig.PROOF_OF_LIFE_INTERVAL +
-                                    's interval'
-                            );
-                            sthServer.resetKPIs();
-                        }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
-                        if (callback) {
-                            return callback();
-                        }
+                        sthServer.resetKPIs();
+                    }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
+                    if (callback) {
+                        return callback();
                     }
                 }
-            );
+            });
         }
     );
 }

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -28,12 +28,12 @@ var sthLogger = require('logops');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
 var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils.js');
 var sthDatabaseNaming = require(ROOT_PATH +
-  '/lib/database/model/sthDatabaseNaming');
+    '/lib/database/model/sthDatabaseNaming');
 var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
 var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
 
 var isStarted = false,
-  proofOfLifeInterval;
+    proofOfLifeInterval;
 
 /**
  * Stops the application stopping the server after completing all the
@@ -41,39 +41,39 @@ var isStarted = false,
  * @param {Error} err The error provoking the exit if any
  */
 function exitGracefully(err, callback) {
-  function onStopped() {
-    isStarted = false;
-    var exitCode = 0;
+    function onStopped() {
+        isStarted = false;
+        var exitCode = 0;
+        if (err) {
+            exitCode = 1;
+        } else {
+            sthLogger.info(
+                sthConfig.LOGGING_CONTEXT.SHUTDOWN,
+                'Application exited successfully'
+            );
+        }
+        if (callback) {
+            callback(err);
+        }
+        // TODO:
+        // Due to https://github.com/winstonjs/winston/issues/228 we use the
+        //  setTimeout() hack. Once the issue is solved, we will fix it.
+        setTimeout(process.exit.bind(null, exitCode), 500);
+    }
+
     if (err) {
-      exitCode = 1;
-    } else {
-      sthLogger.info(
-        sthConfig.LOGGING_CONTEXT.SHUTDOWN,
-        'Application exited successfully'
-      );
+        var message = err.toString();
+        if (message.indexOf('listen EADDRINUSE') !== -1) {
+            message +=
+                ' (another STH instance maybe already listening on the same port)';
+        }
+        sthLogger.error(sthConfig.LOGGING_CONTEXT.SHUTDOWN, message);
     }
-    if (callback) {
-      callback(err);
-    }
-    // TODO:
-    // Due to https://github.com/winstonjs/winston/issues/228 we use the
-    //  setTimeout() hack. Once the issue is solved, we will fix it.
-    setTimeout(process.exit.bind(null, exitCode), 500);
-  }
 
-  if (err) {
-    var message = err.toString();
-    if (message.indexOf('listen EADDRINUSE') !== -1) {
-      message +=
-        ' (another STH instance maybe already listening on the same port)';
+    if (proofOfLifeInterval) {
+        clearInterval(proofOfLifeInterval);
     }
-    sthLogger.error(sthConfig.LOGGING_CONTEXT.SHUTDOWN, message);
-  }
-
-  if (proofOfLifeInterval) {
-    clearInterval(proofOfLifeInterval);
-  }
-  sthServer.stopServer(sthDatabase.closeConnection.bind(null, onStopped));
+    sthServer.stopServer(sthDatabase.closeConnection.bind(null, onStopped));
 }
 
 /**
@@ -84,96 +84,100 @@ function exitGracefully(err, callback) {
  * @return {*}
  */
 function startup(callback) {
-  if (isStarted) {
-    if (callback) {
-      return process.nextTick(callback);
-    }
-    return;
-  }
-
-  var version = sthUtils.getVersion();
-  sthLogger.info(
-    sthConfig.LOGGING_CONTEXT.SERVER_START,
-    'Starting up the STH server version %s...',
-    version.version
-  );
-
-  // Connect to the MongoDB database
-  sthDatabase.connect(
-    {
-      authentication: sthConfig.DB_AUTHENTICATION,
-      dbURI: sthConfig.DB_URI,
-      replicaSet: sthConfig.REPLICA_SET,
-      database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-      poolSize: sthConfig.POOL_SIZE,
-    },
-    function(err) {
-      if (err) {
-        // Error when connecting to the MongoDB database
-        return exitGracefully(err, callback);
-      }
-
-      // Start the hapi server
-      sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(
-        err
-      ) {
-        if (err) {
-          sthLogger.error(
-            sthConfig.LOGGING_CONTEXT.SERVER_START,
-            err.toString()
-          );
-          // Error when starting the server
-          return exitGracefully(err, callback);
-        } else {
-          isStarted = true;
-          sthLogger.info(
-            sthConfig.LOGGING_CONTEXT.SERVER_START,
-            'Server started at',
-            sthServer.server.info.uri
-          );
-          proofOfLifeInterval = setInterval(function() {
-            sthLogger.info(
-              sthConfig.LOGGING_CONTEXT.SERVER_LOG,
-              'Everything OK, ' +
-                sthServer.getKPIs().attendedRequests +
-                ' requests attended in the last ' +
-                sthConfig.PROOF_OF_LIFE_INTERVAL +
-                's interval'
-            );
-            sthServer.resetKPIs();
-          }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
-          if (callback) {
-            return callback();
-          }
+    if (isStarted) {
+        if (callback) {
+            return process.nextTick(callback);
         }
-      });
+        return;
     }
-  );
+
+    var version = sthUtils.getVersion();
+    sthLogger.info(
+        sthConfig.LOGGING_CONTEXT.SERVER_START,
+        'Starting up the STH server version %s...',
+        version.version
+    );
+
+    // Connect to the MongoDB database
+    sthDatabase.connect(
+        {
+            authentication: sthConfig.DB_AUTHENTICATION,
+            dbURI: sthConfig.DB_URI,
+            replicaSet: sthConfig.REPLICA_SET,
+            database: sthDatabaseNaming.getDatabaseName(
+                sthConfig.DEFAULT_SERVICE
+            ),
+            poolSize: sthConfig.POOL_SIZE,
+        },
+        function(err) {
+            if (err) {
+                // Error when connecting to the MongoDB database
+                return exitGracefully(err, callback);
+            }
+
+            // Start the hapi server
+            sthServer.startServer(
+                sthConfig.STH_HOST,
+                sthConfig.STH_PORT,
+                function(err) {
+                    if (err) {
+                        sthLogger.error(
+                            sthConfig.LOGGING_CONTEXT.SERVER_START,
+                            err.toString()
+                        );
+                        // Error when starting the server
+                        return exitGracefully(err, callback);
+                    } else {
+                        isStarted = true;
+                        sthLogger.info(
+                            sthConfig.LOGGING_CONTEXT.SERVER_START,
+                            'Server started at',
+                            sthServer.server.info.uri
+                        );
+                        proofOfLifeInterval = setInterval(function() {
+                            sthLogger.info(
+                                sthConfig.LOGGING_CONTEXT.SERVER_LOG,
+                                'Everything OK, ' +
+                                    sthServer.getKPIs().attendedRequests +
+                                    ' requests attended in the last ' +
+                                    sthConfig.PROOF_OF_LIFE_INTERVAL +
+                                    's interval'
+                            );
+                            sthServer.resetKPIs();
+                        }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
+                        if (callback) {
+                            return callback();
+                        }
+                    }
+                }
+            );
+        }
+    );
 }
 
 // Starts the STH application up in case this file has not been 'require'd,
 //  such as, for example, for testing
 if (!module.parent) {
-  startup();
+    startup();
 }
 
 // In case Control+C is clicked, exit gracefully
 process.on('SIGINT', function() {
-  return exitGracefully(null);
+    return exitGracefully(null);
 });
 
 // In case of an uncaught exception exists gracefully
 process.on('uncaughtException', function(exception) {
-  return exitGracefully(exception);
+    return exitGracefully(exception);
 });
 
 module.exports = {
-  startup: startup,
-  get sthServer() {
-    return sthServer;
-  },
-  get sthDatabase() {
-    return sthDatabase;
-  },
-  exitGracefully: exitGracefully,
+    startup: startup,
+    get sthServer() {
+        return sthServer;
+    },
+    get sthDatabase() {
+        return sthDatabase;
+    },
+    exitGracefully: exitGracefully,
 };

--- a/lib/utils/sthError.js
+++ b/lib/utils/sthError.js
@@ -73,5 +73,5 @@ module.exports = {
     CollectionExistsError: CollectionExistsError,
     CollectionDataInferenceError: CollectionDataInferenceError,
     NotExistentCollectionError: NotExistentCollectionError,
-    NotSupportedMigration: NotSupportedMigration,
+    NotSupportedMigration: NotSupportedMigration
 };

--- a/lib/utils/sthError.js
+++ b/lib/utils/sthError.js
@@ -23,43 +23,55 @@
 
 'use strict';
 
-var CollectionDataInferenceError = function (databaseName, collectionName) {
-  Error.call(this);
-  this.code = 'COLLECTION_NAME_INFERENCE_ERROR';
-  this.name = 'CollectionNameInferenceError';
-  this.message = 'The target collection name for collection ' + collectionName + ' of database ' + databaseName +
-    ' could not be uniquely inferred';
+var CollectionDataInferenceError = function(databaseName, collectionName) {
+    Error.call(this);
+    this.code = 'COLLECTION_NAME_INFERENCE_ERROR';
+    this.name = 'CollectionNameInferenceError';
+    this.message =
+        'The target collection name for collection ' +
+        collectionName +
+        ' of database ' +
+        databaseName +
+        ' could not be uniquely inferred';
 };
 CollectionDataInferenceError.prototype = Object.create(Error.prototype);
 
 var CollectionExistsError = function(databaseName, collectionName) {
-  Error.call(this);
-  this.code = 'COLLECTION_EXISTS_ERROR';
-  this.name = 'CollectionExistsError';
-  this.message = 'The collection ' + collectionName + ' exists in the database ' + databaseName;
+    Error.call(this);
+    this.code = 'COLLECTION_EXISTS_ERROR';
+    this.name = 'CollectionExistsError';
+    this.message = 'The collection ' + collectionName + ' exists in the database ' + databaseName;
 };
 CollectionExistsError.prototype = Object.create(Error.prototype);
 
 var NotExistentCollectionError = function(databaseName, collectionName) {
-  Error.call(this);
-  this.code = 'COLLECTION_EXISTS_ERROR';
-  this.name = 'CollectionExistsError';
-  this.message = 'The collection ' + collectionName + ' does not exist in the database ' + databaseName;
+    Error.call(this);
+    this.code = 'COLLECTION_EXISTS_ERROR';
+    this.name = 'CollectionExistsError';
+    this.message = 'The collection ' + collectionName + ' does not exist in the database ' + databaseName;
 };
 NotExistentCollectionError.prototype = Object.create(Error.prototype);
 
-var NotSupportedMigration = function (databaseName, collectionName, originalDataModel, targetDataModel) {
-  Error.call(this);
-  this.code = 'NOT_SUPPORTED_MIGRATION';
-  this.name = 'NotSupportedMigration';
-  this.message = 'The collection ' + collectionName + ' of database ' + databaseName +
-    ' with data model ' + originalDataModel + ' cannot be migrated to the ' + targetDataModel + ' data model';
+var NotSupportedMigration = function(databaseName, collectionName, originalDataModel, targetDataModel) {
+    Error.call(this);
+    this.code = 'NOT_SUPPORTED_MIGRATION';
+    this.name = 'NotSupportedMigration';
+    this.message =
+        'The collection ' +
+        collectionName +
+        ' of database ' +
+        databaseName +
+        ' with data model ' +
+        originalDataModel +
+        ' cannot be migrated to the ' +
+        targetDataModel +
+        ' data model';
 };
 NotSupportedMigration.prototype = Object.create(Error.prototype);
 
 module.exports = {
-  CollectionExistsError: CollectionExistsError,
-  CollectionDataInferenceError: CollectionDataInferenceError,
-  NotExistentCollectionError: NotExistentCollectionError,
-  NotSupportedMigration: NotSupportedMigration
+    CollectionExistsError: CollectionExistsError,
+    CollectionDataInferenceError: CollectionDataInferenceError,
+    NotExistentCollectionError: NotExistentCollectionError,
+    NotSupportedMigration: NotSupportedMigration,
 };

--- a/lib/utils/sthError.js
+++ b/lib/utils/sthError.js
@@ -27,11 +27,8 @@ var CollectionDataInferenceError = function(databaseName, collectionName) {
     Error.call(this);
     this.code = 'COLLECTION_NAME_INFERENCE_ERROR';
     this.name = 'CollectionNameInferenceError';
-    this.message =
-        'The target collection name for collection ' +
-        collectionName +
-        ' of database ' +
-        databaseName +
+    // prettier-ignore
+    this.message = 'The target collection name for collection ' + collectionName + ' of database ' + databaseName +
         ' could not be uniquely inferred';
 };
 CollectionDataInferenceError.prototype = Object.create(Error.prototype);
@@ -56,16 +53,9 @@ var NotSupportedMigration = function(databaseName, collectionName, originalDataM
     Error.call(this);
     this.code = 'NOT_SUPPORTED_MIGRATION';
     this.name = 'NotSupportedMigration';
-    this.message =
-        'The collection ' +
-        collectionName +
-        ' of database ' +
-        databaseName +
-        ' with data model ' +
-        originalDataModel +
-        ' cannot be migrated to the ' +
-        targetDataModel +
-        ' data model';
+    // prettier-ignore
+    this.message =  'The collection ' + collectionName + ' of database ' + databaseName + ' with data model ' +
+        originalDataModel + ' cannot be migrated to the ' + targetDataModel + ' data model';
 };
 NotSupportedMigration.prototype = Object.create(Error.prototype);
 

--- a/lib/utils/sthUtils.js
+++ b/lib/utils/sthUtils.js
@@ -192,20 +192,14 @@ function getISODateString(date) {
     }
 
     return (
-        date.getUTCFullYear() +
-        '-' +
-        pad(date.getUTCMonth() + 1) +
-        '-' +
-        pad(date.getUTCDate()) +
-        'T' +
-        pad(date.getUTCHours()) +
-        ':' +
-        pad(date.getUTCMinutes()) +
-        ':' +
-        pad(date.getUTCSeconds()) +
-        '.' +
-        pad(date.getUTCMilliseconds(), true) +
-        'Z'
+        // prettier-ignore
+        date.getUTCFullYear() + '-' +
+        pad(date.getUTCMonth() + 1) + '-' +
+        pad(date.getUTCDate()) + 'T' +
+        pad(date.getUTCHours()) + ':' +
+        pad(date.getUTCMinutes()) + ':' +
+        pad(date.getUTCSeconds()) + '.' +
+        pad(date.getUTCMilliseconds(), true) + 'Z'
     );
 }
 

--- a/lib/utils/sthUtils.js
+++ b/lib/utils/sthUtils.js
@@ -37,33 +37,33 @@ var sthPackage = require(ROOT_PATH + '/package.json');
  * @returns {Date} The origin calculated for the passed date and resolution
  */
 function getOrigin(aDate, resolution) {
-  var year = aDate.getUTCFullYear(),
-    month = aDate.getUTCMonth(),
-    date = aDate.getUTCDate(),
-    hours = aDate.getUTCHours(),
-    minutes = aDate.getUTCMinutes(),
-    seconds = aDate.getUTCSeconds();
+    var year = aDate.getUTCFullYear(),
+        month = aDate.getUTCMonth(),
+        date = aDate.getUTCDate(),
+        hours = aDate.getUTCHours(),
+        minutes = aDate.getUTCMinutes(),
+        seconds = aDate.getUTCSeconds();
 
-  switch (resolution) {
-    case sthConfig.RESOLUTION.MONTH:
-      month = 0;
-    /* falls through */
-    case sthConfig.RESOLUTION.DAY:
-      date = 1;
-    /* falls through */
-    case sthConfig.RESOLUTION.HOUR:
-      hours = 0;
-    /* falls through */
-    case sthConfig.RESOLUTION.MINUTE:
-      minutes = 0;
-    /* falls through */
-    case sthConfig.RESOLUTION.SECOND:
-      seconds = 0;
-      break;
-    default:
-      return null;
-  }
-  return new Date(Date.UTC(year, month, date, hours, minutes, seconds));
+    switch (resolution) {
+        case sthConfig.RESOLUTION.MONTH:
+            month = 0;
+        /* falls through */
+        case sthConfig.RESOLUTION.DAY:
+            date = 1;
+        /* falls through */
+        case sthConfig.RESOLUTION.HOUR:
+            hours = 0;
+        /* falls through */
+        case sthConfig.RESOLUTION.MINUTE:
+            minutes = 0;
+        /* falls through */
+        case sthConfig.RESOLUTION.SECOND:
+            seconds = 0;
+            break;
+        default:
+            return null;
+    }
+    return new Date(Date.UTC(year, month, date, hours, minutes, seconds));
 }
 
 /**
@@ -76,34 +76,34 @@ function getOrigin(aDate, resolution) {
  * @returns {Date} The origin calculated for the passed date and resolution
  */
 function getOriginStart(aDate, resolution) {
-  var year = aDate.getUTCFullYear(),
-    month = aDate.getUTCMonth(),
-    date = aDate.getUTCDate(),
-    hours = aDate.getUTCHours(),
-    minutes = aDate.getUTCMinutes(),
-    seconds = aDate.getUTCSeconds(),
-    milliseconds = aDate.getUTCMilliseconds();
+    var year = aDate.getUTCFullYear(),
+        month = aDate.getUTCMonth(),
+        date = aDate.getUTCDate(),
+        hours = aDate.getUTCHours(),
+        minutes = aDate.getUTCMinutes(),
+        seconds = aDate.getUTCSeconds(),
+        milliseconds = aDate.getUTCMilliseconds();
 
-  switch (resolution) {
-    case sthConfig.RESOLUTION.MONTH:
-      date = 1;
-    /* falls through */
-    case sthConfig.RESOLUTION.DAY:
-      hours = 0;
-    /* falls through */
-    case sthConfig.RESOLUTION.HOUR:
-      minutes = 0;
-    /* falls through */
-    case sthConfig.RESOLUTION.MINUTE:
-      seconds = 0;
-    /* falls through */
-    case sthConfig.RESOLUTION.SECOND:
-      milliseconds = 0;
-      break;
-    default:
-      return null;
-  }
-  return new Date(Date.UTC(year, month, date, hours, minutes, seconds, milliseconds));
+    switch (resolution) {
+        case sthConfig.RESOLUTION.MONTH:
+            date = 1;
+        /* falls through */
+        case sthConfig.RESOLUTION.DAY:
+            hours = 0;
+        /* falls through */
+        case sthConfig.RESOLUTION.HOUR:
+            minutes = 0;
+        /* falls through */
+        case sthConfig.RESOLUTION.MINUTE:
+            seconds = 0;
+        /* falls through */
+        case sthConfig.RESOLUTION.SECOND:
+            milliseconds = 0;
+            break;
+        default:
+            return null;
+    }
+    return new Date(Date.UTC(year, month, date, hours, minutes, seconds, milliseconds));
 }
 
 /**
@@ -116,34 +116,34 @@ function getOriginStart(aDate, resolution) {
  * @returns {Date} The origin calculated for the passed date and resolution
  */
 function getOriginEnd(aDate, resolution) {
-  var year = aDate.getUTCFullYear(),
-    month = aDate.getUTCMonth(),
-    date = aDate.getUTCDate(),
-    hours = aDate.getUTCHours(),
-    minutes = aDate.getUTCMinutes(),
-    seconds = aDate.getUTCSeconds(),
-    milliseconds = aDate.getUTCMilliseconds();
+    var year = aDate.getUTCFullYear(),
+        month = aDate.getUTCMonth(),
+        date = aDate.getUTCDate(),
+        hours = aDate.getUTCHours(),
+        minutes = aDate.getUTCMinutes(),
+        seconds = aDate.getUTCSeconds(),
+        milliseconds = aDate.getUTCMilliseconds();
 
-  switch (resolution) {
-    case sthConfig.RESOLUTION.MONTH:
-      date = 31;
-    /* falls through */
-    case sthConfig.RESOLUTION.DAY:
-      hours = 23;
-    /* falls through */
-    case sthConfig.RESOLUTION.HOUR:
-      minutes = 59;
-    /* falls through */
-    case sthConfig.RESOLUTION.MINUTE:
-      seconds = 59;
-    /* falls through */
-    case sthConfig.RESOLUTION.SECOND:
-      milliseconds = 999;
-      break;
-    default:
-      return null;
-  }
-  return new Date(Date.UTC(year, month, date, hours, minutes, seconds, milliseconds));
+    switch (resolution) {
+        case sthConfig.RESOLUTION.MONTH:
+            date = 31;
+        /* falls through */
+        case sthConfig.RESOLUTION.DAY:
+            hours = 23;
+        /* falls through */
+        case sthConfig.RESOLUTION.HOUR:
+            minutes = 59;
+        /* falls through */
+        case sthConfig.RESOLUTION.MINUTE:
+            seconds = 59;
+        /* falls through */
+        case sthConfig.RESOLUTION.SECOND:
+            milliseconds = 999;
+            break;
+        default:
+            return null;
+    }
+    return new Date(Date.UTC(year, month, date, hours, minutes, seconds, milliseconds));
 }
 
 /**
@@ -153,25 +153,25 @@ function getOriginEnd(aDate, resolution) {
  * @return {Number} Returns the offset
  */
 function getOffset(resolution, date) {
-  var offset;
-  switch (resolution) {
-    case sthConfig.RESOLUTION.SECOND:
-      offset = date.getUTCSeconds();
-      break;
-    case sthConfig.RESOLUTION.MINUTE:
-      offset = date.getUTCMinutes();
-      break;
-    case sthConfig.RESOLUTION.HOUR:
-      offset = date.getUTCHours();
-      break;
-    case sthConfig.RESOLUTION.DAY:
-      offset = date.getUTCDate();
-      break;
-    case sthConfig.RESOLUTION.MONTH:
-      offset = date.getUTCMonth() + 1;
-      break;
-  }
-  return offset;
+    var offset;
+    switch (resolution) {
+        case sthConfig.RESOLUTION.SECOND:
+            offset = date.getUTCSeconds();
+            break;
+        case sthConfig.RESOLUTION.MINUTE:
+            offset = date.getUTCMinutes();
+            break;
+        case sthConfig.RESOLUTION.HOUR:
+            offset = date.getUTCHours();
+            break;
+        case sthConfig.RESOLUTION.DAY:
+            offset = date.getUTCDate();
+            break;
+        case sthConfig.RESOLUTION.MONTH:
+            offset = date.getUTCMonth() + 1;
+            break;
+    }
+    return offset;
 }
 
 /**
@@ -179,25 +179,34 @@ function getOffset(resolution, date) {
  * @return {string} The formatted date
  */
 function getISODateString(date) {
-  function pad(n, isMs) {
-    var result = n;
-    if (!isMs) {
-      result = (n < 10) ? '0' + n : n;
-    } else if (n < 10) {
-      result = '00' + n;
-    } else if (n < 100) {
-      result = '0' + n;
+    function pad(n, isMs) {
+        var result = n;
+        if (!isMs) {
+            result = n < 10 ? '0' + n : n;
+        } else if (n < 10) {
+            result = '00' + n;
+        } else if (n < 100) {
+            result = '0' + n;
+        }
+        return result;
     }
-    return result;
-  }
 
-  return date.getUTCFullYear() + '-' +
-    pad(date.getUTCMonth() + 1) + '-' +
-    pad(date.getUTCDate()) + 'T' +
-    pad(date.getUTCHours()) + ':' +
-    pad(date.getUTCMinutes()) + ':' +
-    pad(date.getUTCSeconds()) + '.' +
-    pad(date.getUTCMilliseconds(), true) + 'Z';
+    return (
+        date.getUTCFullYear() +
+        '-' +
+        pad(date.getUTCMonth() + 1) +
+        '-' +
+        pad(date.getUTCDate()) +
+        'T' +
+        pad(date.getUTCHours()) +
+        ':' +
+        pad(date.getUTCMinutes()) +
+        ':' +
+        pad(date.getUTCSeconds()) +
+        '.' +
+        pad(date.getUTCMilliseconds(), true) +
+        'Z'
+    );
 }
 
 /**
@@ -205,16 +214,16 @@ function getISODateString(date) {
  * @return {object} A JSON-formatted object including the version information
  */
 function getVersion() {
-  var message = {};
-  if (sthPackage) {
-    if (sthPackage.version) {
-      message.version = sthPackage.version;
+    var message = {};
+    if (sthPackage) {
+        if (sthPackage.version) {
+            message.version = sthPackage.version;
+        }
     }
-  }
-  if (Object.getOwnPropertyNames(message).length === 0) {
-    message.version = 'No version information available';
-  }
-  return message;
+    if (Object.getOwnPropertyNames(message).length === 0) {
+        message.version = 'No version information available';
+    }
+    return message;
 }
 
 /**
@@ -223,7 +232,7 @@ function getVersion() {
  * @return {boolean} True if the passed argument is an instantiable date, false otherwise
  */
 function isDate(date) {
-  return (date instanceof Date) || !isNaN(Date.parse(date));
+    return date instanceof Date || !isNaN(Date.parse(date));
 }
 
 /**
@@ -233,13 +242,13 @@ function isDate(date) {
  * @return {*} The metadata value, if any
  */
 function getMetadataValue(metadatas, name) {
-  if (metadatas) {
-    for (var i = 0; i < metadatas.length; i++) {
-      if (metadatas[i].name === name) {
-        return metadatas[i].value;
-      }
+    if (metadatas) {
+        for (var i = 0; i < metadatas.length; i++) {
+            if (metadatas[i].name === name) {
+                return metadatas[i].value;
+            }
+        }
     }
-  }
 }
 
 /**
@@ -250,12 +259,12 @@ function getMetadataValue(metadatas, name) {
  * @return {*} The atribute timestamp
  */
 function getAttributeTimestamp(attribute, recvTime) {
-  var timeInstant = getMetadataValue(attribute.metadatas, 'TimeInstant');
-  if (isDate(timeInstant)) {
-    return new Date(timeInstant);
-  } else {
-    return recvTime;
-  }
+    var timeInstant = getMetadataValue(attribute.metadatas, 'TimeInstant');
+    if (isDate(timeInstant)) {
+        return new Date(timeInstant);
+    } else {
+        return recvTime;
+    }
 }
 
 /**
@@ -264,21 +273,21 @@ function getAttributeTimestamp(attribute, recvTime) {
  * @return {string} The aggrgation type for the passed attribute value
  */
 function getAggregationType(attrValue) {
-  // isNaN(' ') is false so an additional check is needed to deal with attributes values to one or more blank spaces
-  if (!isNaN(attrValue) && !(typeof(attrValue) === 'string' && attrValue.trim() === '')) {
-    return sthConfig.AGGREGATIONS.NUMERIC;
-  } else if (typeof(attrValue) === 'string') {
-    return sthConfig.AGGREGATIONS.TEXTUAL;
-  }
+    // isNaN(' ') is false so an additional check is needed to deal with attributes values to one or more blank spaces
+    if (!isNaN(attrValue) && !(typeof attrValue === 'string' && attrValue.trim() === '')) {
+        return sthConfig.AGGREGATIONS.NUMERIC;
+    } else if (typeof attrValue === 'string') {
+        return sthConfig.AGGREGATIONS.TEXTUAL;
+    }
 }
 
 module.exports = {
-  getOrigin: getOrigin,
-  getOriginStart: getOriginStart,
-  getOriginEnd: getOriginEnd,
-  getOffset: getOffset,
-  getISODateString: getISODateString,
-  getVersion: getVersion,
-  getAttributeTimestamp: getAttributeTimestamp,
-  getAggregationType: getAggregationType
+    getOrigin: getOrigin,
+    getOriginStart: getOriginStart,
+    getOriginEnd: getOriginEnd,
+    getOffset: getOffset,
+    getISODateString: getISODateString,
+    getVersion: getVersion,
+    getAttributeTimestamp: getAttributeTimestamp,
+    getAggregationType: getAggregationType,
 };

--- a/lib/utils/sthUtils.js
+++ b/lib/utils/sthUtils.js
@@ -289,5 +289,5 @@ module.exports = {
     getISODateString: getISODateString,
     getVersion: getVersion,
     getAttributeTimestamp: getAttributeTimestamp,
-    getAggregationType: getAggregationType,
+    getAggregationType: getAggregationType
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "clear-require": "~1.0.1",
     "coveralls": "~3.0.2",
+    "eslint-plugin-jasmine": "^2.10.1",
     "expect.js": "~0.3.1",
     "husky": "~1.1.0",
     "istanbul": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "clear-require": "~1.0.1",
     "coveralls": "~3.0.2",
-    "eslint-plugin-jasmine": "^2.10.1",
+    "eslint-plugin-jasmine": "~2.10.1",
     "expect.js": "~0.3.1",
     "husky": "~1.1.0",
     "istanbul": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clear-require": "~1.0.1",
     "coveralls": "~3.0.2",
     "expect.js": "~0.3.1",
-    "husky": "^1.1.0",
+    "husky": "~1.1.0",
     "istanbul": "~0.4.5",
     "jshint": "~2.9.6",
     "lint-staged": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
-    "prettier": "prettier --tab-width 4 --single-quote --trailing-comma es5 --write **/*.js *.js",
+    "prettier": "prettier --config .prettierrc.json --write '**/**/**/*.js' '**/**/*.js' '**/*.js' '*.js'",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
@@ -72,7 +72,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --tab-width 4 --parser flow --single-quote --trailing-comma es5 --write",
+      "prettier --config .prettierrc.json --write",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
-    "prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js",
+    "prettier": "prettier --tab-width 4 --single-quote --trailing-comma es5 --write **/*.js *.js",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
@@ -72,7 +72,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --parser flow --single-quote --trailing-comma es5 --write",
+      "prettier --tab-width 4 --parser flow --single-quote --trailing-comma es5 --write",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -26,17 +26,21 @@
     "test": "mocha --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
+    "prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/unit/' --reporter spec --timeout 3000 --ui bdd --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "devDependencies": {
-    "jshint": "~2.9.6",
     "clear-require": "~1.0.1",
     "coveralls": "~3.0.2",
     "expect.js": "~0.3.1",
+    "husky": "^1.1.0",
     "istanbul": "~0.4.5",
+    "jshint": "~2.9.6",
+    "lint-staged": "^7.3.0",
     "mocha": "5.2.0",
+    "prettier": "^1.14.2",
     "proxyquire": "1.7.10",
     "request": "2.88.0",
     "watch": "~1.0.2"
@@ -60,5 +64,16 @@
     "rfc5987-value-chars": "~1.0.0",
     "uuid": "~2.0.1"
   },
-  "keywords": []
+  "keywords": [],
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --parser flow --single-quote --trailing-comma es5 --write",
+      "git add"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "husky": "~1.1.0",
     "istanbul": "~0.4.5",
     "jshint": "~2.9.6",
-    "lint-staged": "^7.3.0",
+    "lint-staged": "~7.3.0",
     "mocha": "5.2.0",
-    "prettier": "^1.14.2",
+    "prettier": "~1.14.2",
     "proxyquire": "1.7.10",
     "request": "2.88.0",
     "watch": "~1.0.2"

--- a/resources/performanceTestCheck.js
+++ b/resources/performanceTestCheck.js
@@ -15,14 +15,9 @@ function assertEntriesPerCollection(entriesPerCollection) {
                 var database = db.getSisterDB(databases[i].name);
                 var collections = database.getCollectionNames();
                 for (var j = 0; j < collections.length; j++) {
-                    if (
-                        collections[j].indexOf('sth_') === 0 &&
-                        collections[j].indexOf('aggr') === -1
-                    ) {
+                    if (collections[j].indexOf('sth_') === 0 && collections[j].indexOf('aggr') === -1) {
                         caseCounter++;
-                        print(
-                            '** Checking collection ' + collections[j] + '...'
-                        );
+                        print('** Checking collection ' + collections[j] + '...');
                         var count = database[collections[j]].count();
                         var percentage = (count / entriesPerCollection) * 100;
                         print(

--- a/resources/performanceTestCheck.js
+++ b/resources/performanceTestCheck.js
@@ -2,47 +2,49 @@
  * Created by gtv on 21/04/15.
  */
 function assertEntriesPerCollection(entriesPerCollection) {
-  if (!entriesPerCollection || isNaN(entriesPerCollection)) {
-    return print('Usage: assert(entriesPerCollection);');
-  } else {
-    // Get the available databases
-    var databases = db.getMongo().getDBs().databases;
-    var caseCounter = 0;
-    var errorCounter = 0;
-    for (var i = 0; i < databases.length; i++) {
-      if (databases[i].name.indexOf('sth_') === 0) {
-        print('* Checking database ' + databases[i].name + '...');
-        var database = db.getSisterDB(databases[i].name);
-        var collections = database.getCollectionNames();
-        for (var j = 0; j < collections.length; j++) {
-          if (
-            collections[j].indexOf('sth_') === 0 &&
-            collections[j].indexOf('aggr') === -1
-          ) {
-            caseCounter++;
-            print('** Checking collection ' + collections[j] + '...');
-            var count = database[collections[j]].count();
-            var percentage = (count / entriesPerCollection) * 100;
-            print(
-              '*** Expected ' +
-                entriesPerCollection +
-                ' and found ' +
-                count +
-                '... ' +
-                percentage +
-                '% ' +
-                (percentage === 100 ? 'PERFECT' : 'ERROR')
-            );
-            if (percentage !== 100) {
-              errorCounter++;
+    if (!entriesPerCollection || isNaN(entriesPerCollection)) {
+        return print('Usage: assert(entriesPerCollection);');
+    } else {
+        // Get the available databases
+        var databases = db.getMongo().getDBs().databases;
+        var caseCounter = 0;
+        var errorCounter = 0;
+        for (var i = 0; i < databases.length; i++) {
+            if (databases[i].name.indexOf('sth_') === 0) {
+                print('* Checking database ' + databases[i].name + '...');
+                var database = db.getSisterDB(databases[i].name);
+                var collections = database.getCollectionNames();
+                for (var j = 0; j < collections.length; j++) {
+                    if (
+                        collections[j].indexOf('sth_') === 0 &&
+                        collections[j].indexOf('aggr') === -1
+                    ) {
+                        caseCounter++;
+                        print(
+                            '** Checking collection ' + collections[j] + '...'
+                        );
+                        var count = database[collections[j]].count();
+                        var percentage = (count / entriesPerCollection) * 100;
+                        print(
+                            '*** Expected ' +
+                                entriesPerCollection +
+                                ' and found ' +
+                                count +
+                                '... ' +
+                                percentage +
+                                '% ' +
+                                (percentage === 100 ? 'PERFECT' : 'ERROR')
+                        );
+                        if (percentage !== 100) {
+                            errorCounter++;
+                        }
+                    }
+                }
             }
-          }
         }
-      }
+        print();
+        print('SUMARY:');
+        print('  - Passed: ' + caseCounter);
+        print('  - Errors: ' + errorCounter);
     }
-    print();
-    print('SUMARY:');
-    print('  - Passed: ' + caseCounter);
-    print('  - Errors: ' + errorCounter);
-  }
 }

--- a/resources/performanceTestCheck.js
+++ b/resources/performanceTestCheck.js
@@ -3,7 +3,7 @@
  */
 function assertEntriesPerCollection(entriesPerCollection) {
   if (!entriesPerCollection || isNaN(entriesPerCollection)) {
-    return print('Usage: assert(entriesPerCollection);')
+    return print('Usage: assert(entriesPerCollection);');
   } else {
     // Get the available databases
     var databases = db.getMongo().getDBs().databases;
@@ -15,13 +15,24 @@ function assertEntriesPerCollection(entriesPerCollection) {
         var database = db.getSisterDB(databases[i].name);
         var collections = database.getCollectionNames();
         for (var j = 0; j < collections.length; j++) {
-          if (collections[j].indexOf('sth_') === 0 && collections[j].indexOf('aggr') === -1) {
+          if (
+            collections[j].indexOf('sth_') === 0 &&
+            collections[j].indexOf('aggr') === -1
+          ) {
             caseCounter++;
             print('** Checking collection ' + collections[j] + '...');
             var count = database[collections[j]].count();
             var percentage = (count / entriesPerCollection) * 100;
-            print('*** Expected ' + entriesPerCollection + ' and found ' + count + '... ' + percentage + '% ' +
-              ((percentage === 100) ? 'PERFECT' : 'ERROR'));
+            print(
+              '*** Expected ' +
+                entriesPerCollection +
+                ' and found ' +
+                count +
+                '... ' +
+                percentage +
+                '% ' +
+                (percentage === 100 ? 'PERFECT' : 'ERROR')
+            );
             if (percentage !== 100) {
               errorCounter++;
             }

--- a/resources/performanceTestCheck.js
+++ b/resources/performanceTestCheck.js
@@ -20,16 +20,9 @@ function assertEntriesPerCollection(entriesPerCollection) {
                         print('** Checking collection ' + collections[j] + '...');
                         var count = database[collections[j]].count();
                         var percentage = (count / entriesPerCollection) * 100;
-                        print(
-                            '*** Expected ' +
-                                entriesPerCollection +
-                                ' and found ' +
-                                count +
-                                '... ' +
-                                percentage +
-                                '% ' +
-                                (percentage === 100 ? 'PERFECT' : 'ERROR')
-                        );
+                        // prettier-ignore
+                        print('*** Expected ' + entriesPerCollection + ' and found ' + count + '... ' + percentage + '% ' +
+                            (percentage === 100 ? 'PERFECT' : 'ERROR'));
                         if (percentage !== 100) {
                             errorCounter++;
                         }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -13,7 +13,7 @@
   "maxparams": 4,
   "maxdepth": 4,
   "camelcase": true,
-  "maxlen": 120,
+  "maxlen": 180,
   "node": true,
   "expr": true,
   "esversion": 6,
@@ -26,5 +26,7 @@
     "beforeEach": true,
     "afterEach": true,
     "mock": true
-  }
+  },
+  "laxbreak": true,
+  "quotmark": 0
 }

--- a/test/unit/sthConfiguration_test.js
+++ b/test/unit/sthConfiguration_test.js
@@ -30,733 +30,686 @@ var expect = require('expect.js');
 var clearRequire = require('clear-require');
 
 var DEFAULT_VALUES = {
-  LOGOPS_LEVEL: 'INFO',
-  LOGOPS_FORMAT: 'pipe',
-  STH_HOST: 'localhost',
-  STH_PORT: 8666,
-  FILTER_OUT_EMPTY: true,
-  DEFAULT_SERVICE: 'testservice',
-  DEFAULT_SERVICE_PATH: '/testservicepath',
-  AGGREGATION_BY: ['day', 'hour', 'minute'],
-  TEMPORAL_DIR: 'temp',
-  DATA_MODEL: 'collection-per-entity',
-  DB_USERNAME: '',
-  DB_PASSWORD: '',
-  DB_URI: 'localhost:27017',
-  REPLICA_SET: '',
-  DB_PREFIX: 'sth_',
-  COLLECTION_PREFIX: 'sth_',
-  POOL_SIZE: 5,
-  WRITE_CONCERN: '1',
-  SHOULD_STORE: 'both',
-  TRUNCATION_EXPIRE_AFTER_SECONDS: 0,
-  TRUNCATION_SIZE: 0,
-  TRUNCATION_MAX: 0,
-  IGNORE_BLANK_SPACES: true,
-  NAME_ENCODING: false,
-  PROOF_OF_LIFE_INTERVAL: 60
+    LOGOPS_LEVEL: 'INFO',
+    LOGOPS_FORMAT: 'pipe',
+    STH_HOST: 'localhost',
+    STH_PORT: 8666,
+    FILTER_OUT_EMPTY: true,
+    DEFAULT_SERVICE: 'testservice',
+    DEFAULT_SERVICE_PATH: '/testservicepath',
+    AGGREGATION_BY: ['day', 'hour', 'minute'],
+    TEMPORAL_DIR: 'temp',
+    DATA_MODEL: 'collection-per-entity',
+    DB_USERNAME: '',
+    DB_PASSWORD: '',
+    DB_URI: 'localhost:27017',
+    REPLICA_SET: '',
+    DB_PREFIX: 'sth_',
+    COLLECTION_PREFIX: 'sth_',
+    POOL_SIZE: 5,
+    WRITE_CONCERN: '1',
+    SHOULD_STORE: 'both',
+    TRUNCATION_EXPIRE_AFTER_SECONDS: 0,
+    TRUNCATION_SIZE: 0,
+    TRUNCATION_MAX: 0,
+    IGNORE_BLANK_SPACES: true,
+    NAME_ENCODING: false,
+    PROOF_OF_LIFE_INTERVAL: 60,
 };
 
 describe('sthConfiguration tests', function() {
-  describe('default values', function() {
-    if (Object.keys(process.env).indexOf('LOGOPS_LEVEL') === -1) {
-      it('should set the logging level configuration parameter to its default value', function() {
-        expect(sthConfig.LOGOPS_LEVEL).to.equal(DEFAULT_VALUES.LOGOPS_LEVEL);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('LOGOPS_FORMAT') === -1) {
-      it('should set the logging format configuration parameter to its default value', function() {
-        expect(sthConfig.LOGOPS_FORMAT).to.equal(DEFAULT_VALUES.LOGOPS_FORMAT);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('STH_HOST') === -1) {
-      it('should set the STH server host configuration parameter to its default value', function() {
-        expect(sthConfig.STH_HOST).to.equal(DEFAULT_VALUES.STH_HOST);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('STH_PORT') === -1) {
-      it('should set the STH server port configuration parameter to its default value', function() {
-        expect(sthConfig.STH_PORT).to.equal(DEFAULT_VALUES.STH_PORT);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('DEFAULT_SERVICE') === -1) {
-      it('should set the default service configuration parameter to its default value', function() {
-        expect(sthConfig.DEFAULT_SERVICE).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('DEFAULT_SERVICE_PATH') === -1) {
-      it('should set the default service path configuration parameter to its default value', function() {
-        expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE_PATH);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('FILTER_OUT_EMPTY') === -1) {
-      it('should set the filter out empty configuration parameter to its default value', function() {
-        expect(sthConfig.FILTER_OUT_EMPTY).to.equal(DEFAULT_VALUES.FILTER_OUT_EMPTY);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('AGGREGATION_BY') === -1) {
-      it('should set the resolution to aggregate the data by to its default value',
-        function() {
-          DEFAULT_VALUES.AGGREGATION_BY.forEach(function(aggregationBy) {
-            expect(sthConfig.AGGREGATION_BY).to.contain(aggregationBy);
-          });
+    describe('default values', function() {
+        if (Object.keys(process.env).indexOf('LOGOPS_LEVEL') === -1) {
+            it('should set the logging level configuration parameter to its default value', function() {
+                expect(sthConfig.LOGOPS_LEVEL).to.equal(DEFAULT_VALUES.LOGOPS_LEVEL);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('TEMPORAL_DIR') === -1) {
-      it('should set the temporal directory configuration parameter to its default value',
-        function() {
-          expect(sthConfig.TEMPORAL_DIR).to.equal(DEFAULT_VALUES.TEMPORAL_DIR);
+        if (Object.keys(process.env).indexOf('LOGOPS_FORMAT') === -1) {
+            it('should set the logging format configuration parameter to its default value', function() {
+                expect(sthConfig.LOGOPS_FORMAT).to.equal(DEFAULT_VALUES.LOGOPS_FORMAT);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('DATA_MODEL') === -1) {
-      it('should set the data model configuration parameter to its default value', function() {
-        expect(sthConfig.DATA_MODEL).to.equal(DEFAULT_VALUES.DATA_MODEL);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('DB_USERNAME') === -1) {
-      it('should set the database user configuration parameter to its default value',
-        function() {
-          expect(sthConfig.DB_USERNAME).to.equal(DEFAULT_VALUES.DB_USERNAME);
+        if (Object.keys(process.env).indexOf('STH_HOST') === -1) {
+            it('should set the STH server host configuration parameter to its default value', function() {
+                expect(sthConfig.STH_HOST).to.equal(DEFAULT_VALUES.STH_HOST);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('DB_PASSWORD') === -1) {
-      it('should set the database password configuration parameter to its default value',
-        function() {
-          expect(sthConfig.DB_PASSWORD).to.equal(DEFAULT_VALUES.DB_PASSWORD);
+        if (Object.keys(process.env).indexOf('STH_PORT') === -1) {
+            it('should set the STH server port configuration parameter to its default value', function() {
+                expect(sthConfig.STH_PORT).to.equal(DEFAULT_VALUES.STH_PORT);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('DB_URI') === -1) {
-      it('should set the database URI configuration parameter to its default value',
-        function() {
-          expect(sthConfig.DB_URI).to.equal(DEFAULT_VALUES.DB_URI);
+        if (Object.keys(process.env).indexOf('DEFAULT_SERVICE') === -1) {
+            it('should set the default service configuration parameter to its default value', function() {
+                expect(sthConfig.DEFAULT_SERVICE).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('REPLICA_SET') === -1) {
-      it('should set the database replica set configuration parameter to its default value',
-        function() {
-          expect(sthConfig.REPLICA_SET).to.equal(DEFAULT_VALUES.REPLICA_SET);
+        if (Object.keys(process.env).indexOf('DEFAULT_SERVICE_PATH') === -1) {
+            it('should set the default service path configuration parameter to its default value', function() {
+                expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE_PATH);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('DB_PREFIX') === -1) {
-      it('should set the database prefix configuration parameter to its default value', function() {
-        expect(sthConfig.DB_PREFIX).to.equal(DEFAULT_VALUES.DB_PREFIX);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('COLLECTION_PREFIX') === -1) {
-      it('should set the collection prefix configuration parameter to its default value', function() {
-        expect(sthConfig.COLLECTION_PREFIX).to.equal(DEFAULT_VALUES.COLLECTION_PREFIX);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('POOL_SIZE') === -1) {
-      it('should set the database pool size configuration parameter to its default value', function() {
-        expect(sthConfig.POOL_SIZE).to.equal(DEFAULT_VALUES.POOL_SIZE);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('WRITE_CONCERN') === -1) {
-      it('should set the database write concern configuration parameter to its default value', function() {
-        expect(sthConfig.WRITE_CONCERN).to.equal(DEFAULT_VALUES.WRITE_CONCERN);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('SHOULD_STORE') === -1) {
-      it('should set the database should store data configuration parameter to its default value', function() {
-        expect(sthConfig.SHOULD_STORE).to.equal(DEFAULT_VALUES.SHOULD_STORE);
-      });
-    }
-
-    if (Object.keys(process.env).indexOf('TRUNCATION_EXPIRE_AFTER_SECONDS') === -1) {
-      it('should set the database truncation expiration after seconds configuration parameter to its default value',
-        function() {
-          expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(DEFAULT_VALUES.TRUNCATION_EXPIRE_AFTER_SECONDS);
+        if (Object.keys(process.env).indexOf('FILTER_OUT_EMPTY') === -1) {
+            it('should set the filter out empty configuration parameter to its default value', function() {
+                expect(sthConfig.FILTER_OUT_EMPTY).to.equal(DEFAULT_VALUES.FILTER_OUT_EMPTY);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('TRUNCATION_SIZE') === -1) {
-      it('should set the database truncation size configuration parameter to its default value',
-        function() {
-          expect(sthConfig.TRUNCATION_SIZE).to.equal(DEFAULT_VALUES.TRUNCATION_SIZE);
+        if (Object.keys(process.env).indexOf('AGGREGATION_BY') === -1) {
+            it('should set the resolution to aggregate the data by to its default value', function() {
+                DEFAULT_VALUES.AGGREGATION_BY.forEach(function(aggregationBy) {
+                    expect(sthConfig.AGGREGATION_BY).to.contain(aggregationBy);
+                });
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('TRUNCATION_MAX') === -1) {
-      it('should set the database truncation document number configuration parameter to its default value',
-        function() {
-          expect(sthConfig.TRUNCATION_MAX).to.equal(DEFAULT_VALUES.TRUNCATION_MAX);
+        if (Object.keys(process.env).indexOf('TEMPORAL_DIR') === -1) {
+            it('should set the temporal directory configuration parameter to its default value', function() {
+                expect(sthConfig.TEMPORAL_DIR).to.equal(DEFAULT_VALUES.TEMPORAL_DIR);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('IGNORE_BLANK_SPACES') === -1) {
-      it('should set the database ignore blank spaces configuration parameter to its default value',
-        function() {
-          expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(DEFAULT_VALUES.IGNORE_BLANK_SPACES);
+        if (Object.keys(process.env).indexOf('DATA_MODEL') === -1) {
+            it('should set the data model configuration parameter to its default value', function() {
+                expect(sthConfig.DATA_MODEL).to.equal(DEFAULT_VALUES.DATA_MODEL);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('NAME_ENCODING') === -1) {
-      it('should set the database name encoding configuration parameter to its default value',
-        function() {
-          expect(sthConfig.NAME_ENCODING).to.equal(DEFAULT_VALUES.NAME_ENCODING);
+        if (Object.keys(process.env).indexOf('DB_USERNAME') === -1) {
+            it('should set the database user configuration parameter to its default value', function() {
+                expect(sthConfig.DB_USERNAME).to.equal(DEFAULT_VALUES.DB_USERNAME);
+            });
         }
-      );
-    }
 
-    if (Object.keys(process.env).indexOf('PROOF_OF_LIFE_INTERVAL') === -1) {
-      it('should set the proof of life interval configuration parameter to its default value', function() {
-        expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
-      });
-    }
-  });
+        if (Object.keys(process.env).indexOf('DB_PASSWORD') === -1) {
+            it('should set the database password configuration parameter to its default value', function() {
+                expect(sthConfig.DB_PASSWORD).to.equal(DEFAULT_VALUES.DB_PASSWORD);
+            });
+        }
 
-  describe('setting values via environment variables', function() {
-    beforeEach(function() {
-      clearRequire(STH_CONFIGURATION_PATH);
+        if (Object.keys(process.env).indexOf('DB_URI') === -1) {
+            it('should set the database URI configuration parameter to its default value', function() {
+                expect(sthConfig.DB_URI).to.equal(DEFAULT_VALUES.DB_URI);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('REPLICA_SET') === -1) {
+            it('should set the database replica set configuration parameter to its default value', function() {
+                expect(sthConfig.REPLICA_SET).to.equal(DEFAULT_VALUES.REPLICA_SET);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('DB_PREFIX') === -1) {
+            it('should set the database prefix configuration parameter to its default value', function() {
+                expect(sthConfig.DB_PREFIX).to.equal(DEFAULT_VALUES.DB_PREFIX);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('COLLECTION_PREFIX') === -1) {
+            it('should set the collection prefix configuration parameter to its default value', function() {
+                expect(sthConfig.COLLECTION_PREFIX).to.equal(DEFAULT_VALUES.COLLECTION_PREFIX);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('POOL_SIZE') === -1) {
+            it('should set the database pool size configuration parameter to its default value', function() {
+                expect(sthConfig.POOL_SIZE).to.equal(DEFAULT_VALUES.POOL_SIZE);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('WRITE_CONCERN') === -1) {
+            it('should set the database write concern configuration parameter to its default value', function() {
+                expect(sthConfig.WRITE_CONCERN).to.equal(DEFAULT_VALUES.WRITE_CONCERN);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('SHOULD_STORE') === -1) {
+            it('should set the database should store data configuration parameter to its default value', function() {
+                expect(sthConfig.SHOULD_STORE).to.equal(DEFAULT_VALUES.SHOULD_STORE);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('TRUNCATION_EXPIRE_AFTER_SECONDS') === -1) {
+            it('should set the database truncation expiration after seconds configuration parameter to its default value', function() {
+                expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(
+                    DEFAULT_VALUES.TRUNCATION_EXPIRE_AFTER_SECONDS
+                );
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('TRUNCATION_SIZE') === -1) {
+            it('should set the database truncation size configuration parameter to its default value', function() {
+                expect(sthConfig.TRUNCATION_SIZE).to.equal(DEFAULT_VALUES.TRUNCATION_SIZE);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('TRUNCATION_MAX') === -1) {
+            it('should set the database truncation document number configuration parameter to its default value', function() {
+                expect(sthConfig.TRUNCATION_MAX).to.equal(DEFAULT_VALUES.TRUNCATION_MAX);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('IGNORE_BLANK_SPACES') === -1) {
+            it('should set the database ignore blank spaces configuration parameter to its default value', function() {
+                expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(DEFAULT_VALUES.IGNORE_BLANK_SPACES);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('NAME_ENCODING') === -1) {
+            it('should set the database name encoding configuration parameter to its default value', function() {
+                expect(sthConfig.NAME_ENCODING).to.equal(DEFAULT_VALUES.NAME_ENCODING);
+            });
+        }
+
+        if (Object.keys(process.env).indexOf('PROOF_OF_LIFE_INTERVAL') === -1) {
+            it('should set the proof of life interval configuration parameter to its default value', function() {
+                expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
+            });
+        }
     });
 
-    it('should set the logging level configuration parameter to \'DEBUG\'', function() {
-      process.env.LOGOPS_LEVEL = 'debug';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.LOGOPS_LEVEL).to.equal('DEBUG');
-    });
-
-    it('should set the logging level configuration parameter to the default value if set to an invalid value',
-      function() {
-        process.env.LOGOPS_LEVEL = 'DEXXXBUG';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.LOGOPS_LEVEL).to.equal(DEFAULT_VALUES.LOGOPS_LEVEL);
-      }
-    );
-
-    it('should set the logging format configuration parameter to \'dev\'', function() {
-      process.env.LOGOPS_FORMAT = 'dev';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.LOGOPS_FORMAT).to.equal('dev');
-    });
-
-    it('should set the logging format configuration parameter to the default value if set to an invalid value',
-      function() {
-        process.env.LOGOPS_FORMAT = 'devXXX';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.LOGOPS_FORMAT).to.equal(DEFAULT_VALUES.LOGOPS_FORMAT);
-      }
-    );
-
-    it('should set the STH host configuration parameter to \'127.0.0.1\'', function() {
-      process.env.STH_HOST = '127.0.0.1';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.STH_HOST).to.equal('127.0.0.1');
-    });
-
-    it('should set the STH host configuration parameter to the default value if not set via STH_HOST',
-      function() {
-        delete process.env.STH_HOST;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.STH_HOST).to.equal(DEFAULT_VALUES.STH_HOST);
-      }
-    );
-
-    it('should set the STH port configuration parameter to \'6666\'', function() {
-      process.env.STH_PORT = '6666';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.STH_PORT).to.equal(6666);
-    });
-
-    it('should set the STH port configuration parameter to the default value if not set via STH_PORT',
-      function() {
-        delete process.env.STH_PORT;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.STH_PORT).to.equal(DEFAULT_VALUES.STH_PORT);
-      }
-    );
-
-    it('should set the STH port configuration parameter to the default value if not set to a valid number',
-      function() {
-        process.env.STH_PORT = 'ABC';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.STH_PORT).to.equal(DEFAULT_VALUES.STH_PORT);
-      }
-    );
-
-    it('should set the default service configuration parameter to \'my_test_service\'', function() {
-      process.env.DEFAULT_SERVICE = 'my_test_service';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.DEFAULT_SERVICE).to.equal('my_test_service');
-    });
-
-    it('should set the default service configuration parameter to the default value if not set via DEFAULT_SERVICE',
-      function() {
-        delete process.env.DEFAULT_SERVICE;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DEFAULT_SERVICE).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE);
-      }
-    );
-
-    it('should set the default service path configuration parameter to \'/my_test_service_path\'', function() {
-      process.env.DEFAULT_SERVICE_PATH = '/my_test_service_path';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal('/my_test_service_path');
-    });
-
-    it('should set the default service path configuration parameter to the default value if not set via ' +
-      'DEFAULT_SERVICE_PATH',
-      function() {
-        delete process.env.DEFAULT_SERVICE_PATH;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE_PATH);
-      }
-    );
-
-    it('should set the default service path configuration parameter to the default value if set to an invalid value',
-      function() {
-        process.env.DEFAULT_SERVICE_PATH = 'testservicepath'; // Not starting with '/'.
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE_PATH);
-      }
-    );
-
-    it('should set the filter out empty configuration parameter to \'false\'', function() {
-      process.env.FILTER_OUT_EMPTY = 'false';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.FILTER_OUT_EMPTY).to.equal(false);
-    });
-
-    it('should set the filter out empty configuration parameter to the default value if not set via FILTER_OUT_EMPTY',
-      function() {
-        delete process.env.FILTER_OUT_EMPTY;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.FILTER_OUT_EMPTY).to.equal(DEFAULT_VALUES.FILTER_OUT_EMPTY);
-      }
-    );
-
-    it('should set the filter out empty configuration parameter to the default value if not set to a valid value',
-      function() {
-        process.env.FILTER_OUT_EMPTY = 'not-false';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.FILTER_OUT_EMPTY).to.equal(DEFAULT_VALUES.FILTER_OUT_EMPTY);
-      }
-    );
-
-    it('should set the resolutions to aggregate the data by configuration parameter to \'[minute, second]\'',
-      function() {
-        process.env.AGGREGATION_BY = '["' + sthConfig.RESOLUTION.MINUTE + '", "' +
-          sthConfig.RESOLUTION.SECOND + '"]';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.AGGREGATION_BY).to.contain(sthConfig.RESOLUTION.MINUTE);
-        expect(sthConfig.AGGREGATION_BY).to.contain(sthConfig.RESOLUTION.SECOND);
-      }
-    );
-
-    it('should set the resolutions to aggregate the data by configuration parameter to the default value ' +
-      'if not set via AGGREGATION_BY',
-      function() {
-        delete process.env.AGGREGATION_BY;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        DEFAULT_VALUES.AGGREGATION_BY.forEach(function(aggregationBy) {
-          expect(sthConfig.AGGREGATION_BY).to.contain(aggregationBy);
+    describe('setting values via environment variables', function() {
+        beforeEach(function() {
+            clearRequire(STH_CONFIGURATION_PATH);
         });
-      }
-    );
 
-    it('should set the resolutions to aggregate the data by configuration parameter to the default value ' +
-      'if set to an invalid value',
-      function() {
-        process.env.AGGREGATION_BY = 'not-an-array';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        DEFAULT_VALUES.AGGREGATION_BY.forEach(function(aggregationBy) {
-          expect(sthConfig.AGGREGATION_BY).to.contain(aggregationBy);
+        it("should set the logging level configuration parameter to 'DEBUG'", function() {
+            process.env.LOGOPS_LEVEL = 'debug';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.LOGOPS_LEVEL).to.equal('DEBUG');
         });
-      }
-    );
 
-    it('should set the temporal directory configuration parameter to \'my_temp_dir\'', function() {
-      process.env.TEMPORAL_DIR = 'my_temp_dir';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.TEMPORAL_DIR).to.equal('my_temp_dir');
+        it('should set the logging level configuration parameter to the default value if set to an invalid value', function() {
+            process.env.LOGOPS_LEVEL = 'DEXXXBUG';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.LOGOPS_LEVEL).to.equal(DEFAULT_VALUES.LOGOPS_LEVEL);
+        });
+
+        it("should set the logging format configuration parameter to 'dev'", function() {
+            process.env.LOGOPS_FORMAT = 'dev';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.LOGOPS_FORMAT).to.equal('dev');
+        });
+
+        it('should set the logging format configuration parameter to the default value if set to an invalid value', function() {
+            process.env.LOGOPS_FORMAT = 'devXXX';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.LOGOPS_FORMAT).to.equal(DEFAULT_VALUES.LOGOPS_FORMAT);
+        });
+
+        it("should set the STH host configuration parameter to '127.0.0.1'", function() {
+            process.env.STH_HOST = '127.0.0.1';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.STH_HOST).to.equal('127.0.0.1');
+        });
+
+        it('should set the STH host configuration parameter to the default value if not set via STH_HOST', function() {
+            delete process.env.STH_HOST;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.STH_HOST).to.equal(DEFAULT_VALUES.STH_HOST);
+        });
+
+        it("should set the STH port configuration parameter to '6666'", function() {
+            process.env.STH_PORT = '6666';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.STH_PORT).to.equal(6666);
+        });
+
+        it('should set the STH port configuration parameter to the default value if not set via STH_PORT', function() {
+            delete process.env.STH_PORT;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.STH_PORT).to.equal(DEFAULT_VALUES.STH_PORT);
+        });
+
+        it('should set the STH port configuration parameter to the default value if not set to a valid number', function() {
+            process.env.STH_PORT = 'ABC';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.STH_PORT).to.equal(DEFAULT_VALUES.STH_PORT);
+        });
+
+        it("should set the default service configuration parameter to 'my_test_service'", function() {
+            process.env.DEFAULT_SERVICE = 'my_test_service';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DEFAULT_SERVICE).to.equal('my_test_service');
+        });
+
+        it('should set the default service configuration parameter to the default value if not set via DEFAULT_SERVICE', function() {
+            delete process.env.DEFAULT_SERVICE;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DEFAULT_SERVICE).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE);
+        });
+
+        it("should set the default service path configuration parameter to '/my_test_service_path'", function() {
+            process.env.DEFAULT_SERVICE_PATH = '/my_test_service_path';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal('/my_test_service_path');
+        });
+
+        it(
+            'should set the default service path configuration parameter to the default value if not set via ' +
+                'DEFAULT_SERVICE_PATH',
+            function() {
+                delete process.env.DEFAULT_SERVICE_PATH;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE_PATH);
+            }
+        );
+
+        it('should set the default service path configuration parameter to the default value if set to an invalid value', function() {
+            process.env.DEFAULT_SERVICE_PATH = 'testservicepath'; // Not starting with '/'.
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DEFAULT_SERVICE_PATH).to.equal(DEFAULT_VALUES.DEFAULT_SERVICE_PATH);
+        });
+
+        it("should set the filter out empty configuration parameter to 'false'", function() {
+            process.env.FILTER_OUT_EMPTY = 'false';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.FILTER_OUT_EMPTY).to.equal(false);
+        });
+
+        it('should set the filter out empty configuration parameter to the default value if not set via FILTER_OUT_EMPTY', function() {
+            delete process.env.FILTER_OUT_EMPTY;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.FILTER_OUT_EMPTY).to.equal(DEFAULT_VALUES.FILTER_OUT_EMPTY);
+        });
+
+        it('should set the filter out empty configuration parameter to the default value if not set to a valid value', function() {
+            process.env.FILTER_OUT_EMPTY = 'not-false';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.FILTER_OUT_EMPTY).to.equal(DEFAULT_VALUES.FILTER_OUT_EMPTY);
+        });
+
+        it("should set the resolutions to aggregate the data by configuration parameter to '[minute, second]'", function() {
+            process.env.AGGREGATION_BY =
+                '["' + sthConfig.RESOLUTION.MINUTE + '", "' + sthConfig.RESOLUTION.SECOND + '"]';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.AGGREGATION_BY).to.contain(sthConfig.RESOLUTION.MINUTE);
+            expect(sthConfig.AGGREGATION_BY).to.contain(sthConfig.RESOLUTION.SECOND);
+        });
+
+        it(
+            'should set the resolutions to aggregate the data by configuration parameter to the default value ' +
+                'if not set via AGGREGATION_BY',
+            function() {
+                delete process.env.AGGREGATION_BY;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                DEFAULT_VALUES.AGGREGATION_BY.forEach(function(aggregationBy) {
+                    expect(sthConfig.AGGREGATION_BY).to.contain(aggregationBy);
+                });
+            }
+        );
+
+        it(
+            'should set the resolutions to aggregate the data by configuration parameter to the default value ' +
+                'if set to an invalid value',
+            function() {
+                process.env.AGGREGATION_BY = 'not-an-array';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                DEFAULT_VALUES.AGGREGATION_BY.forEach(function(aggregationBy) {
+                    expect(sthConfig.AGGREGATION_BY).to.contain(aggregationBy);
+                });
+            }
+        );
+
+        it("should set the temporal directory configuration parameter to 'my_temp_dir'", function() {
+            process.env.TEMPORAL_DIR = 'my_temp_dir';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.TEMPORAL_DIR).to.equal('my_temp_dir');
+        });
+
+        it('should set the temporal directory configuration parameter to the default value if not set via TEMPORAL_DIR', function() {
+            delete process.env.TEMPORAL_DIR;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.TEMPORAL_DIR).to.equal(DEFAULT_VALUES.TEMPORAL_DIR);
+        });
+
+        it("should set the data model configuration parameter to 'collection-per-service-path'", function() {
+            process.env.DATA_MODEL = 'collection-per-service-path';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DATA_MODEL).to.equal('collection-per-service-path');
+        });
+
+        it(
+            'should set the data model configuration parameter to the default value if not set via ' + 'DATA_MODEL',
+            function() {
+                delete process.env.DATA_MODEL;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.DATA_MODEL).to.equal(DEFAULT_VALUES.DATA_MODEL);
+            }
+        );
+
+        it('should set the data model configuration parameter to the default value if set to an invalid value', function() {
+            process.env.DATA_MODEL = 'collection-per-invalid-value'; // Not starting with '/'.
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DATA_MODEL).to.equal(DEFAULT_VALUES.DATA_MODEL);
+        });
+
+        it("should set the database user configuration parameter to 'db-user'", function() {
+            process.env.DB_USERNAME = 'db-user';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DB_USERNAME).to.equal('db-user');
+        });
+
+        it(
+            'should set the database user configuration parameter to the default value ' + 'if not set via DB_USERNAME',
+            function() {
+                delete process.env.DB_USERNAME;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.DB_USERNAME).to.equal(DEFAULT_VALUES.DB_USERNAME);
+            }
+        );
+
+        it("should set the database password configuration parameter to 'db-password'", function() {
+            process.env.DB_PASSWORD = 'db-password';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DB_PASSWORD).to.equal('db-password');
+        });
+
+        it(
+            'should set the database password configuration parameter to the default value ' +
+                'if not set via DB_PASSWORD',
+            function() {
+                delete process.env.DB_PASSWORD;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.DB_PASSWORD).to.equal(DEFAULT_VALUES.DB_PASSWORD);
+            }
+        );
+
+        it("should set the database URI configuration parameter to 'my.db.host.com:12345'", function() {
+            process.env.DB_URI = 'my.db.host.com:12345';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DB_URI).to.equal('my.db.host.com:12345');
+        });
+
+        it("should set the database URI configuration parameter to 'mongodb1:27017,mongodb2:27017,mongodb3:27017'", function() {
+            process.env.DB_URI = 'mongodb1:27017,mongodb2:27017,mongodb3:27017';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DB_URI).to.equal('mongodb1:27017,mongodb2:27017,mongodb3:27017');
+        });
+
+        it(
+            'should set the database URI configuration parameter to the default value ' + 'if not set via DB_URI',
+            function() {
+                delete process.env.DB_URI;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.DB_URI).to.equal(DEFAULT_VALUES.DB_URI);
+            }
+        );
+
+        it("should set the database replica set configuration parameter to 'the-replica-set'", function() {
+            process.env.REPLICA_SET = 'the-replica-set';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.REPLICA_SET).to.equal('the-replica-set');
+        });
+
+        it(
+            'should set the database replica set configuration parameter to the default value ' +
+                'if not set via REPLICA_SET',
+            function() {
+                delete process.env.REPLICA_SET;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.REPLICA_SET).to.equal(DEFAULT_VALUES.REPLICA_SET);
+            }
+        );
+
+        it("should set the database prefix configuration parameter to 'my_db_prefix'", function() {
+            process.env.DB_PREFIX = 'my_db_prefix';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DB_PREFIX).to.equal('my_db_prefix');
+        });
+
+        it('should set the database prefix configuration parameter to the default value if not set via DB_PREFIX', function() {
+            delete process.env.DB_PREFIX;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.DB_PREFIX).to.equal(DEFAULT_VALUES.DB_PREFIX);
+        });
+
+        it("should set the collection prefix configuration parameter to 'my_collection_prefix'", function() {
+            process.env.COLLECTION_PREFIX = 'my_collection_prefix';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.COLLECTION_PREFIX).to.equal('my_collection_prefix');
+        });
+
+        it('should set the collection prefix configuration parameter to the default value if not set via COLLECTION_PREFIX', function() {
+            delete process.env.COLLECTION_PREFIX;
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.COLLECTION_PREFIX).to.equal(DEFAULT_VALUES.COLLECTION_PREFIX);
+        });
+
+        it("should set the database pool size configuration parameter to '10'", function() {
+            process.env.POOL_SIZE = '10';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.POOL_SIZE).to.equal(10);
+        });
+
+        it(
+            'should set the database pool size configuration parameter to the default value if not set via ' +
+                'POOL_SIZE',
+            function() {
+                delete process.env.POOL_SIZE;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.POOL_SIZE).to.equal(DEFAULT_VALUES.POOL_SIZE);
+            }
+        );
+
+        it('should set the database pool size configuration parameter to the default value if set to an invalid value', function() {
+            process.env.POOL_SIZE = '-5';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.POOL_SIZE).to.equal(DEFAULT_VALUES.POOL_SIZE);
+        });
+
+        it("should set the database write concern configuration parameter to '5'", function() {
+            process.env.WRITE_CONCERN = '5';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.WRITE_CONCERN).to.equal('5');
+        });
+
+        it(
+            'should set the database write concern configuration parameter to the default value if not set via ' +
+                'POOL_SIZE',
+            function() {
+                delete process.env.WRITE_CONCERN;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.WRITE_CONCERN).to.equal(DEFAULT_VALUES.WRITE_CONCERN);
+            }
+        );
+
+        it('should set the database write concern configuration parameter to the default value if set to an invalid value', function() {
+            process.env.WRITE_CONCERN = 'ABC';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.WRITE_CONCERN).to.equal(DEFAULT_VALUES.WRITE_CONCERN);
+        });
+
+        it("should set the database should store data configuration parameter to 'only-aggregated'", function() {
+            process.env.SHOULD_STORE = 'only-aggregated';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.SHOULD_STORE).to.equal('only-aggregated');
+        });
+
+        it(
+            'should set the database should store data configuration parameter to the default value if not set via ' +
+                'SHOULD_STORE',
+            function() {
+                delete process.env.SHOULD_STORE;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.SHOULD_STORE).to.equal(DEFAULT_VALUES.SHOULD_STORE);
+            }
+        );
+
+        it(
+            'should set the database should store data configuration parameter to the default value if set to an invalid ' +
+                'value',
+            function() {
+                process.env.SHOULD_STORE = 'only-whaaat?';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.SHOULD_STORE).to.equal(DEFAULT_VALUES.SHOULD_STORE);
+            }
+        );
+
+        it("should set the database truncation expiration time configuration parameter to '123456789'", function() {
+            process.env.TRUNCATION_EXPIRE_AFTER_SECONDS = '123456789';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(123456789);
+        });
+
+        it(
+            'should set the database truncation expiration time configuration parameter to the default value ' +
+                'if not set via TRUNCATION_EXPIRE_AFTER_SECONDS',
+            function() {
+                delete process.env.TRUNCATION_EXPIRE_AFTER_SECONDS;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(
+                    DEFAULT_VALUES.TRUNCATION_EXPIRE_AFTER_SECONDS
+                );
+            }
+        );
+
+        it(
+            'should set the database truncation expiration time configuration parameter to the default value ' +
+                'if set to an invalid value',
+            function() {
+                process.env.TRUNCATION_EXPIRE_AFTER_SECONDS = 'not-a-number';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(
+                    DEFAULT_VALUES.TRUNCATION_EXPIRE_AFTER_SECONDS
+                );
+            }
+        );
+
+        it("should set the database truncation time configuration parameter to '987654321'", function() {
+            process.env.TRUNCATION_SIZE = '987654321';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.TRUNCATION_SIZE).to.equal(987654321);
+        });
+
+        it(
+            'should set the database truncation size configuration parameter to the default value ' +
+                'if not set via TRUNCATION_SIZE',
+            function() {
+                delete process.env.TRUNCATION_SIZE;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.TRUNCATION_SIZE).to.equal(DEFAULT_VALUES.TRUNCATION_SIZE);
+            }
+        );
+
+        it(
+            'should set the database truncation size configuration parameter to the default value ' +
+                'if set to an invalid value',
+            function() {
+                process.env.TRUNCATION_SIZE = 'not-a-number';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.TRUNCATION_SIZE).to.equal(DEFAULT_VALUES.TRUNCATION_SIZE);
+            }
+        );
+
+        it("should set the database truncation document number configuration parameter to '12345'", function() {
+            process.env.TRUNCATION_MAX = '12345';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.TRUNCATION_MAX).to.equal(12345);
+        });
+
+        it(
+            'should set the database truncation document number configuration parameter to the default value ' +
+                'if not set via TRUNCATION_MAX',
+            function() {
+                delete process.env.TRUNCATION_MAX;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.TRUNCATION_MAX).to.equal(DEFAULT_VALUES.TRUNCATION_MAX);
+            }
+        );
+
+        it(
+            'should set the database truncation size configuration parameter to the default value ' +
+                'if set to an invalid value',
+            function() {
+                process.env.TRUNCATION_MAX = 'not-a-number';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.TRUNCATION_MAX).to.equal(DEFAULT_VALUES.TRUNCATION_MAX);
+            }
+        );
+
+        it("should set the database ignore blank spaces configuration parameter to 'false'", function() {
+            process.env.IGNORE_BLANK_SPACES = 'false';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(false);
+        });
+
+        it(
+            'should set the database ignore blank spaces configuration parameter to the default value ' +
+                'if not set via IGNORE_BLANK_SPACES',
+            function() {
+                delete process.env.IGNORE_BLANK_SPACES;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(DEFAULT_VALUES.IGNORE_BLANK_SPACES);
+            }
+        );
+
+        it(
+            'should set the database ignore blank spaces configuration parameter to the default value ' +
+                'if set to an invalid value',
+            function() {
+                process.env.IGNORE_BLANK_SPACES = 'not-false';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(DEFAULT_VALUES.IGNORE_BLANK_SPACES);
+            }
+        );
+
+        it("should set the database name encoding configuration parameter to 'false'", function() {
+            process.env.NAME_ENCODING = 'false';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.NAME_ENCODING).to.equal(false);
+        });
+
+        it(
+            'should set the database name encoding configuration parameter to the default value ' +
+                'if not set via NAME_ENCODING',
+            function() {
+                delete process.env.NAME_ENCODING;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.NAME_ENCODING).to.equal(DEFAULT_VALUES.NAME_ENCODING);
+            }
+        );
+
+        it(
+            'should set the database name encoding configuration parameter to the default value ' +
+                'if set to an invalid value',
+            function() {
+                process.env.NAME_ENCODING = 'not-false';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.NAME_ENCODING).to.equal(DEFAULT_VALUES.NAME_ENCODING);
+            }
+        );
+
+        it("should set the proof of life interval configuration parameter to '120'", function() {
+            process.env.PROOF_OF_LIFE_INTERVAL = '120';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(120);
+        });
+
+        it(
+            'should set the proof of life interval configuration parameter to the default value if not set via ' +
+                'PROOF_OF_LIFE_INTERVAL',
+            function() {
+                delete process.env.PROOF_OF_LIFE_INTERVAL;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
+            }
+        );
+
+        it(
+            'should set the proof of life interval configuration parameter to the default value if not set to a valid ' +
+                'number',
+            function() {
+                process.env.PROOF_OF_LIFE_INTERVAL = 'ABC';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
+            }
+        );
     });
-
-    it('should set the temporal directory configuration parameter to the default value if not set via TEMPORAL_DIR',
-      function() {
-        delete process.env.TEMPORAL_DIR;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TEMPORAL_DIR).to.equal(DEFAULT_VALUES.TEMPORAL_DIR);
-      }
-    );
-
-    it('should set the data model configuration parameter to \'collection-per-service-path\'', function() {
-      process.env.DATA_MODEL = 'collection-per-service-path';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.DATA_MODEL).to.equal('collection-per-service-path');
-    });
-
-    it('should set the data model configuration parameter to the default value if not set via ' +
-      'DATA_MODEL',
-      function() {
-        delete process.env.DATA_MODEL;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DATA_MODEL).to.equal(DEFAULT_VALUES.DATA_MODEL);
-      }
-    );
-
-    it('should set the data model configuration parameter to the default value if set to an invalid value',
-      function() {
-        process.env.DATA_MODEL = 'collection-per-invalid-value'; // Not starting with '/'.
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DATA_MODEL).to.equal(DEFAULT_VALUES.DATA_MODEL);
-      }
-    );
-
-    it('should set the database user configuration parameter to \'db-user\'',
-      function() {
-        process.env.DB_USERNAME = 'db-user';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_USERNAME).to.equal('db-user');
-      }
-    );
-
-    it('should set the database user configuration parameter to the default value ' +
-      'if not set via DB_USERNAME',
-      function() {
-        delete process.env.DB_USERNAME;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_USERNAME).to.equal(DEFAULT_VALUES.DB_USERNAME);
-      }
-    );
-
-    it('should set the database password configuration parameter to \'db-password\'',
-      function() {
-        process.env.DB_PASSWORD = 'db-password';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_PASSWORD).to.equal('db-password');
-      }
-    );
-
-    it('should set the database password configuration parameter to the default value ' +
-      'if not set via DB_PASSWORD',
-      function() {
-        delete process.env.DB_PASSWORD;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_PASSWORD).to.equal(DEFAULT_VALUES.DB_PASSWORD);
-      }
-    );
-
-    it('should set the database URI configuration parameter to \'my.db.host.com:12345\'',
-      function() {
-        process.env.DB_URI = 'my.db.host.com:12345';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_URI).to.equal('my.db.host.com:12345');
-      }
-    );
-
-    it('should set the database URI configuration parameter to \'mongodb1:27017,mongodb2:27017,mongodb3:27017\'',
-      function() {
-        process.env.DB_URI = 'mongodb1:27017,mongodb2:27017,mongodb3:27017';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_URI).to.equal('mongodb1:27017,mongodb2:27017,mongodb3:27017');
-      }
-    );
-
-    it('should set the database URI configuration parameter to the default value ' +
-      'if not set via DB_URI',
-      function() {
-        delete process.env.DB_URI;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_URI).to.equal(DEFAULT_VALUES.DB_URI);
-      }
-    );
-
-    it('should set the database replica set configuration parameter to \'the-replica-set\'',
-      function() {
-        process.env.REPLICA_SET = 'the-replica-set';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.REPLICA_SET).to.equal('the-replica-set');
-      }
-    );
-
-    it('should set the database replica set configuration parameter to the default value ' +
-      'if not set via REPLICA_SET',
-      function() {
-        delete process.env.REPLICA_SET;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.REPLICA_SET).to.equal(DEFAULT_VALUES.REPLICA_SET);
-      }
-    );
-
-    it('should set the database prefix configuration parameter to \'my_db_prefix\'', function() {
-      process.env.DB_PREFIX = 'my_db_prefix';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.DB_PREFIX).to.equal('my_db_prefix');
-    });
-
-    it('should set the database prefix configuration parameter to the default value if not set via DB_PREFIX',
-      function() {
-        delete process.env.DB_PREFIX;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.DB_PREFIX).to.equal(DEFAULT_VALUES.DB_PREFIX);
-      }
-    );
-
-    it('should set the collection prefix configuration parameter to \'my_collection_prefix\'', function() {
-      process.env.COLLECTION_PREFIX = 'my_collection_prefix';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.COLLECTION_PREFIX).to.equal('my_collection_prefix');
-    });
-
-    it('should set the collection prefix configuration parameter to the default value if not set via COLLECTION_PREFIX',
-      function() {
-        delete process.env.COLLECTION_PREFIX;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.COLLECTION_PREFIX).to.equal(DEFAULT_VALUES.COLLECTION_PREFIX);
-      }
-    );
-
-    it('should set the database pool size configuration parameter to \'10\'', function() {
-      process.env.POOL_SIZE = '10';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.POOL_SIZE).to.equal(10);
-    });
-
-    it('should set the database pool size configuration parameter to the default value if not set via ' +
-      'POOL_SIZE',
-      function() {
-        delete process.env.POOL_SIZE;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.POOL_SIZE).to.equal(DEFAULT_VALUES.POOL_SIZE);
-      }
-    );
-
-    it('should set the database pool size configuration parameter to the default value if set to an invalid value',
-      function() {
-        process.env.POOL_SIZE = '-5';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.POOL_SIZE).to.equal(DEFAULT_VALUES.POOL_SIZE);
-      }
-    );
-
-    it('should set the database write concern configuration parameter to \'5\'', function() {
-      process.env.WRITE_CONCERN = '5';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.WRITE_CONCERN).to.equal('5');
-    });
-
-    it('should set the database write concern configuration parameter to the default value if not set via ' +
-      'POOL_SIZE',
-      function() {
-        delete process.env.WRITE_CONCERN;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.WRITE_CONCERN).to.equal(DEFAULT_VALUES.WRITE_CONCERN);
-      }
-    );
-
-    it('should set the database write concern configuration parameter to the default value if set to an invalid value',
-      function() {
-        process.env.WRITE_CONCERN = 'ABC';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.WRITE_CONCERN).to.equal(DEFAULT_VALUES.WRITE_CONCERN);
-      }
-    );
-
-    it('should set the database should store data configuration parameter to \'only-aggregated\'', function() {
-      process.env.SHOULD_STORE = 'only-aggregated';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.SHOULD_STORE).to.equal('only-aggregated');
-    });
-
-    it('should set the database should store data configuration parameter to the default value if not set via ' +
-      'SHOULD_STORE',
-      function() {
-        delete process.env.SHOULD_STORE;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.SHOULD_STORE).to.equal(DEFAULT_VALUES.SHOULD_STORE);
-      }
-    );
-
-    it('should set the database should store data configuration parameter to the default value if set to an invalid ' +
-      'value',
-      function() {
-        process.env.SHOULD_STORE = 'only-whaaat?';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.SHOULD_STORE).to.equal(DEFAULT_VALUES.SHOULD_STORE);
-      }
-    );
-
-    it('should set the database truncation expiration time configuration parameter to \'123456789\'',
-      function() {
-        process.env.TRUNCATION_EXPIRE_AFTER_SECONDS = '123456789';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(123456789);
-      }
-    );
-
-    it('should set the database truncation expiration time configuration parameter to the default value ' +
-      'if not set via TRUNCATION_EXPIRE_AFTER_SECONDS',
-      function() {
-        delete process.env.TRUNCATION_EXPIRE_AFTER_SECONDS;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(DEFAULT_VALUES.TRUNCATION_EXPIRE_AFTER_SECONDS);
-      }
-    );
-
-    it('should set the database truncation expiration time configuration parameter to the default value ' +
-      'if set to an invalid value',
-      function() {
-        process.env.TRUNCATION_EXPIRE_AFTER_SECONDS = 'not-a-number';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS).to.equal(DEFAULT_VALUES.TRUNCATION_EXPIRE_AFTER_SECONDS);
-      }
-    );
-
-    it('should set the database truncation time configuration parameter to \'987654321\'',
-      function() {
-        process.env.TRUNCATION_SIZE = '987654321';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_SIZE).to.equal(987654321);
-      }
-    );
-
-    it('should set the database truncation size configuration parameter to the default value ' +
-      'if not set via TRUNCATION_SIZE',
-      function() {
-        delete process.env.TRUNCATION_SIZE;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_SIZE).to.equal(DEFAULT_VALUES.TRUNCATION_SIZE);
-      }
-    );
-
-    it('should set the database truncation size configuration parameter to the default value ' +
-      'if set to an invalid value',
-      function() {
-        process.env.TRUNCATION_SIZE = 'not-a-number';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_SIZE).to.equal(DEFAULT_VALUES.TRUNCATION_SIZE);
-      }
-    );
-
-    it('should set the database truncation document number configuration parameter to \'12345\'',
-      function() {
-        process.env.TRUNCATION_MAX = '12345';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_MAX).to.equal(12345);
-      }
-    );
-
-    it('should set the database truncation document number configuration parameter to the default value ' +
-      'if not set via TRUNCATION_MAX',
-      function() {
-        delete process.env.TRUNCATION_MAX;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_MAX).to.equal(DEFAULT_VALUES.TRUNCATION_MAX);
-      }
-    );
-
-    it('should set the database truncation size configuration parameter to the default value ' +
-      'if set to an invalid value',
-      function() {
-        process.env.TRUNCATION_MAX = 'not-a-number';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.TRUNCATION_MAX).to.equal(DEFAULT_VALUES.TRUNCATION_MAX);
-      }
-    );
-
-    it('should set the database ignore blank spaces configuration parameter to \'false\'',
-      function() {
-        process.env.IGNORE_BLANK_SPACES = 'false';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(false);
-      }
-    );
-
-    it('should set the database ignore blank spaces configuration parameter to the default value ' +
-      'if not set via IGNORE_BLANK_SPACES',
-      function() {
-        delete process.env.IGNORE_BLANK_SPACES;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(DEFAULT_VALUES.IGNORE_BLANK_SPACES);
-      }
-    );
-
-    it('should set the database ignore blank spaces configuration parameter to the default value ' +
-      'if set to an invalid value',
-      function() {
-        process.env.IGNORE_BLANK_SPACES = 'not-false';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.IGNORE_BLANK_SPACES).to.equal(DEFAULT_VALUES.IGNORE_BLANK_SPACES);
-      }
-    );
-
-    it('should set the database name encoding configuration parameter to \'false\'',
-      function() {
-        process.env.NAME_ENCODING = 'false';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.NAME_ENCODING).to.equal(false);
-      }
-    );
-
-    it('should set the database name encoding configuration parameter to the default value ' +
-      'if not set via NAME_ENCODING',
-      function() {
-        delete process.env.NAME_ENCODING;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.NAME_ENCODING).to.equal(DEFAULT_VALUES.NAME_ENCODING);
-      }
-    );
-
-    it('should set the database name encoding configuration parameter to the default value ' +
-      'if set to an invalid value',
-      function() {
-        process.env.NAME_ENCODING = 'not-false';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.NAME_ENCODING).to.equal(DEFAULT_VALUES.NAME_ENCODING);
-      }
-    );
-
-    it('should set the proof of life interval configuration parameter to \'120\'', function() {
-      process.env.PROOF_OF_LIFE_INTERVAL = '120';
-      sthConfig = require(STH_CONFIGURATION_PATH);
-      expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(120);
-    });
-
-    it('should set the proof of life interval configuration parameter to the default value if not set via ' +
-      'PROOF_OF_LIFE_INTERVAL',
-      function() {
-        delete process.env.PROOF_OF_LIFE_INTERVAL;
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
-      }
-    );
-
-    it('should set the proof of life interval configuration parameter to the default value if not set to a valid ' +
-      'number',
-      function() {
-        process.env.PROOF_OF_LIFE_INTERVAL = 'ABC';
-        sthConfig = require(STH_CONFIGURATION_PATH);
-        expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
-      }
-    );
-  });
 });

--- a/test/unit/sthConfiguration_test.js
+++ b/test/unit/sthConfiguration_test.js
@@ -54,7 +54,7 @@ var DEFAULT_VALUES = {
     TRUNCATION_MAX: 0,
     IGNORE_BLANK_SPACES: true,
     NAME_ENCODING: false,
-    PROOF_OF_LIFE_INTERVAL: 60,
+    PROOF_OF_LIFE_INTERVAL: 60
 };
 
 describe('sthConfiguration tests', function() {

--- a/test/unit/sthDatabaseModelTool_test.js
+++ b/test/unit/sthDatabaseModelTool_test.js
@@ -291,24 +291,21 @@ function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
@@ -336,15 +333,10 @@ function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
             )
         );
 
-        it(
-            'should detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' + dataType + 
+            ' data collection needs ' + 'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+            ' data model',
             analysisInclusionTest.bind(
                 null,
                 dataType,
@@ -363,46 +355,34 @@ function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
  * @param  {String}  aggregationType The aggregation type
  */
 function collectionPerEntityAnalysisTests(dataType, aggregationType) {
-    describe('collection per entity analysis', function() {
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection',
+    describe('col// pretty analysis', function() {
+        // prettier-ignore
+        it( 'should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +  ' ' + dataType +
+            ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
-        it(
-            'should not detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +  dataType +
+            ' data collection needs migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
             analysisExclusionTest.bind(
                 null,
                 dataType,
@@ -411,15 +391,10 @@ function collectionPerEntityAnalysisTests(dataType, aggregationType) {
             )
         );
 
-        it(
-            'should detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' data model',
+        // prettier-ignore
+        it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' + dataType +
+            ' data collection needs ' + 'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+            ' data model',
             analysisInclusionTest.bind(
                 null,
                 dataType,
@@ -428,15 +403,10 @@ function collectionPerEntityAnalysisTests(dataType, aggregationType) {
             )
         );
 
-        it(
-            'should detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' + dataType +
+           ' data collection needs ' + 'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+           ' data model',
             analysisInclusionTest.bind(
                 null,
                 dataType,
@@ -456,45 +426,34 @@ function collectionPerEntityAnalysisTests(dataType, aggregationType) {
  */
 function collectionPerServicePathAnalysisTests(dataType, aggregationType) {
     describe('collection per service path analysis', function() {
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' + dataType +
+            ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should not detect the any system.* collection needs migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the any system.* collection needs migration to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
-        it(
-            'should not detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' + dataType +
+            ' data collection needs ' + 'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+            ' data model',
             analysisExclusionTest.bind(
                 null,
                 dataType,
@@ -503,15 +462,10 @@ function collectionPerServicePathAnalysisTests(dataType, aggregationType) {
             )
         );
 
-        it(
-            'should detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' data model',
+        // prettier-ignore
+        it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' + dataType +
+            ' data collection needs ' + 'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + 
+            ' data model',
             analysisInclusionTest.bind(
                 null,
                 dataType,
@@ -520,15 +474,10 @@ function collectionPerServicePathAnalysisTests(dataType, aggregationType) {
             )
         );
 
-        it(
-            'should detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' data model',
+        // prettier-ignore
+        it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' + dataType +
+            ' data collection needs ' + 'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+            ' data model',
             analysisInclusionTest.bind(
                 null,
                 dataType,
@@ -921,14 +870,14 @@ function collectionPerEntityCleanMigrationTests(dataType, aggregationType, optio
 function collectionPerEntityUpdateMigrationTests(dataType, aggregationType, options) {
     describe('collection per entity updatable migration', function() {
         // prettier-ignore
-        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-            dataType + ' data collection',
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' + dataType +
+            ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
         // prettier-ignore
-        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-            dataType + ' data collection',
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' + dataType +
+            ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 

--- a/test/unit/sthDatabaseModelTool_test.js
+++ b/test/unit/sthDatabaseModelTool_test.js
@@ -39,22 +39,22 @@ var DATABASE_CONNECTION_PARAMS = {
     dbURI: sthConfig.DB_URI,
     replicaSet: sthConfig.REPLICA_SET,
     database: DATABASE_NAME,
-    poolSize: sthConfig.POOL_SIZE,
+    poolSize: sthConfig.POOL_SIZE
 };
 var COLLECTION_NAME_PARAMS = {
     service: sthConfig.DEFAULT_SERVICE,
     servicePath: sthConfig.DEFAULT_SERVICE_PATH,
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
-    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrName: sthTestConfig.ATTRIBUTE_NAME
 };
 var ATTRIBUTE = {
     NAME: 'attrName',
     TYPE: 'attrType',
     VALUE: {
-        NUMERIC: 666,
+        NUMERIC: 666
     },
-    RECV_TIME: {},
+    RECV_TIME: {}
 };
 ATTRIBUTE.RECV_TIME[sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH] = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 0));
 ATTRIBUTE.RECV_TIME[sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY] = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 555));
@@ -149,7 +149,7 @@ function insertData(dataType, aggregationType, dataModel, callback) {
             entityId: sthTestConfig.ENTITY_ID,
             entityType: sthTestConfig.ENTITY_TYPE,
             attribute: attribute,
-            notificationInfo: { inserts: true },
+            notificationInfo: { inserts: true }
         };
 
         if (dataType === sthTestConfig.DATA_TYPES.RAW) {
@@ -776,7 +776,7 @@ function expectAggregatedDataMigration(params, options, done) {
                 } else {
                     callback();
                 }
-            },
+            }
         ],
         done
     );
@@ -927,7 +927,7 @@ function collectionPerEntityCleanMigrationTests(dataType, aggregationType, optio
                     dataType: dataType,
                     aggregationType: aggregationType,
                     originDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-                    targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                    targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
                 },
                 options
             )
@@ -983,7 +983,7 @@ function collectionPerEntityUpdateMigrationTests(dataType, aggregationType, opti
                     dataType: dataType,
                     aggregationType: aggregationType,
                     originDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-                    targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                    targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
                 },
                 options
             )
@@ -1025,22 +1025,22 @@ describe('sthDatabaseModelTool tests', function() {
 
                         collectionPerEntityCleanMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
                             removeCollection: false,
-                            updateCollection: false,
+                            updateCollection: false
                         });
 
                         collectionPerEntityCleanMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
                             removeCollection: true,
-                            updateCollection: false,
+                            updateCollection: false
                         });
 
                         collectionPerEntityUpdateMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
                             removeCollection: false,
-                            updateCollection: true,
+                            updateCollection: true
                         });
 
                         collectionPerEntityUpdateMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
                             removeCollection: true,
-                            updateCollection: true,
+                            updateCollection: true
                         });
                     });
                 });

--- a/test/unit/sthDatabaseModelTool_test.js
+++ b/test/unit/sthDatabaseModelTool_test.js
@@ -104,12 +104,9 @@ function cleanDatabaseTests(dataType) {
     var dataModelsKeys = Object.keys(sthConfig.DATA_MODELS);
     describe('database clean up', function() {
         for (var index1 = 0; index1 < dataModelsKeys.length; index1++) {
-            it(
-                'should drop the ' +
-                    sthConfig.DATA_MODELS[dataModelsKeys[index1]] +
-                    ' ' +
-                    dataType +
-                    ' data collection if it exists',
+            // prettier-ignore
+            it('should drop the ' + sthConfig.DATA_MODELS[dataModelsKeys[index1]] + ' ' + dataType + 
+                ' data collection if it exists',
                 dropCollection.bind(null, dataType, sthConfig.DATA_MODELS[dataModelsKeys[index1]])
             );
         }

--- a/test/unit/sthDatabaseModelTool_test.js
+++ b/test/unit/sthDatabaseModelTool_test.js
@@ -285,12 +285,9 @@ function systemCollectionNotIncludedTest(targetDataModel, done) {
  */
 function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
     describe('collection per attribute analysis', function() {
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' + dataType +
+            ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
         );
 
@@ -315,15 +312,10 @@ function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
             systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
-        it(
-            'should not detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' data model',
+        // prettier-ignore
+        it('should not detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' + dataType +
+            ' data collection needs migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+            ' data model',
             analysisExclusionTest.bind(
                 null,
                 dataType,
@@ -332,15 +324,10 @@ function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
             )
         );
 
-        it(
-            'should detect the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
-                ' ' +
-                dataType +
-                ' data collection needs ' +
-                'migration to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' data model',
+        // prettier-ignore
+        it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' + dataType +
+            ' data collection needs migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+            ' data model',
             analysisInclusionTest.bind(
                 null,
                 dataType,
@@ -852,32 +839,22 @@ function noMigrationTest(dataType, originDataModel, targetDataModel, done) {
  */
 function collectionPerEntityNotUpdatableMigrationTests(dataType, aggregationType) {
     describe('collection per entity not updatable migration', function() {
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
+            dataType + ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
+            dataType + ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
-        it(
-            'should not migrate the ' +
-                dataType +
-                ' data collection from the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model',
+        // prettier-ignore
+        it('should not migrate the ' + dataType + ' data collection from the ' + 
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' to the ' +
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
             noMigrationTest.bind(
                 null,
                 dataType,
@@ -903,24 +880,17 @@ function collectionPerEntityNotUpdatableMigrationTests(dataType, aggregationType
  */
 function collectionPerEntityCleanMigrationTests(dataType, aggregationType, options) {
     describe('collection per entity clean migration', function() {
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' + dataType + 
+            ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should migrate the ' +
-                dataType +
-                ' data collection from the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model' +
-                (options.removeCollection ? ' removing the original collection afterwards' : ''),
+        // prettier-ignore
+        it('should migrate the ' + dataType + ' data collection from the ' + 
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' to the ' + 
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model' +
+            (options.removeCollection ? ' removing the original collection afterwards' : ''),
             migrationTest.bind(
                 null,
                 {
@@ -950,33 +920,24 @@ function collectionPerEntityCleanMigrationTests(dataType, aggregationType, optio
  */
 function collectionPerEntityUpdateMigrationTests(dataType, aggregationType, options) {
     describe('collection per entity updatable migration', function() {
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
+            dataType + ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
         );
 
-        it(
-            'should insert data into the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' ' +
-                dataType +
-                ' data collection',
+        // prettier-ignore
+        it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
+            dataType + ' data collection',
             insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
         );
 
-        it(
-            'should migrate the ' +
-                dataType +
-                ' data collection from the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
-                ' to the ' +
-                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
-                ' data model updating the target collection' +
-                (options.removeCollection ? ' and removing the original collection afterwards' : ''),
+        // prettier-ignore
+        it('should migrate the ' + dataType + ' data collection from the ' + 
+            sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' to the ' + 
+            sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+            ' data model updating the target collection' +
+            (options.removeCollection ? ' and removing the original collection afterwards' : ''),
             migrationTest.bind(
                 null,
                 {

--- a/test/unit/sthDatabaseModelTool_test.js
+++ b/test/unit/sthDatabaseModelTool_test.js
@@ -35,26 +35,26 @@ var async = require('async');
 
 var DATABASE_NAME = sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE);
 var DATABASE_CONNECTION_PARAMS = {
-  authentication: sthConfig.DB_AUTHENTICATION,
-  dbURI: sthConfig.DB_URI,
-  replicaSet: sthConfig.REPLICA_SET,
-  database: DATABASE_NAME,
-  poolSize: sthConfig.POOL_SIZE
+    authentication: sthConfig.DB_AUTHENTICATION,
+    dbURI: sthConfig.DB_URI,
+    replicaSet: sthConfig.REPLICA_SET,
+    database: DATABASE_NAME,
+    poolSize: sthConfig.POOL_SIZE,
 };
 var COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
 };
 var ATTRIBUTE = {
-  NAME: 'attrName',
-  TYPE: 'attrType',
-  VALUE: {
-    NUMERIC: 666
-  },
-  RECV_TIME: {}
+    NAME: 'attrName',
+    TYPE: 'attrType',
+    VALUE: {
+        NUMERIC: 666,
+    },
+    RECV_TIME: {},
 };
 ATTRIBUTE.RECV_TIME[sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH] = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 0));
 ATTRIBUTE.RECV_TIME[sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY] = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 555));
@@ -65,10 +65,13 @@ ATTRIBUTE.RECV_TIME[sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE] = new Date(D
  * @param  {Function} callback The callblack
  */
 function connectToDatabase(callback) {
-  if (sthDatabase.connection) {
-    return process.nextTick(callback.bind(null, null, sthDatabase.connection));
-  }
-  sthDatabase.connect(DATABASE_CONNECTION_PARAMS, callback);
+    if (sthDatabase.connection) {
+        return process.nextTick(callback.bind(null, null, sthDatabase.connection));
+    }
+    sthDatabase.connect(
+        DATABASE_CONNECTION_PARAMS,
+        callback
+    );
 }
 
 /**
@@ -78,18 +81,19 @@ function connectToDatabase(callback) {
  * @param  {Function} callback  The Callback
  */
 function dropCollection(type, dataModel, callback) {
-  sthConfig.DATA_MODEL = dataModel;
-  var collectionName = (type === sthTestConfig.DATA_TYPES.RAW) ?
-    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
+    sthConfig.DATA_MODEL = dataModel;
+    var collectionName =
+        type === sthTestConfig.DATA_TYPES.RAW
+            ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+            : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
 
-  sthDatabase.connection.dropCollection(collectionName, function (err) {
-    if (err && err.code === 26 && err.name === 'MongoError' && err.message === 'ns not found') {
-      // The collection does not exist
-      return process.nextTick(callback);
-    }
-    return process.nextTick(callback.bind(null, err));
-  });
+    sthDatabase.connection.dropCollection(collectionName, function(err) {
+        if (err && err.code === 26 && err.name === 'MongoError' && err.message === 'ns not found') {
+            // The collection does not exist
+            return process.nextTick(callback);
+        }
+        return process.nextTick(callback.bind(null, err));
+    });
 }
 
 /**
@@ -97,14 +101,19 @@ function dropCollection(type, dataModel, callback) {
  * @param  {String} dataType The data type
  */
 function cleanDatabaseTests(dataType) {
-  var dataModelsKeys = Object.keys(sthConfig.DATA_MODELS);
-  describe('database clean up', function() {
-    for (var index1 = 0; index1 < dataModelsKeys.length; index1++) {
-      it('should drop the ' + sthConfig.DATA_MODELS[dataModelsKeys[index1]] + ' ' + dataType +
-        ' data collection if it exists', dropCollection.bind(null, dataType,
-          sthConfig.DATA_MODELS[dataModelsKeys[index1]]));
-    }
-  });
+    var dataModelsKeys = Object.keys(sthConfig.DATA_MODELS);
+    describe('database clean up', function() {
+        for (var index1 = 0; index1 < dataModelsKeys.length; index1++) {
+            it(
+                'should drop the ' +
+                    sthConfig.DATA_MODELS[dataModelsKeys[index1]] +
+                    ' ' +
+                    dataType +
+                    ' data collection if it exists',
+                dropCollection.bind(null, dataType, sthConfig.DATA_MODELS[dataModelsKeys[index1]])
+            );
+        }
+    });
 }
 
 /**
@@ -115,40 +124,40 @@ function cleanDatabaseTests(dataType) {
  * @param  {Function} callback        The callback
  */
 function insertData(dataType, aggregationType, dataModel, callback) {
-  var INSERTION_PARAMS,
-      collectionName,
-      attribute = {};
+    var INSERTION_PARAMS,
+        collectionName,
+        attribute = {};
 
-  attribute.name = ATTRIBUTE.NAME;
-  attribute.type = ATTRIBUTE.TYPE;
-  attribute.value = (aggregationType === sthConfig.AGGREGATIONS.NUMERIC ?
-    ATTRIBUTE.VALUE.NUMERIC : dataModel);
+    attribute.name = ATTRIBUTE.NAME;
+    attribute.type = ATTRIBUTE.TYPE;
+    attribute.value = aggregationType === sthConfig.AGGREGATIONS.NUMERIC ? ATTRIBUTE.VALUE.NUMERIC : dataModel;
 
-  sthConfig.DATA_MODEL = dataModel;
-  collectionName = (dataType === sthTestConfig.DATA_TYPES.RAW) ?
-    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
+    sthConfig.DATA_MODEL = dataModel;
+    collectionName =
+        dataType === sthTestConfig.DATA_TYPES.RAW
+            ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+            : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
 
-  sthDatabase.connection.collection(collectionName, function(err, collection) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
+    sthDatabase.connection.collection(collectionName, function(err, collection) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
+        }
 
-    INSERTION_PARAMS = {
-      collection: collection,
-      recvTime: ATTRIBUTE.RECV_TIME[dataModel],
-      entityId: sthTestConfig.ENTITY_ID,
-      entityType: sthTestConfig.ENTITY_TYPE,
-      attribute: attribute,
-      notificationInfo: { inserts: true }
-    };
+        INSERTION_PARAMS = {
+            collection: collection,
+            recvTime: ATTRIBUTE.RECV_TIME[dataModel],
+            entityId: sthTestConfig.ENTITY_ID,
+            entityType: sthTestConfig.ENTITY_TYPE,
+            attribute: attribute,
+            notificationInfo: { inserts: true },
+        };
 
-    if (dataType === sthTestConfig.DATA_TYPES.RAW) {
-      sthDatabase.storeRawData(INSERTION_PARAMS, callback);
-    } else {
-      sthDatabase.storeAggregatedData(INSERTION_PARAMS, callback);
-    }
-  });
+        if (dataType === sthTestConfig.DATA_TYPES.RAW) {
+            sthDatabase.storeRawData(INSERTION_PARAMS, callback);
+        } else {
+            sthDatabase.storeAggregatedData(INSERTION_PARAMS, callback);
+        }
+    });
 }
 
 /**
@@ -158,12 +167,12 @@ function insertData(dataType, aggregationType, dataModel, callback) {
  * @return {Boolean}              True if the database is included in the analysis result, false otherwise
  */
 function isDatabaseIncluded(analysis, databaseName) {
-  for (var index = 0; index < analysis.result.length; index++) {
-    if (analysis.result[index].databaseName === databaseName) {
-      return true;
+    for (var index = 0; index < analysis.result.length; index++) {
+        if (analysis.result[index].databaseName === databaseName) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 /**
@@ -174,16 +183,16 @@ function isDatabaseIncluded(analysis, databaseName) {
  * @return {Boolean}                True if the collection is included in the analysis result, false otherwise
  */
 function isCollectionIncluded(analysis, databaseName, collectionName) {
-  for (var index1 = 0; index1 < analysis.result.length; index1++) {
-    if (analysis.result[index1].databaseName === databaseName) {
-      for (var index2 = 0; index2 < analysis.result[index1].collections2Migrate.length; index2++) {
-        if (analysis.result[index1].collections2Migrate[index2].collectionName === collectionName) {
-          return true;
+    for (var index1 = 0; index1 < analysis.result.length; index1++) {
+        if (analysis.result[index1].databaseName === databaseName) {
+            for (var index2 = 0; index2 < analysis.result[index1].collections2Migrate.length; index2++) {
+                if (analysis.result[index1].collections2Migrate[index2].collectionName === collectionName) {
+                    return true;
+                }
+            }
         }
-      }
     }
-  }
-  return false;
+    return false;
 }
 
 /**
@@ -195,22 +204,25 @@ function isCollectionIncluded(analysis, databaseName, collectionName) {
  * @param  {Function} done            mocha's done() function
  */
 function analysisInclusionTest(dataType, originDataModel, targetDataModel, done) {
-  sthConfig.DATA_MODEL = targetDataModel;
-  sthDatabaseModelTool.getDataModelAnalysis(function(err, analysis) {
-    if (err) {
-      return done(err);
-    }
-    expect(analysis.currentDataModel).to.equal(targetDataModel);
-    expect(isDatabaseIncluded(analysis, DATABASE_NAME)).to.equal(true);
-    sthConfig.DATA_MODEL = originDataModel;
-    expect(
-      isCollectionIncluded(analysis, DATABASE_NAME,
-        dataType === sthTestConfig.DATA_TYPES.RAW ?
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS))
-    ).to.equal(true);
-    done();
-  });
+    sthConfig.DATA_MODEL = targetDataModel;
+    sthDatabaseModelTool.getDataModelAnalysis(function(err, analysis) {
+        if (err) {
+            return done(err);
+        }
+        expect(analysis.currentDataModel).to.equal(targetDataModel);
+        expect(isDatabaseIncluded(analysis, DATABASE_NAME)).to.equal(true);
+        sthConfig.DATA_MODEL = originDataModel;
+        expect(
+            isCollectionIncluded(
+                analysis,
+                DATABASE_NAME,
+                dataType === sthTestConfig.DATA_TYPES.RAW
+                    ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                    : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+            )
+        ).to.equal(true);
+        done();
+    });
 }
 
 /**
@@ -222,21 +234,24 @@ function analysisInclusionTest(dataType, originDataModel, targetDataModel, done)
  * @param  {Function} done            mocha's done() function
  */
 function analysisExclusionTest(dataType, originDataModel, targetDataModel, done) {
-  sthConfig.DATA_MODEL = targetDataModel;
-  sthDatabaseModelTool.getDataModelAnalysis(function(err, analysis) {
-    if (err) {
-      return done(err);
-    }
-    expect(analysis.currentDataModel).to.equal(targetDataModel);
-    sthConfig.DATA_MODEL = originDataModel;
-    expect(
-      isCollectionIncluded(analysis, DATABASE_NAME,
-        dataType === sthTestConfig.DATA_TYPES.RAW ?
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS))
-    ).to.equal(false);
-    done();
-  });
+    sthConfig.DATA_MODEL = targetDataModel;
+    sthDatabaseModelTool.getDataModelAnalysis(function(err, analysis) {
+        if (err) {
+            return done(err);
+        }
+        expect(analysis.currentDataModel).to.equal(targetDataModel);
+        sthConfig.DATA_MODEL = originDataModel;
+        expect(
+            isCollectionIncluded(
+                analysis,
+                DATABASE_NAME,
+                dataType === sthTestConfig.DATA_TYPES.RAW
+                    ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                    : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+            )
+        ).to.equal(false);
+        done();
+    });
 }
 
 /**
@@ -245,20 +260,22 @@ function analysisExclusionTest(dataType, originDataModel, targetDataModel, done)
  * @param  {Function} done            Mocha done() funtion
  */
 function systemCollectionNotIncludedTest(targetDataModel, done) {
-  sthConfig.DATA_MODEL = targetDataModel;
-  sthDatabaseModelTool.getDataModelAnalysis(function(err, analysis) {
-    if (err) {
-      return done(err);
-    }
-    for (var index1 = 0; index1 < analysis.result.length; index1++) {
-      if (analysis.result[index1].databaseName === DATABASE_NAME) {
-        for (var index2 = 0; index2 < analysis.result[index1].collections2Migrate.length; index2++) {
-          expect(analysis.result[index1].collections2Migrate[index2].collectionName.indexOf('system.')).not.to.equal(0);
+    sthConfig.DATA_MODEL = targetDataModel;
+    sthDatabaseModelTool.getDataModelAnalysis(function(err, analysis) {
+        if (err) {
+            return done(err);
         }
-      }
-    }
-    done();
-  });
+        for (var index1 = 0; index1 < analysis.result.length; index1++) {
+            if (analysis.result[index1].databaseName === DATABASE_NAME) {
+                for (var index2 = 0; index2 < analysis.result[index1].collections2Migrate.length; index2++) {
+                    expect(
+                        analysis.result[index1].collections2Migrate[index2].collectionName.indexOf('system.')
+                    ).not.to.equal(0);
+                }
+            }
+        }
+        done();
+    });
 }
 
 /**
@@ -267,47 +284,90 @@ function systemCollectionNotIncludedTest(targetDataModel, done) {
  * @param  {String}  aggregationType The aggregation type
  */
 function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
-  describe('collection per attribute analysis', function() {
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+    describe('collection per attribute analysis', function() {
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
+        );
 
-    it('should not detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
-      analysisExclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+        it(
+            'should not detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' data model',
+            analysisExclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE
+            )
+        );
 
-    it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
-      analysisInclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+        it(
+            'should detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' data model',
+            analysisInclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY
+            )
+        );
 
-    it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      analysisInclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            analysisInclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
+            )
+        );
 
-    cleanDatabaseTests(dataType);
-  });
+        cleanDatabaseTests(dataType);
+    });
 }
 
 /**
@@ -316,46 +376,90 @@ function collectionPerAttributeAnalysisTests(dataType, aggregationType) {
  * @param  {String}  aggregationType The aggregation type
  */
 function collectionPerEntityAnalysisTests(dataType, aggregationType) {
-  describe('collection per entity analysis', function() {
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+    describe('collection per entity analysis', function() {
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
+        );
 
-    it('should not detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
-      analysisExclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+        it(
+            'should not detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' data model',
+            analysisExclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY
+            )
+        );
 
-    it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
-      analysisInclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+        it(
+            'should detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' data model',
+            analysisInclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE
+            )
+        );
 
-    it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      analysisInclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            analysisInclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
+            )
+        );
 
-    cleanDatabaseTests(dataType);
-  });
+        cleanDatabaseTests(dataType);
+    });
 }
 
 /**
@@ -364,47 +468,90 @@ function collectionPerEntityAnalysisTests(dataType, aggregationType) {
  * @param  {String}  aggregationType The aggregation type
  */
 function collectionPerServicePathAnalysisTests(dataType, aggregationType) {
-  describe('collection per service path analysis', function() {
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+    describe('collection per service path analysis', function() {
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should not detect the any system.* collection needs migration to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should not detect the any system.* collection needs migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            systemCollectionNotIncludedTest.bind(null, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
+        );
 
-    it('should not detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      analysisExclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should not detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            analysisExclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
+            )
+        );
 
-    it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE + ' data model',
-      analysisInclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE));
+        it(
+            'should detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE +
+                ' data model',
+            analysisInclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE
+            )
+        );
 
-    it('should detect the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-      dataType + ' data collection needs ' +
-      'migration to the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' data model',
-      analysisInclusionTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+        it(
+            'should detect the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' ' +
+                dataType +
+                ' data collection needs ' +
+                'migration to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' data model',
+            analysisInclusionTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY
+            )
+        );
 
-    cleanDatabaseTests(dataType);
-  });
+        cleanDatabaseTests(dataType);
+    });
 }
 
 /**
@@ -414,18 +561,18 @@ function collectionPerServicePathAnalysisTests(dataType, aggregationType) {
  * @return {Object}                 The query
  */
 function getQuery4RawDataMigrationTest(originDataModel, targetDataModel) {
-  var query = {};
-  switch (targetDataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      query.entityId = sthTestConfig.ENTITY_ID;
-      query.entityType = sthTestConfig.ENTITY_TYPE;
-      query.attrName = ATTRIBUTE.NAME;
-      query.attrType = ATTRIBUTE.TYPE;
-      query.recvTime = ATTRIBUTE.RECV_TIME[originDataModel];
-      return query;
-    default:
-      return;
-  }
+    var query = {};
+    switch (targetDataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            query.entityId = sthTestConfig.ENTITY_ID;
+            query.entityType = sthTestConfig.ENTITY_TYPE;
+            query.attrName = ATTRIBUTE.NAME;
+            query.attrType = ATTRIBUTE.TYPE;
+            query.recvTime = ATTRIBUTE.RECV_TIME[originDataModel];
+            return query;
+        default:
+            return;
+    }
 }
 
 /**
@@ -434,13 +581,13 @@ function getQuery4RawDataMigrationTest(originDataModel, targetDataModel) {
  * @param  {Function} callback       The callback
  */
 function expectCollectionRemoved(collectionName, callback) {
-  sthDatabase.connection.collection(collectionName, { strict: true}, function(err) {
-    var error;
-    if (err.message.indexOf('does not exist') === -1) {
-      error = err;
-    }
-    callback(error);
-  });
+    sthDatabase.connection.collection(collectionName, { strict: true }, function(err) {
+        var error;
+        if (err.message.indexOf('does not exist') === -1) {
+            error = err;
+        }
+        callback(error);
+    });
 }
 
 /**
@@ -460,37 +607,43 @@ function expectCollectionRemoved(collectionName, callback) {
  * @param  {Function} done   mocha's done function
  */
 function expectRawDataMigration(params, options, done) {
-  sthDatabase.connection.collection(params.targetCollectionName, function(err, targetCollection) {
-    targetCollection.find(getQuery4RawDataMigrationTest(params.originDataModel, params.targetDataModel)).
-      toArray(function(err, results) {
-        if (err) {
-          return done(err);
-        }
-        expect(results.length).to.equal(1);
-        expect(results[0].attrValue).to.equal(
-          params.aggregationType === sthConfig.AGGREGATIONS.NUMERIC ?
-            ATTRIBUTE.VALUE.NUMERIC : params.originDataModel);
-        targetCollection.find(getQuery4RawDataMigrationTest(params.targetDataModel, params.targetDataModel)).
-          toArray(function(err, results) {
-            if (err) {
-              return done(err);
-            }
-            if (options.updateCollection) {
+    sthDatabase.connection.collection(params.targetCollectionName, function(err, targetCollection) {
+        targetCollection
+            .find(getQuery4RawDataMigrationTest(params.originDataModel, params.targetDataModel))
+            .toArray(function(err, results) {
+                if (err) {
+                    return done(err);
+                }
                 expect(results.length).to.equal(1);
                 expect(results[0].attrValue).to.equal(
-                  params.aggregationType === sthConfig.AGGREGATIONS.NUMERIC ?
-                    ATTRIBUTE.VALUE.NUMERIC : params.targetDataModel);
-            } else {
-              expect(results.length).to.equal(0);
-            }
-            if (options.removeCollection) {
-              expectCollectionRemoved(params.originCollectionName, done);
-            } else {
-              done();
-            }
-          });
-      });
-  });
+                    params.aggregationType === sthConfig.AGGREGATIONS.NUMERIC
+                        ? ATTRIBUTE.VALUE.NUMERIC
+                        : params.originDataModel
+                );
+                targetCollection
+                    .find(getQuery4RawDataMigrationTest(params.targetDataModel, params.targetDataModel))
+                    .toArray(function(err, results) {
+                        if (err) {
+                            return done(err);
+                        }
+                        if (options.updateCollection) {
+                            expect(results.length).to.equal(1);
+                            expect(results[0].attrValue).to.equal(
+                                params.aggregationType === sthConfig.AGGREGATIONS.NUMERIC
+                                    ? ATTRIBUTE.VALUE.NUMERIC
+                                    : params.targetDataModel
+                            );
+                        } else {
+                            expect(results.length).to.equal(0);
+                        }
+                        if (options.removeCollection) {
+                            expectCollectionRemoved(params.originCollectionName, done);
+                        } else {
+                            done();
+                        }
+                    });
+            });
+    });
 }
 
 /**
@@ -501,18 +654,18 @@ function expectRawDataMigration(params, options, done) {
  * @return {Object}                 The query
  */
 function getQuery4AggregatedDataMigrationTest(originDataModel, targetDataModel, resolution) {
-  var query = {};
-  switch (targetDataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      query['_id.entityId'] = sthTestConfig.ENTITY_ID;
-      query['_id.entityType'] = sthTestConfig.ENTITY_TYPE;
-      query['_id.attrName'] = ATTRIBUTE.NAME;
-      query['_id.origin'] = sthUtils.getOrigin(ATTRIBUTE.RECV_TIME[originDataModel], resolution);
-      query['_id.resolution'] = resolution;
-      return query;
-    default:
-      return;
-  }
+    var query = {};
+    switch (targetDataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            query['_id.entityId'] = sthTestConfig.ENTITY_ID;
+            query['_id.entityType'] = sthTestConfig.ENTITY_TYPE;
+            query['_id.attrName'] = ATTRIBUTE.NAME;
+            query['_id.origin'] = sthUtils.getOrigin(ATTRIBUTE.RECV_TIME[originDataModel], resolution);
+            query['_id.resolution'] = resolution;
+            return query;
+        default:
+            return;
+    }
 }
 
 /**
@@ -521,11 +674,11 @@ function getQuery4AggregatedDataMigrationTest(originDataModel, targetDataModel, 
  * @param {Number} offset The offset
  */
 function getAggregatedEntry4Offset(points, offset) {
-  for (var index = 0; index < points.length; index++) {
-    if (points[index].offset === offset) {
-      return points[index];
+    for (var index = 0; index < points.length; index++) {
+        if (points[index].offset === offset) {
+            return points[index];
+        }
     }
-  }
 }
 
 /**
@@ -549,82 +702,84 @@ function getAggregatedEntry4Offset(points, offset) {
  * @param  {Function} callback         The callback
  */
 function expectAggregatedDataMigration4Resolution(params, options, callback) {
-  params.targetCollection.find(
-    getQuery4AggregatedDataMigrationTest(params.originDataModel, params.targetDataModel, params.resolution)
-  ).toArray(function(err, results) {
-    if (err) {
-      return process.nextTick(callback.bind(this, err));
-    }
-    expect(results.length).to.equal(1);
-    var point = getAggregatedEntry4Offset(results[0].points,
-      sthUtils.getOffset(params.resolution, ATTRIBUTE.RECV_TIME[params.originDataModel]));
-    if (options.updateCollection) {
-      if (point.sum) {
-        expect(point.samples).to.equal(2);
-        expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC * 2);
-        expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2) * 2);
-        expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-        expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-      } else {
-        expect(point.samples).to.equal(2);
-        expect(point.occur[params.originDataModel]).to.equal(1);
-        expect(point.occur[params.targetDataModel]).to.equal(1);
-      }
-    } else {
-      if (point.sum) {
-        expect(point.samples).to.equal(1);
-        expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-        expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2));
-        expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-        expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-      } else {
-        expect(point.samples).to.equal(1);
-        expect(point.occur[params.originDataModel]).to.equal(1);
-      }
-    }
-    return process.nextTick(callback);
-  });
+    params.targetCollection
+        .find(getQuery4AggregatedDataMigrationTest(params.originDataModel, params.targetDataModel, params.resolution))
+        .toArray(function(err, results) {
+            if (err) {
+                return process.nextTick(callback.bind(this, err));
+            }
+            expect(results.length).to.equal(1);
+            var point = getAggregatedEntry4Offset(
+                results[0].points,
+                sthUtils.getOffset(params.resolution, ATTRIBUTE.RECV_TIME[params.originDataModel])
+            );
+            if (options.updateCollection) {
+                if (point.sum) {
+                    expect(point.samples).to.equal(2);
+                    expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC * 2);
+                    expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2) * 2);
+                    expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                    expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                } else {
+                    expect(point.samples).to.equal(2);
+                    expect(point.occur[params.originDataModel]).to.equal(1);
+                    expect(point.occur[params.targetDataModel]).to.equal(1);
+                }
+            } else {
+                if (point.sum) {
+                    expect(point.samples).to.equal(1);
+                    expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                    expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2));
+                    expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                    expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                } else {
+                    expect(point.samples).to.equal(1);
+                    expect(point.occur[params.originDataModel]).to.equal(1);
+                }
+            }
+            return process.nextTick(callback);
+        });
 }
 
 /**
-* Expectations to be validated for the migration of aggregated data type
-* @param  {Object}   params  An object including the following properties:
-*                              - dataType: The data type
-*                              - aggregationType: The aggregation type
-*                              - originCollectionName: The origin collection name
-*                              - originDataModel: The origin data model
-*                              - targetCollectionName: The target collection name
-*                              - targetDataModel: The target data model
-* @param  {Object}   options An object including the following properties:
-*                              - removeCollection: Flag indicating if the origin collection should be removed after
-*                                                    the migration
-*                              - updateCollection: Flag indicating if the target collection should be updated if it
-*                                                    exists
+ * Expectations to be validated for the migration of aggregated data type
+ * @param  {Object}   params  An object including the following properties:
+ *                              - dataType: The data type
+ *                              - aggregationType: The aggregation type
+ *                              - originCollectionName: The origin collection name
+ *                              - originDataModel: The origin data model
+ *                              - targetCollectionName: The target collection name
+ *                              - targetDataModel: The target data model
+ * @param  {Object}   options An object including the following properties:
+ *                              - removeCollection: Flag indicating if the origin collection should be removed after
+ *                                                    the migration
+ *                              - updateCollection: Flag indicating if the target collection should be updated if it
+ *                                                    exists
  * @param  {Function} done  mocha's done() function
  */
 function expectAggregatedDataMigration(params, options, done) {
-  async.waterfall(
-    [
-      async.apply(sthDatabase.connection.collection.bind(sthDatabase.connection, params.targetCollectionName)),
-      function onTargetCollection(targetCollection, callback) {
-        var expect4Resolution = [];
-        sthConfig.AGGREGATION_BY.forEach(function(resolution) {
-          params.resolution = resolution;
-          params.targetCollection = targetCollection;
-          expect4Resolution.push(
-            async.apply(expectAggregatedDataMigration4Resolution, params, options));
-        });
-        async.parallel(expect4Resolution, callback);
-      },
-      function expectOriginCollectionRemoved(expect4ResolutionResult, callback) {
-        if (options.removeCollection) {
-          expectCollectionRemoved(params.originCollectionName, callback);
-        } else {
-          callback();
-        }
-      }
-    ],
-    done);
+    async.waterfall(
+        [
+            async.apply(sthDatabase.connection.collection.bind(sthDatabase.connection, params.targetCollectionName)),
+            function onTargetCollection(targetCollection, callback) {
+                var expect4Resolution = [];
+                sthConfig.AGGREGATION_BY.forEach(function(resolution) {
+                    params.resolution = resolution;
+                    params.targetCollection = targetCollection;
+                    expect4Resolution.push(async.apply(expectAggregatedDataMigration4Resolution, params, options));
+                });
+                async.parallel(expect4Resolution, callback);
+            },
+            function expectOriginCollectionRemoved(expect4ResolutionResult, callback) {
+                if (options.removeCollection) {
+                    expectCollectionRemoved(params.originCollectionName, callback);
+                } else {
+                    callback();
+                }
+            },
+        ],
+        done
+    );
 }
 
 /**
@@ -642,29 +797,30 @@ function expectAggregatedDataMigration(params, options, done) {
  * @param  {Function} done   mocha's done() function
  */
 function migrationTest(params, options, done) {
-  sthConfig.DATA_MODEL = params.originDataModel;
-  var originCollectionName = (params.dataType === sthTestConfig.DATA_TYPES.RAW ?
-    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS));
-  params.originCollectionName = originCollectionName;
+    sthConfig.DATA_MODEL = params.originDataModel;
+    var originCollectionName =
+        params.dataType === sthTestConfig.DATA_TYPES.RAW
+            ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+            : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
+    params.originCollectionName = originCollectionName;
 
-  sthConfig.DATA_MODEL = params.targetDataModel;
-  var targetCollectionName = (params.dataType === sthTestConfig.DATA_TYPES.RAW ?
-    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS));
-  params.targetCollectionName = targetCollectionName;
+    sthConfig.DATA_MODEL = params.targetDataModel;
+    var targetCollectionName =
+        params.dataType === sthTestConfig.DATA_TYPES.RAW
+            ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+            : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
+    params.targetCollectionName = targetCollectionName;
 
-  sthDatabaseModelTool.migrateCollection(DATABASE_NAME, originCollectionName, options,
-    function(err) {
-    if (err) {
-      return done(err);
-    }
-    if (params.dataType === sthTestConfig.DATA_TYPES.RAW) {
-      expectRawDataMigration(params, options, done);
-    } else {
-      expectAggregatedDataMigration(params, options, done);
-    }
-  });
+    sthDatabaseModelTool.migrateCollection(DATABASE_NAME, originCollectionName, options, function(err) {
+        if (err) {
+            return done(err);
+        }
+        if (params.dataType === sthTestConfig.DATA_TYPES.RAW) {
+            expectRawDataMigration(params, options, done);
+        } else {
+            expectAggregatedDataMigration(params, options, done);
+        }
+    });
 }
 
 /**
@@ -675,16 +831,17 @@ function migrationTest(params, options, done) {
  * @param  {Function} done            mocha's done() function
  */
 function noMigrationTest(dataType, originDataModel, targetDataModel, done) {
-  sthConfig.DATA_MODEL = originDataModel;
-  var originCollectionName = (dataType === sthTestConfig.DATA_TYPES.RAW ?
-    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS));
+    sthConfig.DATA_MODEL = originDataModel;
+    var originCollectionName =
+        dataType === sthTestConfig.DATA_TYPES.RAW
+            ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+            : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
 
-  sthConfig.DATA_MODEL = targetDataModel;
-  sthDatabaseModelTool.migrateCollection(DATABASE_NAME, originCollectionName, function(err) {
-    expect(err).to.exit;
-    done();
-  });
+    sthConfig.DATA_MODEL = targetDataModel;
+    sthDatabaseModelTool.migrateCollection(DATABASE_NAME, originCollectionName, function(err) {
+        expect(err).to.exit;
+        done();
+    });
 }
 
 /**
@@ -694,27 +851,43 @@ function noMigrationTest(dataType, originDataModel, targetDataModel, done) {
  * @param  {String} aggregationType The aggregation type
  */
 function collectionPerEntityNotUpdatableMigrationTests(dataType, aggregationType) {
-  describe('collection per entity not updatable migration', function() {
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+    describe('collection per entity not updatable migration', function() {
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
+        );
 
-    it('should not migrate the ' + dataType + ' data collection from the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model',
-      noMigrationTest.bind(null, dataType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
-    );
+        it(
+            'should not migrate the ' +
+                dataType +
+                ' data collection from the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model',
+            noMigrationTest.bind(
+                null,
+                dataType,
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
+            )
+        );
 
-    cleanDatabaseTests(dataType);
-  });
+        cleanDatabaseTests(dataType);
+    });
 }
 
 /**
@@ -729,30 +902,39 @@ function collectionPerEntityNotUpdatableMigrationTests(dataType, aggregationType
  *                                                          it exists
  */
 function collectionPerEntityCleanMigrationTests(dataType, aggregationType, options) {
-  describe('collection per entity clean migration', function() {
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+    describe('collection per entity clean migration', function() {
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should migrate the ' + dataType + ' data collection from the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model' +
-      (options.removeCollection ? ' removing the original collection afterwards': ''),
-      migrationTest.bind(
-        null,
-        {
-          dataType: dataType,
-          aggregationType: aggregationType,
-          originDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-          targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
-        },
-        options
-      )
-    );
+        it(
+            'should migrate the ' +
+                dataType +
+                ' data collection from the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model' +
+                (options.removeCollection ? ' removing the original collection afterwards' : ''),
+            migrationTest.bind(
+                null,
+                {
+                    dataType: dataType,
+                    aggregationType: aggregationType,
+                    originDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+                    targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                },
+                options
+            )
+        );
 
-    cleanDatabaseTests(dataType);
-  });
+        cleanDatabaseTests(dataType);
+    });
 }
 
 /**
@@ -767,106 +949,106 @@ function collectionPerEntityCleanMigrationTests(dataType, aggregationType, optio
  *                                                          it exists
  */
 function collectionPerEntityUpdateMigrationTests(dataType, aggregationType, options) {
-  describe('collection per entity updatable migration', function() {
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY));
+    describe('collection per entity updatable migration', function() {
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY)
+        );
 
-    it('should insert data into the ' + sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' ' +
-      dataType + ' data collection',
-      insertData.bind(null, dataType, aggregationType,
-        sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH));
+        it(
+            'should insert data into the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' ' +
+                dataType +
+                ' data collection',
+            insertData.bind(null, dataType, aggregationType, sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH)
+        );
 
-    it('should migrate the ' + dataType + ' data collection from the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY + ' to the ' +
-      sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH + ' data model updating the target collection' +
-      (options.removeCollection ? ' and removing the original collection afterwards': ''),
-      migrationTest.bind(
-        null,
-        {
-          dataType: dataType,
-          aggregationType: aggregationType,
-          originDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
-          targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH
-        },
-        options
-      )
-    );
+        it(
+            'should migrate the ' +
+                dataType +
+                ' data collection from the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY +
+                ' to the ' +
+                sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH +
+                ' data model updating the target collection' +
+                (options.removeCollection ? ' and removing the original collection afterwards' : ''),
+            migrationTest.bind(
+                null,
+                {
+                    dataType: dataType,
+                    aggregationType: aggregationType,
+                    originDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY,
+                    targetDataModel: sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH,
+                },
+                options
+            )
+        );
 
-    cleanDatabaseTests(dataType);
-  });
+        cleanDatabaseTests(dataType);
+    });
 }
 
 describe('sthDatabaseModelTool tests', function() {
-  this.timeout(5000);
-  var originalDataModel = sthConfig.DATA_MODEL;
-  [sthConfig.AGGREGATIONS.NUMERIC, sthConfig.AGGREGATIONS.TEXTUAL].forEach(function(aggregationType) {
-    describe(aggregationType + ' aggregation type', function() {
-      var dataTypes = Object.keys(sthTestConfig.DATA_TYPES);
-      dataTypes.forEach(function(dataType) {
-        describe(sthTestConfig.DATA_TYPES[dataType] + ' data', function() {
-          describe('data model analysis', function() {
-            before(connectToDatabase);
+    this.timeout(5000);
+    var originalDataModel = sthConfig.DATA_MODEL;
+    [sthConfig.AGGREGATIONS.NUMERIC, sthConfig.AGGREGATIONS.TEXTUAL].forEach(function(aggregationType) {
+        describe(aggregationType + ' aggregation type', function() {
+            var dataTypes = Object.keys(sthTestConfig.DATA_TYPES);
+            dataTypes.forEach(function(dataType) {
+                describe(sthTestConfig.DATA_TYPES[dataType] + ' data', function() {
+                    describe('data model analysis', function() {
+                        before(connectToDatabase);
 
-            cleanDatabaseTests(dataType);
+                        cleanDatabaseTests(dataType);
 
-            collectionPerAttributeAnalysisTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
+                        collectionPerAttributeAnalysisTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
 
-            collectionPerEntityAnalysisTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
+                        collectionPerEntityAnalysisTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
 
-            collectionPerServicePathAnalysisTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
-          });
+                        collectionPerServicePathAnalysisTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
+                    });
 
-          describe('data model migration', function() {
-            before(connectToDatabase);
+                    describe('data model migration', function() {
+                        before(connectToDatabase);
 
-            cleanDatabaseTests(dataType);
+                        cleanDatabaseTests(dataType);
 
-            collectionPerEntityNotUpdatableMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType);
+                        collectionPerEntityNotUpdatableMigrationTests(
+                            sthTestConfig.DATA_TYPES[dataType],
+                            aggregationType
+                        );
 
-            collectionPerEntityCleanMigrationTests(
-              sthTestConfig.DATA_TYPES[dataType],
-              aggregationType,
-              {
-                removeCollection: false,
-                updateCollection: false
-              }
-            );
+                        collectionPerEntityCleanMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
+                            removeCollection: false,
+                            updateCollection: false,
+                        });
 
-            collectionPerEntityCleanMigrationTests(
-              sthTestConfig.DATA_TYPES[dataType],
-              aggregationType,
-              {
-                removeCollection: true,
-                updateCollection: false
-              }
-            );
+                        collectionPerEntityCleanMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
+                            removeCollection: true,
+                            updateCollection: false,
+                        });
 
-            collectionPerEntityUpdateMigrationTests(
-              sthTestConfig.DATA_TYPES[dataType],
-              aggregationType,
-              {
-                removeCollection: false,
-                updateCollection: true
-              }
-            );
+                        collectionPerEntityUpdateMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
+                            removeCollection: false,
+                            updateCollection: true,
+                        });
 
-            collectionPerEntityUpdateMigrationTests(
-              sthTestConfig.DATA_TYPES[dataType],
-              aggregationType,
-              {
-                removeCollection: true,
-                updateCollection: true
-              }
-            );
-          });
+                        collectionPerEntityUpdateMigrationTests(sthTestConfig.DATA_TYPES[dataType], aggregationType, {
+                            removeCollection: true,
+                            updateCollection: true,
+                        });
+                    });
+                });
+            });
         });
-      });
     });
-  });
 
-  after(function() {
-    sthConfig.DATA_MODEL = originalDataModel;
-  });
+    after(function() {
+        sthConfig.DATA_MODEL = originalDataModel;
+    });
 });

--- a/test/unit/sthDatabaseNameCodecTool_test.js
+++ b/test/unit/sthDatabaseNameCodecTool_test.js
@@ -41,14 +41,14 @@ var DATABASE_CONNECTION_PARAMS = {
     dbURI: sthConfig.DB_URI,
     replicaSet: sthConfig.REPLICA_SET,
     database: DATABASE_NAME,
-    poolSize: sthConfig.POOL_SIZE,
+    poolSize: sthConfig.POOL_SIZE
 };
 var COLLECTION_NAME_PARAMS = {
     service: DEFAULT_SERVICE,
     servicePath: sthConfig.DEFAULT_SERVICE_PATH,
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
-    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrName: sthTestConfig.ATTRIBUTE_NAME
 };
 
 /**
@@ -73,12 +73,12 @@ function createRawAndAggregatedCollections(callback) {
     async.series(
         [
             async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
-                shouldCreate: true,
+                shouldCreate: true
             }),
             async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
                 shouldCreate: true,
-                isAggregated: true,
-            }),
+                isAggregated: true
+            })
         ],
         callback
     );
@@ -140,7 +140,7 @@ function encodeDecodeMandatoryOptionsTest(function2Test, callback) {
 function collectionAndDatabaseMandatoryOptionsTest(function2Test, callback) {
     function2Test(
         {
-            collection: sthConfig.COLLECTION_PREFIX + 'any_collection',
+            collection: sthConfig.COLLECTION_PREFIX + 'any_collection'
         },
         function(err) {
             expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
@@ -159,7 +159,7 @@ function shouldDetectCollectionTest(encodingFlag, databaseName, collectionName, 
     sthDatabaseNameCodecTool.getEncodingAnalysis(
         {
             encode: !!encodingFlag,
-            decode: !encodingFlag,
+            decode: !encodingFlag
         },
         function(err, analysis) {
             if (err) {
@@ -184,7 +184,7 @@ function shouldNotDetectCollectionTest(encodingFlag, databaseName, callback) {
             encode: !!encodingFlag,
             decode: !encodingFlag,
             database: databaseName,
-            collection: sthConfig.COLLECTION_PREFIX + 'inexistent_collection',
+            collection: sthConfig.COLLECTION_PREFIX + 'inexistent_collection'
         },
         function(err, analysis) {
             if (err) {
@@ -230,7 +230,7 @@ function shouldEncodeOrDecodeDatabaseTest(databaseName, encodingFlag, callback) 
         {
             encode: !!encodingFlag,
             decode: !encodingFlag,
-            database: databaseName,
+            database: databaseName
         },
         function(err) {
             if (err) {
@@ -271,7 +271,7 @@ function shouldEncodeOrDecodeCollectionTest(databaseName, collectionName, encodi
             encode: !!encodingFlag,
             decode: !encodingFlag,
             database: databaseName,
-            collection: collectionName,
+            collection: collectionName
         },
         function(err) {
             if (err) {
@@ -330,7 +330,7 @@ describe('sthDatabaseNameCodecTool tests', function() {
             it("should detect database '" + DATABASE_NAME + "' as susceptible of being encoded", function(done) {
                 sthDatabaseNameCodecTool.getEncodingAnalysis(
                     {
-                        encode: true,
+                        encode: true
                     },
                     function(err, analysis) {
                         if (err) {
@@ -348,7 +348,7 @@ describe('sthDatabaseNameCodecTool tests', function() {
                     sthDatabaseNameCodecTool.getEncodingAnalysis(
                         {
                             encode: true,
-                            database: sthConfig.DB_PREFIX + 'inexistent_database',
+                            database: sthConfig.DB_PREFIX + 'inexistent_database'
                         },
                         function(err, analysis) {
                             if (err) {

--- a/test/unit/sthDatabaseNameCodecTool_test.js
+++ b/test/unit/sthDatabaseNameCodecTool_test.js
@@ -37,18 +37,18 @@ var sthTestConfig = require(ROOT_PATH + '/test/unit/sthTestConfiguration');
 var DEFAULT_SERVICE = sthConfig.DEFAULT_SERVICE.replace(/s/g, 'S');
 var DATABASE_NAME = sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE);
 var DATABASE_CONNECTION_PARAMS = {
-  authentication: sthConfig.DB_AUTHENTICATION,
-  dbURI: sthConfig.DB_URI,
-  replicaSet: sthConfig.REPLICA_SET,
-  database: DATABASE_NAME,
-  poolSize: sthConfig.POOL_SIZE
+    authentication: sthConfig.DB_AUTHENTICATION,
+    dbURI: sthConfig.DB_URI,
+    replicaSet: sthConfig.REPLICA_SET,
+    database: DATABASE_NAME,
+    poolSize: sthConfig.POOL_SIZE,
 };
 var COLLECTION_NAME_PARAMS = {
-  service: DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME
+    service: DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
 };
 
 /**
@@ -56,10 +56,13 @@ var COLLECTION_NAME_PARAMS = {
  * @param  {Function} callback The callblack
  */
 function connectToDatabase(callback) {
-  if (sthDatabase.connection) {
-    return process.nextTick(callback.bind(null, null, sthDatabase.connection));
-  }
-  sthDatabase.connect(DATABASE_CONNECTION_PARAMS, callback);
+    if (sthDatabase.connection) {
+        return process.nextTick(callback.bind(null, null, sthDatabase.connection));
+    }
+    sthDatabase.connect(
+        DATABASE_CONNECTION_PARAMS,
+        callback
+    );
 }
 
 /**
@@ -67,26 +70,18 @@ function connectToDatabase(callback) {
  * @param  {Function} callback The callback
  */
 function createRawAndAggregatedCollections(callback) {
-  async.series(
-    [
-      async.apply(
-        sthDatabase.getCollection,
-        COLLECTION_NAME_PARAMS,
-        {
-          shouldCreate: true
-        }
-      ),
-      async.apply(
-        sthDatabase.getCollection,
-        COLLECTION_NAME_PARAMS,
-        {
-          shouldCreate: true,
-          isAggregated: true
-        }
-      )
-    ],
-    callback
-  );
+    async.series(
+        [
+            async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
+                shouldCreate: true,
+            }),
+            async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
+                shouldCreate: true,
+                isAggregated: true,
+            }),
+        ],
+        callback
+    );
 }
 
 /**
@@ -96,12 +91,15 @@ function createRawAndAggregatedCollections(callback) {
  * @param  {Function} callback       The callback
  */
 function checkCollectionExists(databaseName, collectionName, callback) {
-  sthDatabase.connection.db(databaseName).listCollections({name: collectionName}).toArray(function(err, collections) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    return process.nextTick(callback.bind(null, err, collections.length === 1));
-  });
+    sthDatabase.connection
+        .db(databaseName)
+        .listCollections({ name: collectionName })
+        .toArray(function(err, collections) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            return process.nextTick(callback.bind(null, err, collections.length === 1));
+        });
 }
 
 /**
@@ -109,17 +107,17 @@ function checkCollectionExists(databaseName, collectionName, callback) {
  * @param  {Function} callback The callback
  */
 function dropDatabases(callback) {
-  sthDatabase.connection.db(DATABASE_NAME.toLowerCase()).dropDatabase(function(err) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    sthDatabase.connection.db(DATABASE_NAME).dropDatabase(function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      sthDatabase.connection.db(sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME)).dropDatabase(callback);
+    sthDatabase.connection.db(DATABASE_NAME.toLowerCase()).dropDatabase(function(err) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
+        }
+        sthDatabase.connection.db(DATABASE_NAME).dropDatabase(function(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            sthDatabase.connection.db(sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME)).dropDatabase(callback);
+        });
     });
-  });
 }
 
 /**
@@ -128,14 +126,10 @@ function dropDatabases(callback) {
  * @param  {Function} callback      The callback
  */
 function encodeDecodeMandatoryOptionsTest(function2Test, callback) {
-  function2Test(
-    {
-    },
-    function(err) {
-      expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
-      process.nextTick(callback);
-    }
-  );
+    function2Test({}, function(err) {
+        expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
+        process.nextTick(callback);
+    });
 }
 
 /**
@@ -144,15 +138,15 @@ function encodeDecodeMandatoryOptionsTest(function2Test, callback) {
  * @param  {Function} callback      The callback
  */
 function collectionAndDatabaseMandatoryOptionsTest(function2Test, callback) {
-  function2Test(
-    {
-      collection: sthConfig.COLLECTION_PREFIX + 'any_collection'
-    },
-    function(err) {
-      expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
-      process.nextTick(callback);
-    }
-  );
+    function2Test(
+        {
+            collection: sthConfig.COLLECTION_PREFIX + 'any_collection',
+        },
+        function(err) {
+            expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
+            process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -162,22 +156,21 @@ function collectionAndDatabaseMandatoryOptionsTest(function2Test, callback) {
  * @param  {Function} callback       The callback
  */
 function shouldDetectCollectionTest(encodingFlag, databaseName, collectionName, callback) {
-  sthDatabaseNameCodecTool.getEncodingAnalysis(
-    {
-      encode: !!encodingFlag,
-      decode: !encodingFlag
-    },
-    function(err, analysis) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      expect(analysis[databaseName]).to.not.be(undefined);
-      expect(analysis[databaseName].collections).to.not.be(undefined);
-      expect(analysis[databaseName].collections[collectionName].
-        name).to.not.equal(collectionName);
-      return process.nextTick(callback);
-    }
-  );
+    sthDatabaseNameCodecTool.getEncodingAnalysis(
+        {
+            encode: !!encodingFlag,
+            decode: !encodingFlag,
+        },
+        function(err, analysis) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            expect(analysis[databaseName]).to.not.be(undefined);
+            expect(analysis[databaseName].collections).to.not.be(undefined);
+            expect(analysis[databaseName].collections[collectionName].name).to.not.equal(collectionName);
+            return process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -186,22 +179,22 @@ function shouldDetectCollectionTest(encodingFlag, databaseName, collectionName, 
  * @param  {Function} callback     The callback
  */
 function shouldNotDetectCollectionTest(encodingFlag, databaseName, callback) {
-  sthDatabaseNameCodecTool.getEncodingAnalysis(
-    {
-      encode: !!encodingFlag,
-      decode: !encodingFlag,
-      database: databaseName,
-      collection: sthConfig.COLLECTION_PREFIX + 'inexistent_collection'
-    },
-    function(err, analysis) {
-     if (err) {
-       return process.nextTick(callback.bind(null, err));
-      }
-     expect(analysis[databaseName]).to.not.be(undefined);
-     expect(analysis[databaseName].collections).to.be(undefined);
-     return process.nextTick(callback);
-    }
-  );
+    sthDatabaseNameCodecTool.getEncodingAnalysis(
+        {
+            encode: !!encodingFlag,
+            decode: !encodingFlag,
+            database: databaseName,
+            collection: sthConfig.COLLECTION_PREFIX + 'inexistent_collection',
+        },
+        function(err, analysis) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            expect(analysis[databaseName]).to.not.be(undefined);
+            expect(analysis[databaseName].collections).to.be(undefined);
+            return process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -210,19 +203,19 @@ function shouldNotDetectCollectionTest(encodingFlag, databaseName, callback) {
  * @param  {Function} callback     The callback
  */
 function checkDatabaseExists(databaseName, callback) {
-  var adminDB = sthDatabase.connection.admin();
-  adminDB.listDatabases(function(err, databases) {
-    var databaseFound = false;
-    databases.databases.forEach(function (database) {
-      if (database.name === databaseName) {
-        databaseFound = true;
-        return process.nextTick(callback.bind(null, null, databaseFound));
-      }
+    var adminDB = sthDatabase.connection.admin();
+    adminDB.listDatabases(function(err, databases) {
+        var databaseFound = false;
+        databases.databases.forEach(function(database) {
+            if (database.name === databaseName) {
+                databaseFound = true;
+                return process.nextTick(callback.bind(null, null, databaseFound));
+            }
+        });
+        if (!databaseFound) {
+            return process.nextTick(callback.bind(null, null, false));
+        }
     });
-    if (!databaseFound) {
-      return process.nextTick(callback.bind(null, null, false));
-    }
-  });
 }
 
 /**
@@ -233,38 +226,36 @@ function checkDatabaseExists(databaseName, callback) {
  * @param  {Function} callback       The callback
  */
 function shouldEncodeOrDecodeDatabaseTest(databaseName, encodingFlag, callback) {
-  sthDatabaseNameCodecTool.encodeOrDecode(
-    {
-      encode: !!encodingFlag,
-      decode: !encodingFlag,
-      database: databaseName
-    },
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      checkDatabaseExists(
-        databaseName,
-        function(err, exists) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          expect(exists).to.be.equal(false);
-          checkDatabaseExists(
-            encodingFlag ? sthDatabaseNameCodec.encodeDatabaseName(databaseName) :
-              sthDatabaseNameCodec.decodeDatabaseName(databaseName),
-            function(err, exists) {
-              if (err) {
+    sthDatabaseNameCodecTool.encodeOrDecode(
+        {
+            encode: !!encodingFlag,
+            decode: !encodingFlag,
+            database: databaseName,
+        },
+        function(err) {
+            if (err) {
                 return process.nextTick(callback.bind(null, err));
-              }
-              expect(exists).to.be.equal(true);
-              process.nextTick(callback);
             }
-          );
+            checkDatabaseExists(databaseName, function(err, exists) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                expect(exists).to.be.equal(false);
+                checkDatabaseExists(
+                    encodingFlag
+                        ? sthDatabaseNameCodec.encodeDatabaseName(databaseName)
+                        : sthDatabaseNameCodec.decodeDatabaseName(databaseName),
+                    function(err, exists) {
+                        if (err) {
+                            return process.nextTick(callback.bind(null, err));
+                        }
+                        expect(exists).to.be.equal(true);
+                        process.nextTick(callback);
+                    }
+                );
+            });
         }
-      );
-    }
-  );
+    );
 }
 
 /**
@@ -275,303 +266,390 @@ function shouldEncodeOrDecodeDatabaseTest(databaseName, encodingFlag, callback) 
  * @param  {Function} callback       The callback
  */
 function shouldEncodeOrDecodeCollectionTest(databaseName, collectionName, encodingFlag, callback) {
-  sthDatabaseNameCodecTool.encodeOrDecode(
-    {
-      encode: !!encodingFlag,
-      decode: !encodingFlag,
-      database: databaseName,
-      collection: collectionName
-    },
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      checkCollectionExists(databaseName, collectionName,
-        function(err, exists) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          expect(exists).to.be.equal(false);
-          checkCollectionExists(
-            encodingFlag ? sthDatabaseNameCodec.encodeDatabaseName(databaseName) :
-              sthDatabaseNameCodec.decodeDatabaseName(databaseName),
-            encodingFlag ? sthDatabaseNameCodec.encodeCollectionName(collectionName) :
-              sthDatabaseNameCodec.decodeCollectionName(collectionName),
-            function(err, exists) {
-              if (err) {
+    sthDatabaseNameCodecTool.encodeOrDecode(
+        {
+            encode: !!encodingFlag,
+            decode: !encodingFlag,
+            database: databaseName,
+            collection: collectionName,
+        },
+        function(err) {
+            if (err) {
                 return process.nextTick(callback.bind(null, err));
-              }
-              expect(exists).to.be.equal(true);
-              process.nextTick(callback);
             }
-          );
+            checkCollectionExists(databaseName, collectionName, function(err, exists) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                expect(exists).to.be.equal(false);
+                checkCollectionExists(
+                    encodingFlag
+                        ? sthDatabaseNameCodec.encodeDatabaseName(databaseName)
+                        : sthDatabaseNameCodec.decodeDatabaseName(databaseName),
+                    encodingFlag
+                        ? sthDatabaseNameCodec.encodeCollectionName(collectionName)
+                        : sthDatabaseNameCodec.decodeCollectionName(collectionName),
+                    function(err, exists) {
+                        if (err) {
+                            return process.nextTick(callback.bind(null, err));
+                        }
+                        expect(exists).to.be.equal(true);
+                        process.nextTick(callback);
+                    }
+                );
+            });
         }
-      );
-    }
-  );
+    );
 }
 
 describe('sthDatabaseNameCodecTool tests', function() {
-  this.timeout(5000);
-  var ORIGINAL_NAME_ENCODING = sthConfig.NAME_ENCODING,
-      ORIGINAL_NAME_SEPARATOR = sthConfig.NAME_SEPARATOR;
+    this.timeout(5000);
+    var ORIGINAL_NAME_ENCODING = sthConfig.NAME_ENCODING,
+        ORIGINAL_NAME_SEPARATOR = sthConfig.NAME_SEPARATOR;
 
-  describe('getEncodingAnalysis tests', function() {
-    describe('name encoding disabled', function() {
-      sthConfig.NAME_ENCODING = false;
-      sthConfig.NAME_SEPARATOR = '_';
-      before(function(done) {
-        sthConfig.NAME_ENCODING = false;
-        sthConfig.NAME_SEPARATOR = '_';
-        async.series(
-          [
-            connectToDatabase,
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
+    describe('getEncodingAnalysis tests', function() {
+        describe('name encoding disabled', function() {
+            sthConfig.NAME_ENCODING = false;
+            sthConfig.NAME_SEPARATOR = '_';
+            before(function(done) {
+                sthConfig.NAME_ENCODING = false;
+                sthConfig.NAME_SEPARATOR = '_';
+                async.series([connectToDatabase, dropDatabases, createRawAndAggregatedCollections], done);
+            });
 
-      it('should raise an error if neither -e, --encode or -d, --decode options are set',
-        encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis));
+            it(
+                'should raise an error if neither -e, --encode or -d, --decode options are set',
+                encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
+            );
 
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis));
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
+            );
 
-      it('should detect database \'' + DATABASE_NAME + '\' as susceptible of being encoded', function(done) {
-        sthDatabaseNameCodecTool.getEncodingAnalysis(
-          {
-            encode: true
-          },
-          function(err, analysis) {
-            if (err) {
-              return done(err);
-            }
-            expect(analysis[DATABASE_NAME].name).to.not.equal(DATABASE_NAME);
-            done();
-          }
-        );
-      });
+            it("should detect database '" + DATABASE_NAME + "' as susceptible of being encoded", function(done) {
+                sthDatabaseNameCodecTool.getEncodingAnalysis(
+                    {
+                        encode: true,
+                    },
+                    function(err, analysis) {
+                        if (err) {
+                            return done(err);
+                        }
+                        expect(analysis[DATABASE_NAME].name).to.not.equal(DATABASE_NAME);
+                        done();
+                    }
+                );
+            });
 
-      it('should not detect database \'' + DATABASE_NAME + '\' as susceptible of being encoded if filtered out',
-        function(done) {
-          sthDatabaseNameCodecTool.getEncodingAnalysis(
-            {
-              encode: true,
-              database: sthConfig.DB_PREFIX + 'inexistent_database'
-            },
-            function(err, analysis) {
-              if (err) {
-                return done(err);
-              }
-              expect(analysis[DATABASE_NAME]).to.be(undefined);
-              done();
-            }
-          );
-        }
-      );
+            it(
+                "should not detect database '" + DATABASE_NAME + "' as susceptible of being encoded if filtered out",
+                function(done) {
+                    sthDatabaseNameCodecTool.getEncodingAnalysis(
+                        {
+                            encode: true,
+                            database: sthConfig.DB_PREFIX + 'inexistent_database',
+                        },
+                        function(err, analysis) {
+                            if (err) {
+                                return done(err);
+                            }
+                            expect(analysis[DATABASE_NAME]).to.be(undefined);
+                            done();
+                        }
+                    );
+                }
+            );
 
-      it('should detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being encoded',
-         shouldDetectCollectionTest.bind(null, true, DATABASE_NAME,
-           sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being encoded",
+                shouldDetectCollectionTest.bind(
+                    null,
+                    true,
+                    DATABASE_NAME,
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being encoded if filtered out',
-        shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME));
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being encoded if filtered out",
+                shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME)
+            );
 
-      it('should detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being encoded',
-        shouldDetectCollectionTest.bind(
-          null, true, DATABASE_NAME, sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being encoded",
+                shouldDetectCollectionTest.bind(
+                    null,
+                    true,
+                    DATABASE_NAME,
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being encoded if filtered out',
-        shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME));
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being encoded if filtered out",
+                shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME)
+            );
 
-      after(function() {
-        sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-        sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
-      });
-      sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-      sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+            after(function() {
+                sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+                sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+            });
+            sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+            sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+        });
+
+        describe('name encoding enabled', function() {
+            sthConfig.NAME_ENCODING = true;
+            sthConfig.NAME_SEPARATOR = 'xffff';
+            before(function(done) {
+                sthConfig.NAME_ENCODING = true;
+                sthConfig.NAME_SEPARATOR = 'xffff';
+                async.series([dropDatabases, createRawAndAggregatedCollections], done);
+            });
+
+            it(
+                'should raise an error if neither -e, --encode or -d, --decode options are set',
+                encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
+            );
+
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
+            );
+
+            it(
+                "should detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of " +
+                    'being decoded',
+                shouldDetectCollectionTest.bind(
+                    null,
+                    false,
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
+
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of being decoded if filtered out",
+                shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE))
+            );
+
+            it(
+                "should detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of being decoded",
+                shouldDetectCollectionTest.bind(
+                    null,
+                    false,
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
+
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of being decoded if filtered out",
+                shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE))
+            );
+
+            after(function() {
+                sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+                sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+            });
+            sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+            sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+        });
     });
 
-    describe('name encoding enabled', function() {
-      sthConfig.NAME_ENCODING = true;
-      sthConfig.NAME_SEPARATOR = 'xffff';
-      before(function(done) {
-        sthConfig.NAME_ENCODING = true;
-        sthConfig.NAME_SEPARATOR = 'xffff';
-        async.series(
-          [
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
+    describe('encodeOrDecode tests', function() {
+        describe('name encoding disabled', function() {
+            sthConfig.NAME_ENCODING = false;
+            sthConfig.NAME_SEPARATOR = '_';
+            before(function(done) {
+                sthConfig.NAME_ENCODING = false;
+                sthConfig.NAME_SEPARATOR = '_';
+                async.series([dropDatabases, createRawAndAggregatedCollections], done);
+            });
 
-      it('should raise an error if neither -e, --encode or -d, --decode options are set',
-        encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis));
+            it(
+                'should raise an error if neither -e, --encode or -d, --decode options are set',
+                encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
+            );
 
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis));
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
+            );
 
-      it('should detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + '\' as susceptible of ' +
-         'being decoded',
-         shouldDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should encode the database '" +
+                    DATABASE_NAME +
+                    "' as '" +
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
+                    "'",
+                shouldEncodeOrDecodeDatabaseTest.bind(null, DATABASE_NAME, true)
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-         '\' as susceptible of being decoded if filtered out',
-        shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE)));
+            it(
+                "should encode the collection '" +
+                    sthDatabaseNameCodec.decodeCollectionName(
+                        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                    ) +
+                    "' as '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' and the database '" +
+                    DATABASE_NAME +
+                    "' as '" +
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
+                    "'",
+                shouldEncodeOrDecodeCollectionTest.bind(
+                    null,
+                    DATABASE_NAME,
+                    sthDatabaseNameCodec.decodeCollectionName(
+                        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                    ),
+                    true
+                )
+            );
 
-      it('should detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-         '\' as susceptible of being decoded',
-        shouldDetectCollectionTest.bind(
-          null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should encode the collection '" +
+                    sthDatabaseNameCodec.decodeCollectionName(
+                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                    ) +
+                    "' as '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' and the database '" +
+                    DATABASE_NAME +
+                    "' as '" +
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
+                    "'",
+                shouldEncodeOrDecodeCollectionTest.bind(
+                    null,
+                    DATABASE_NAME,
+                    sthDatabaseNameCodec.decodeCollectionName(
+                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                    ),
+                    true
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-         '\' as susceptible of being decoded if filtered out',
-        shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE)));
+            after(function() {
+                sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+                sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+            });
+            sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+            sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+        });
 
-      after(function() {
-        sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-        sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
-      });
-      sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-      sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+        describe('name encoding enabled', function() {
+            sthConfig.NAME_ENCODING = true;
+            sthConfig.NAME_SEPARATOR = 'xffff';
+            before(function(done) {
+                sthConfig.NAME_ENCODING = true;
+                sthConfig.NAME_SEPARATOR = 'xffff';
+                async.series([dropDatabases, createRawAndAggregatedCollections], done);
+            });
+
+            it(
+                'should raise an error if neither -e, --encode or -d, --decode options are set',
+                encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
+            );
+
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
+            );
+
+            it(
+                "should decode the database '" +
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
+                    "' as '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldEncodeOrDecodeDatabaseTest.bind(
+                    null,
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
+                    false
+                )
+            );
+
+            it(
+                "should decode the collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' as '" +
+                    sthDatabaseNameCodec.decodeCollectionName(
+                        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                    ) +
+                    "' and the database '" +
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
+                    "' as '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldEncodeOrDecodeCollectionTest.bind(
+                    null,
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS),
+                    false
+                )
+            );
+
+            it(
+                "should decode the collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' as '" +
+                    sthDatabaseNameCodec.decodeCollectionName(
+                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                    ) +
+                    "' and the database '" +
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
+                    "' as '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldEncodeOrDecodeCollectionTest.bind(
+                    null,
+                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS),
+                    false
+                )
+            );
+
+            after(function(done) {
+                sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+                sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+                dropDatabases(done);
+            });
+            sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+            sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
+        });
     });
-  });
-
-  describe('encodeOrDecode tests', function() {
-    describe('name encoding disabled', function() {
-      sthConfig.NAME_ENCODING = false;
-      sthConfig.NAME_SEPARATOR = '_';
-      before(function(done) {
-        sthConfig.NAME_ENCODING = false;
-        sthConfig.NAME_SEPARATOR = '_';
-        async.series(
-          [
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
-
-      it('should raise an error if neither -e, --encode or -d, --decode options are set',
-        encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode));
-
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode));
-
-      it('should encode the database \'' + DATABASE_NAME + '\' as \'' +
-         sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + '\'',
-        shouldEncodeOrDecodeDatabaseTest.bind(
-          null, DATABASE_NAME, true));
-
-      it('should encode the collection \'' +
-         sthDatabaseNameCodec.decodeCollectionName(sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)) +
-          '\' as \'' +
-         sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' and the database \'' + DATABASE_NAME + '\' as \'' +
-          sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + '\'',
-        shouldEncodeOrDecodeCollectionTest.bind(
-          null, DATABASE_NAME,
-          sthDatabaseNameCodec.decodeCollectionName(sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)),
-          true));
-
-      it('should encode the collection \'' +
-        sthDatabaseNameCodec.decodeCollectionName(
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)) +
-          '\' as \'' +
-            sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-          '\' and the database \'' + DATABASE_NAME + '\' as \'' +
-         sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + '\'',
-        shouldEncodeOrDecodeCollectionTest.bind(
-          null, DATABASE_NAME,
-          sthDatabaseNameCodec.decodeCollectionName(
-            sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)),
-          true));
-
-      after(function() {
-        sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-        sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
-      });
-      sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-      sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
-    });
-
-    describe('name encoding enabled', function() {
-      sthConfig.NAME_ENCODING = true;
-      sthConfig.NAME_SEPARATOR = 'xffff';
-      before(function(done) {
-        sthConfig.NAME_ENCODING = true;
-        sthConfig.NAME_SEPARATOR = 'xffff';
-        async.series(
-          [
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
-
-      it('should raise an error if neither -e, --encode or -d, --decode options are set',
-        encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode));
-
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode));
-
-      it('should decode the database \'' + sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + '\' as \'' +
-        DATABASE_NAME + '\'',
-        shouldEncodeOrDecodeDatabaseTest.bind(
-          null, sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME), false));
-
-      it('should decode the collection \'' +
-        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-        '\' as \'' +
-        sthDatabaseNameCodec.decodeCollectionName(sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)) +
-        '\' and the database \'' + sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + '\' as \'' +
-        DATABASE_NAME + '\'',
-        shouldEncodeOrDecodeCollectionTest.bind(
-          null,
-          sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS),
-          false
-        )
-      );
-
-      it('should decode the collection \'' +
-        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-        '\' as \'' +
-        sthDatabaseNameCodec.decodeCollectionName(
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)) +
-        '\' and the database \'' + sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + '\' as \'' +
-          DATABASE_NAME + '\'',
-          shouldEncodeOrDecodeCollectionTest.bind(
-            null,
-            sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
-            sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS),
-            false
-          )
-      );
-
-      after(function(done) {
-        sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-        sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
-        dropDatabases(done);
-      });
-      sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-      sthConfig.NAME_SEPARATOR = ORIGINAL_NAME_SEPARATOR;
-    });
-  });
 });

--- a/test/unit/sthDatabaseNameCodecTool_test.js
+++ b/test/unit/sthDatabaseNameCodecTool_test.js
@@ -317,13 +317,13 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 async.series([connectToDatabase, dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -e, --encode or -d, --decode options are set',
+            // prettier-ignore
+            it('should raise an error if neither -e, --encode or -d, --decode options are set',
                 encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
             );
 
@@ -342,8 +342,8 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 );
             });
 
-            it(
-                "should not detect database '" + DATABASE_NAME + "' as susceptible of being encoded if filtered out",
+            // prettier-ignore
+            it("should not detect database '" + DATABASE_NAME + "' as susceptible of being encoded if filtered out",
                 function(done) {
                     sthDatabaseNameCodecTool.getEncodingAnalysis(
                         {
@@ -361,12 +361,9 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 }
             );
 
-            it(
-                "should detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being encoded",
+            // prettier-ignore
+            it("should detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                "' of database '" + DATABASE_NAME + "' as susceptible of being encoded",
                 shouldDetectCollectionTest.bind(
                     null,
                     true,
@@ -375,21 +372,15 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being encoded if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                "' of database '" + DATABASE_NAME + "' as susceptible of being encoded if filtered out",
                 shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME)
             );
 
-            it(
-                "should detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being encoded",
+            // prettier-ignore
+            it("should detect collection '" + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                "' of database '" + DATABASE_NAME + "' as susceptible of being encoded",
                 shouldDetectCollectionTest.bind(
                     null,
                     true,
@@ -398,12 +389,10 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being encoded if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + "' of database '" + 
+                DATABASE_NAME + "' as susceptible of being encoded if filtered out",
                 shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME)
             );
 
@@ -424,23 +413,20 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 async.series([dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -e, --encode or -d, --decode options are set',
+            // prettier-ignore
+            it('should raise an error if neither -e, --encode or -d, --decode options are set',
                 encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.getEncodingAnalysis)
             );
 
-            it(
-                "should detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of " +
-                    'being decoded',
+            // prettier-ignore
+            it("should detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + "' as susceptible of " + 
+                'being decoded',
                 shouldDetectCollectionTest.bind(
                     null,
                     false,
@@ -449,21 +435,17 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of being decoded if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + 
+                "' as susceptible of being decoded if filtered out",
                 shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE))
             );
 
-            it(
-                "should detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of being decoded",
+            // prettier-ignore
+            it("should detect collection '" + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + 
+                "' as susceptible of being decoded",
                 shouldDetectCollectionTest.bind(
                     null,
                     false,
@@ -472,12 +454,11 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of being decoded if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + "' of database '" +
+                sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + 
+                "' as susceptible of being decoded if filtered out",
                 shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE))
             );
 
@@ -500,37 +481,29 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 async.series([dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -e, --encode or -d, --decode options are set',
+            // prettier-ignore
+            it('should raise an error if neither -e, --encode or -d, --decode options are set',
                 encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
             );
 
-            it(
-                "should encode the database '" +
-                    DATABASE_NAME +
-                    "' as '" +
-                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
-                    "'",
+            // prettier-ignore
+            it("should encode the database '" + DATABASE_NAME + "' as '" + 
+                sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + "'",
                 shouldEncodeOrDecodeDatabaseTest.bind(null, DATABASE_NAME, true)
             );
 
-            it(
-                "should encode the collection '" +
-                    sthDatabaseNameCodec.decodeCollectionName(
-                        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
-                    ) +
-                    "' as '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' and the database '" +
-                    DATABASE_NAME +
-                    "' as '" +
-                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
-                    "'",
+            // prettier-ignore
+            it("should encode the collection '" + 
+                sthDatabaseNameCodec.decodeCollectionName(
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                ) + "' as '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' and the database '" + DATABASE_NAME + "' as '" + 
+                sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + "'",
                 shouldEncodeOrDecodeCollectionTest.bind(
                     null,
                     DATABASE_NAME,
@@ -541,18 +514,12 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should encode the collection '" +
-                    sthDatabaseNameCodec.decodeCollectionName(
-                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
-                    ) +
-                    "' as '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' and the database '" +
-                    DATABASE_NAME +
-                    "' as '" +
-                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
-                    "'",
+            // prettier-ignore
+            it("should encode the collection '" + sthDatabaseNameCodec.decodeCollectionName(
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                ) + "' as '" + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' and the database '" + DATABASE_NAME + "' as '" + 
+                sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + "'",
                 shouldEncodeOrDecodeCollectionTest.bind(
                     null,
                     DATABASE_NAME,
@@ -580,22 +547,19 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 async.series([dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -e, --encode or -d, --decode options are set',
+            // prettier-ignore
+            it('should raise an error if neither -e, --encode or -d, --decode options are set',
                 encodeDecodeMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameCodecTool.encodeOrDecode)
             );
 
-            it(
-                "should decode the database '" +
-                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
-                    "' as '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should decode the database '" + sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + "' as '" +
+             DATABASE_NAME + "'",
                 shouldEncodeOrDecodeDatabaseTest.bind(
                     null,
                     sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
@@ -603,18 +567,12 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should decode the collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' as '" +
-                    sthDatabaseNameCodec.decodeCollectionName(
+            // prettier-ignore
+            it("should decode the collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' as '" + sthDatabaseNameCodec.decodeCollectionName(
                         sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
-                    ) +
-                    "' and the database '" +
-                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
-                    "' as '" +
-                    DATABASE_NAME +
-                    "'",
+                    ) + "' and the database '" + sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + "' as '" + 
+                DATABASE_NAME + "'",
                 shouldEncodeOrDecodeCollectionTest.bind(
                     null,
                     sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),
@@ -623,18 +581,13 @@ describe('sthDatabaseNameCodecTool tests', function() {
                 )
             );
 
-            it(
-                "should decode the collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' as '" +
-                    sthDatabaseNameCodec.decodeCollectionName(
-                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
-                    ) +
-                    "' and the database '" +
-                    sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) +
-                    "' as '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should decode the collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + "' as '" + 
+                sthDatabaseNameCodec.decodeCollectionName(
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                ) + "' and the database '" + sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME) + "' as '" + 
+                DATABASE_NAME + "'",
                 shouldEncodeOrDecodeCollectionTest.bind(
                     null,
                     sthDatabaseNameCodec.encodeDatabaseName(DATABASE_NAME),

--- a/test/unit/sthDatabaseNameCodec_test.js
+++ b/test/unit/sthDatabaseNameCodec_test.js
@@ -29,372 +29,411 @@ var sthDatabaseNameCodec = require(ROOT_PATH + '/lib/database/model/sthDatabaseN
 var expect = require('expect.js');
 
 describe('sthDatabaseNameCodec tests', function() {
-  describe('database name codification tests', function() {
-    it('should encode the / character as x002f', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('/')).to.equal('x002f');
+    describe('database name codification tests', function() {
+        it('should encode the / character as x002f', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('/')).to.equal('x002f');
+        });
+
+        it('should encode the \\ character as x005c', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('\\')).to.equal('x005c');
+        });
+
+        it('should encode the . character as x002e', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('.')).to.equal('x002e');
+        });
+
+        it('should encode the whitespace character as x0020', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName(' ')).to.equal('x0020');
+        });
+
+        it('should encode the " character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('"')).to.equal('x0022');
+        });
+
+        it('should encode the $ character as x0024', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('$')).to.equal('x0024');
+        });
+
+        it('should encode the null character as x0000', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('\0')).to.equal('x0000');
+        });
+
+        it(
+            'should encode the separator character ' + sthConfig.NAME_SEPARATOR + ' as x' + sthConfig.NAME_SEPARATOR,
+            function() {
+                expect(sthDatabaseNameCodec.encodeDatabaseName('x12ab')).to.equal('xx12ab');
+            }
+        );
+
+        it('should encode x12ab as xx12ab as xx12ab', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('x12ab')).to.equal('xx12ab');
+        });
+
+        it('should encode x12AB as x12x0041x0042', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('x12AB')).to.equal('x12x0041x0042');
+        });
+
+        it('should encode uppercase letters', function() {
+            for (var ii = 65; ii <= 90; ii++) {
+                expect(sthDatabaseNameCodec.encodeDatabaseName(String.fromCharCode(ii))).to.equal(
+                    'x00' + ii.toString(16)
+                );
+            }
+        });
+
+        it('should not encode lowercase letters', function() {
+            for (var ii = 97; ii <= 122; ii++) {
+                expect(sthDatabaseNameCodec.encodeDatabaseName(String.fromCharCode(ii))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not encode the _ character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('_')).to.equal('_');
+        });
+
+        it('should not encode the ¿ character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('¿')).to.equal('¿');
+        });
+
+        it('should not encode the ? character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('?')).to.equal('?');
+        });
+
+        it('should not encode the ¡ character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('¡')).to.equal('¡');
+        });
+
+        it('should not encode the ! character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('!')).to.equal('!');
+        });
+
+        it('should not encode the | character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('|')).to.equal('|');
+        });
+
+        it('should not encode the , character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName(',')).to.equal(',');
+        });
+
+        it('should not encode the # character', function() {
+            expect(sthDatabaseNameCodec.encodeDatabaseName('#')).to.equal('#');
+        });
+
+        it(
+            'should encode Service.Madrid#North\\Alcobendas City as ' +
+                'x0053ervicex002ex004dadrid#x004eorthx005cx0041lcobendasx0020x0043ity',
+            function() {
+                expect(sthDatabaseNameCodec.encodeDatabaseName('Service.Madrid#North\\$Alcobendas City')).to.equal(
+                    'x0053ervicex002ex004dadrid#x004eorthx005cx0024x0041lcobendasx0020x0043ity'
+                );
+            }
+        );
+    });
+
+    describe('database name decodification tests', function() {
+        it('should decode the x002f as the / character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x002f')).to.equal('/');
+        });
+
+        it('should decode x005c as the \\ character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x005c')).to.equal('\\');
+        });
+
+        it('should decode x002e as the . character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x002e')).to.equal('.');
+        });
+
+        it('should decode x0020 as the whitespace character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x0020')).to.equal(' ');
+        });
+
+        it('should decode x0022 as the " character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x0022')).to.equal('"');
+        });
+
+        it('should decode x0024 as the $ character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x0024')).to.equal('$');
+        });
+
+        it('should decode x0000 as the null character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x0000')).to.equal('\0');
+        });
+
+        it('should not decode the separator character ' + sthConfig.NAME_SEPARATOR, function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName(sthConfig.NAME_SEPARATOR)).to.equal(
+                sthConfig.NAME_SEPARATOR
+            );
+        });
+
+        it('should decode xx12ab as x12ab', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('xx12ab')).to.equal('x12ab');
+        });
+
+        it('should decode x12x0041x0042 as x12AB', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('x12x0041x0042')).to.equal('x12AB');
+        });
+
+        it('should decode uppercase letters', function() {
+            for (var ii = 65; ii <= 90; ii++) {
+                expect(sthDatabaseNameCodec.decodeDatabaseName('x00' + ii.toString(16))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not decode lowercase letters', function() {
+            for (var ii = 97; ii <= 122; ii++) {
+                expect(sthDatabaseNameCodec.decodeDatabaseName('x00' + ii.toString(16))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not decode the _ character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('_')).to.equal('_');
+        });
+
+        it('should not decode the ¿ character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('¿')).to.equal('¿');
+        });
+
+        it('should not decode the ? character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('?')).to.equal('?');
+        });
+
+        it('should not decode the ¡ character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('¡')).to.equal('¡');
+        });
+
+        it('should not decode the ! character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('!')).to.equal('!');
+        });
+
+        it('should not decode the | character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('|')).to.equal('|');
+        });
+
+        it('should not decode the , character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName(',')).to.equal(',');
+        });
+
+        it('should not decode the # character', function() {
+            expect(sthDatabaseNameCodec.decodeDatabaseName('#')).to.equal('#');
+        });
+
+        it(
+            'should decode x0053ervicex002ex004dadrid#x004eorthx005cx0024x0041lcobendasx0020x0043ity as ' +
+                'Service.Madrid#North\\$Alcobendas City',
+            function() {
+                expect(
+                    sthDatabaseNameCodec.decodeDatabaseName(
+                        'x0053ervicex002ex004dadrid#x004eorthx005cx0041lcobendasx0020x0043ity'
+                    )
+                ).to.equal('Service.Madrid#North\\Alcobendas City');
+            }
+        );
+    });
+
+    describe('collection name codification tests', function() {
+        it('should encode the $ character as x0024', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('$')).to.equal('x0024');
+        });
+
+        it('should encode the null character as x0000', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('\0')).to.equal('x0000');
+        });
+
+        it('should encode the / character as x002f', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('/')).to.equal('x002f');
+        });
+
+        it('should encode system. at the beggining as xsystem.', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('system.')).to.equal('xsystem.');
+        });
+
+        it('should encode xsystem. at the beggining as xxsystem.', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('xsystem.')).to.equal('xxsystem.');
+        });
+
+        it('should not encode the.system.collection', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('the.system.collection')).to.equal(
+                'the.system.collection'
+            );
+        });
+
+        it(
+            'should encode the separator character ' + sthConfig.NAME_SEPARATOR + ' as x' + sthConfig.NAME_SEPARATOR,
+            function() {
+                expect(sthDatabaseNameCodec.encodeCollectionName('x12ab')).to.equal('xx12ab');
+            }
+        );
+
+        it('should encode x12ab as xx12ab', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('x12ab')).to.equal('xx12ab');
+        });
+
+        it('should not encode x12AB', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('x12AB')).to.equal('x12AB');
+        });
+
+        it('should not encode uppercase letters', function() {
+            for (var ii = 65; ii <= 90; ii++) {
+                expect(sthDatabaseNameCodec.encodeCollectionName(String.fromCharCode(ii))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not encode lowercase letters', function() {
+            for (var ii = 97; ii <= 122; ii++) {
+                expect(sthDatabaseNameCodec.encodeCollectionName(String.fromCharCode(ii))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not encode the _ character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('_')).to.equal('_');
+        });
+
+        it('should not encode the ¿ character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('¿')).to.equal('¿');
+        });
+
+        it('should not encode the ? character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('?')).to.equal('?');
+        });
+
+        it('should not encode the ¡ character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('¡')).to.equal('¡');
+        });
+
+        it('should not encode the ! character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('!')).to.equal('!');
+        });
+
+        it('should not encode the | character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('|')).to.equal('|');
+        });
+
+        it('should not encode the , character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName(',')).to.equal(',');
+        });
+
+        it('should not encode the # character', function() {
+            expect(sthDatabaseNameCodec.encodeCollectionName('#')).to.equal('#');
+        });
+
+        it(
+            'should encode /ServicePath.Madrid#North\\$Alcobendas City as ' +
+                'x002fServicePath.Madrid#North\\x0024Alcobendas City',
+            function() {
+                expect(
+                    sthDatabaseNameCodec.encodeCollectionName('/ServicePath.Madrid#North\\$Alcobendas City')
+                ).to.equal('x002fServicePath.Madrid#North\\x0024Alcobendas City');
+            }
+        );
+    });
+
+    describe('collection name decodification tests', function() {
+        it('should decode x0024 as the $ character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('x0024')).to.equal('$');
+        });
+
+        it('should decode x0000 as the null character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('x0000')).to.equal('\0');
+        });
+
+        it('should decode x002f as the / character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('x002f')).to.equal('/');
+        });
+
+        it('should decode xsystem. at the beggining as system.', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('xsystem.')).to.equal('system.');
+        });
+
+        it('should decode xxsystem. at the beggining as xsystem.', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('xxsystem.')).to.equal('xsystem.');
+        });
+
+        it('should not decode the.system.collection', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('the.system.collection')).to.equal(
+                'the.system.collection'
+            );
+        });
+
+        it('should not decode the separator character ' + sthConfig.NAME_SEPARATOR, function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName(sthConfig.NAME_SEPARATOR)).to.equal(
+                sthConfig.NAME_SEPARATOR
+            );
+        });
+
+        it('should decode xx12ab as x12ab', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('xx12ab')).to.equal('x12ab');
+        });
+
+        it('should not decode x12AB', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('x12AB')).to.equal('x12AB');
+        });
+
+        it('should not decode uppercase letters', function() {
+            for (var ii = 65; ii <= 90; ii++) {
+                expect(sthDatabaseNameCodec.decodeCollectionName(String.fromCharCode(ii))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not decode lowercase letters', function() {
+            for (var ii = 97; ii <= 122; ii++) {
+                expect(sthDatabaseNameCodec.decodeCollectionName(String.fromCharCode(ii))).to.equal(
+                    String.fromCharCode(ii)
+                );
+            }
+        });
+
+        it('should not decode the _ character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('_')).to.equal('_');
+        });
+
+        it('should not decode the ¿ character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('¿')).to.equal('¿');
+        });
+
+        it('should not decode the ? character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('?')).to.equal('?');
+        });
+
+        it('should not decode the ¡ character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('¡')).to.equal('¡');
+        });
+
+        it('should not decode the ! character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('!')).to.equal('!');
+        });
+
+        it('should not decode the | character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('|')).to.equal('|');
+        });
+
+        it('should not decode the , character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName(',')).to.equal(',');
+        });
+
+        it('should not decode the # character', function() {
+            expect(sthDatabaseNameCodec.decodeCollectionName('#')).to.equal('#');
+        });
+
+        it(
+            'should decode x002fServicePath.Madrid#North\\x0024Alcobendas City as ' +
+                '/ServicePath.Madrid#North\\$Alcobendas City',
+            function() {
+                expect(
+                    sthDatabaseNameCodec.decodeCollectionName('x002fServicePath.Madrid#North\\x0024Alcobendas City')
+                ).to.equal('/ServicePath.Madrid#North\\$Alcobendas City');
+            }
+        );
     });
-
-    it('should encode the \\ character as x005c', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('\\')).to.equal('x005c');
-    });
-
-    it('should encode the . character as x002e', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('.')).to.equal('x002e');
-    });
-
-    it('should encode the whitespace character as x0020', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName(' ')).to.equal('x0020');
-    });
-
-    it('should encode the " character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('"')).to.equal('x0022');
-    });
-
-    it('should encode the $ character as x0024', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('$')).to.equal('x0024');
-    });
-
-    it('should encode the null character as x0000', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('\0')).to.equal('x0000');
-    });
-
-    it('should encode the separator character ' + sthConfig.NAME_SEPARATOR + ' as x' + sthConfig.NAME_SEPARATOR,
-      function() {
-        expect(sthDatabaseNameCodec.encodeDatabaseName('x12ab')).to.equal('xx12ab');
-      }
-    );
-
-    it('should encode x12ab as xx12ab as xx12ab', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('x12ab')).to.equal('xx12ab');
-    });
-
-    it('should encode x12AB as x12x0041x0042', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('x12AB')).to.equal('x12x0041x0042');
-    });
-
-    it('should encode uppercase letters', function() {
-      for (var ii = 65; ii <= 90; ii++) {
-        expect(sthDatabaseNameCodec.encodeDatabaseName(String.fromCharCode(ii))).to.equal('x00' + ii.toString(16));
-      }
-    });
-
-    it('should not encode lowercase letters', function() {
-      for (var ii = 97; ii <= 122; ii++) {
-        expect(sthDatabaseNameCodec.encodeDatabaseName(String.fromCharCode(ii))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not encode the _ character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('_')).to.equal('_');
-    });
-
-    it('should not encode the ¿ character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('¿')).to.equal('¿');
-    });
-
-    it('should not encode the ? character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('?')).to.equal('?');
-    });
-
-    it('should not encode the ¡ character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('¡')).to.equal('¡');
-    });
-
-    it('should not encode the ! character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('!')).to.equal('!');
-    });
-
-    it('should not encode the | character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('|')).to.equal('|');
-    });
-
-    it('should not encode the , character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName(',')).to.equal(',');
-    });
-
-    it('should not encode the # character', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('#')).to.equal('#');
-    });
-
-    it('should encode Service.Madrid#North\\Alcobendas City as ' +
-       'x0053ervicex002ex004dadrid#x004eorthx005cx0041lcobendasx0020x0043ity', function() {
-      expect(sthDatabaseNameCodec.encodeDatabaseName('Service.Madrid#North\\$Alcobendas City')).
-        to.equal('x0053ervicex002ex004dadrid#x004eorthx005cx0024x0041lcobendasx0020x0043ity');
-    });
-  });
-
-  describe('database name decodification tests', function() {
-    it('should decode the x002f as the / character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x002f')).to.equal('/');
-    });
-
-    it('should decode x005c as the \\ character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x005c')).to.equal('\\');
-    });
-
-    it('should decode x002e as the . character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x002e')).to.equal('.');
-    });
-
-    it('should decode x0020 as the whitespace character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x0020')).to.equal(' ');
-    });
-
-    it('should decode x0022 as the " character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x0022')).to.equal('"');
-    });
-
-    it('should decode x0024 as the $ character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x0024')).to.equal('$');
-    });
-
-    it('should decode x0000 as the null character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x0000')).to.equal('\0');
-    });
-
-    it('should not decode the separator character ' + sthConfig.NAME_SEPARATOR,
-      function() {
-        expect(sthDatabaseNameCodec.decodeDatabaseName(sthConfig.NAME_SEPARATOR)).to.equal(sthConfig.NAME_SEPARATOR);
-      }
-    );
-
-    it('should decode xx12ab as x12ab', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('xx12ab')).to.equal('x12ab');
-    });
-
-    it('should decode x12x0041x0042 as x12AB', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('x12x0041x0042')).to.equal('x12AB');
-    });
-
-    it('should decode uppercase letters', function() {
-      for (var ii = 65; ii <= 90; ii++) {
-        expect(sthDatabaseNameCodec.decodeDatabaseName('x00' + ii.toString(16))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not decode lowercase letters', function() {
-      for (var ii = 97; ii <= 122; ii++) {
-        expect(sthDatabaseNameCodec.decodeDatabaseName('x00' + ii.toString(16))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not decode the _ character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('_')).to.equal('_');
-    });
-
-    it('should not decode the ¿ character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('¿')).to.equal('¿');
-    });
-
-    it('should not decode the ? character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('?')).to.equal('?');
-    });
-
-    it('should not decode the ¡ character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('¡')).to.equal('¡');
-    });
-
-    it('should not decode the ! character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('!')).to.equal('!');
-    });
-
-    it('should not decode the | character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('|')).to.equal('|');
-    });
-
-    it('should not decode the , character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName(',')).to.equal(',');
-    });
-
-    it('should not decode the # character', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName('#')).to.equal('#');
-    });
-
-    it('should decode x0053ervicex002ex004dadrid#x004eorthx005cx0024x0041lcobendasx0020x0043ity as ' +
-       'Service.Madrid#North\\$Alcobendas City', function() {
-      expect(sthDatabaseNameCodec.decodeDatabaseName(
-        'x0053ervicex002ex004dadrid#x004eorthx005cx0041lcobendasx0020x0043ity')).to.equal(
-          'Service.Madrid#North\\Alcobendas City');
-    });
-  });
-
-  describe('collection name codification tests', function() {
-    it('should encode the $ character as x0024', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('$')).to.equal('x0024');
-    });
-
-    it('should encode the null character as x0000', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('\0')).to.equal('x0000');
-    });
-
-    it('should encode the / character as x002f', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('/')).to.equal('x002f');
-    });
-
-    it('should encode system. at the beggining as xsystem.', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('system.')).to.equal('xsystem.');
-    });
-
-    it('should encode xsystem. at the beggining as xxsystem.', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('xsystem.')).to.equal('xxsystem.');
-    });
-
-    it('should not encode the.system.collection', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('the.system.collection')).to.equal('the.system.collection');
-    });
-
-    it('should encode the separator character ' + sthConfig.NAME_SEPARATOR + ' as x' + sthConfig.NAME_SEPARATOR,
-      function() {
-        expect(sthDatabaseNameCodec.encodeCollectionName('x12ab')).to.equal('xx12ab');
-      }
-    );
-
-    it('should encode x12ab as xx12ab', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('x12ab')).to.equal('xx12ab');
-    });
-
-    it('should not encode x12AB', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('x12AB')).to.equal('x12AB');
-    });
-
-    it('should not encode uppercase letters', function() {
-      for (var ii = 65; ii <= 90; ii++) {
-        expect(sthDatabaseNameCodec.encodeCollectionName(String.fromCharCode(ii))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not encode lowercase letters', function() {
-      for (var ii = 97; ii <= 122; ii++) {
-        expect(sthDatabaseNameCodec.encodeCollectionName(String.fromCharCode(ii))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not encode the _ character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('_')).to.equal('_');
-    });
-
-    it('should not encode the ¿ character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('¿')).to.equal('¿');
-    });
-
-    it('should not encode the ? character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('?')).to.equal('?');
-    });
-
-    it('should not encode the ¡ character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('¡')).to.equal('¡');
-    });
-
-    it('should not encode the ! character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('!')).to.equal('!');
-    });
-
-    it('should not encode the | character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('|')).to.equal('|');
-    });
-
-    it('should not encode the , character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName(',')).to.equal(',');
-    });
-
-    it('should not encode the # character', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('#')).to.equal('#');
-    });
-
-    it('should encode /ServicePath.Madrid#North\\$Alcobendas City as ' +
-       'x002fServicePath.Madrid#North\\x0024Alcobendas City', function() {
-      expect(sthDatabaseNameCodec.encodeCollectionName('/ServicePath.Madrid#North\\$Alcobendas City')).
-        to.equal('x002fServicePath.Madrid#North\\x0024Alcobendas City');
-    });
-  });
-
-  describe('collection name decodification tests', function() {
-    it('should decode x0024 as the $ character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('x0024')).to.equal('$');
-    });
-
-    it('should decode x0000 as the null character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('x0000')).to.equal('\0');
-    });
-
-    it('should decode x002f as the / character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('x002f')).to.equal('/');
-    });
-
-    it('should decode xsystem. at the beggining as system.', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('xsystem.')).to.equal('system.');
-    });
-
-    it('should decode xxsystem. at the beggining as xsystem.', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('xxsystem.')).to.equal('xsystem.');
-    });
-
-    it('should not decode the.system.collection', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('the.system.collection')).to.equal('the.system.collection');
-    });
-
-    it('should not decode the separator character ' + sthConfig.NAME_SEPARATOR,
-      function() {
-        expect(sthDatabaseNameCodec.decodeCollectionName(sthConfig.NAME_SEPARATOR)).to.equal(sthConfig.NAME_SEPARATOR);
-      }
-    );
-
-    it('should decode xx12ab as x12ab', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('xx12ab')).to.equal('x12ab');
-    });
-
-    it('should not decode x12AB', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('x12AB')).to.equal('x12AB');
-    });
-
-    it('should not decode uppercase letters', function() {
-      for (var ii = 65; ii <= 90; ii++) {
-        expect(sthDatabaseNameCodec.decodeCollectionName(String.fromCharCode(ii))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not decode lowercase letters', function() {
-      for (var ii = 97; ii <= 122; ii++) {
-        expect(sthDatabaseNameCodec.decodeCollectionName(String.fromCharCode(ii))).to.equal(String.fromCharCode(ii));
-      }
-    });
-
-    it('should not decode the _ character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('_')).to.equal('_');
-    });
-
-    it('should not decode the ¿ character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('¿')).to.equal('¿');
-    });
-
-    it('should not decode the ? character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('?')).to.equal('?');
-    });
-
-    it('should not decode the ¡ character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('¡')).to.equal('¡');
-    });
-
-    it('should not decode the ! character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('!')).to.equal('!');
-    });
-
-    it('should not decode the | character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('|')).to.equal('|');
-    });
-
-    it('should not decode the , character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName(',')).to.equal(',');
-    });
-
-    it('should not decode the # character', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('#')).to.equal('#');
-    });
-
-    it('should decode x002fServicePath.Madrid#North\\x0024Alcobendas City as ' +
-       '/ServicePath.Madrid#North\\$Alcobendas City', function() {
-      expect(sthDatabaseNameCodec.decodeCollectionName('x002fServicePath.Madrid#North\\x0024Alcobendas City')).
-        to.equal('/ServicePath.Madrid#North\\$Alcobendas City');
-    });
-  });
 });

--- a/test/unit/sthDatabaseNameMapperTool_test.js
+++ b/test/unit/sthDatabaseNameMapperTool_test.js
@@ -41,14 +41,14 @@ var DATABASE_CONNECTION_PARAMS = {
     dbURI: sthConfig.DB_URI,
     replicaSet: sthConfig.REPLICA_SET,
     database: DATABASE_NAME,
-    poolSize: sthConfig.POOL_SIZE,
+    poolSize: sthConfig.POOL_SIZE
 };
 var COLLECTION_NAME_PARAMS = {
     service: DEFAULT_SERVICE,
     servicePath: sthConfig.DEFAULT_SERVICE_PATH,
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
-    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrName: sthTestConfig.ATTRIBUTE_NAME
 };
 
 /**
@@ -73,12 +73,12 @@ function createRawAndAggregatedCollections(callback) {
     async.series(
         [
             async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
-                shouldCreate: true,
+                shouldCreate: true
             }),
             async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
                 shouldCreate: true,
-                isAggregated: true,
-            }),
+                isAggregated: true
+            })
         ],
         callback
     );
@@ -140,7 +140,7 @@ function mapUnmapMandatoryOptionsTest(function2Test, callback) {
 function collectionAndDatabaseMandatoryOptionsTest(function2Test, callback) {
     function2Test(
         {
-            collection: sthConfig.COLLECTION_PREFIX + 'any_collection',
+            collection: sthConfig.COLLECTION_PREFIX + 'any_collection'
         },
         function(err) {
             expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
@@ -159,7 +159,7 @@ function shouldDetectCollectionTest(mappingFlag, databaseName, collectionName, c
     sthDatabaseNameMapperTool.getMappingAnalysis(
         {
             map: !!mappingFlag,
-            unmap: !mappingFlag,
+            unmap: !mappingFlag
         },
         function(err, analysis) {
             if (err) {
@@ -184,7 +184,7 @@ function shouldNotDetectCollectionTest(mappingFlag, databaseName, collectionName
             map: !!mappingFlag,
             unmap: !mappingFlag,
             database: databaseName,
-            collection: collectionName,
+            collection: collectionName
         },
         function(err, analysis) {
             if (err) {
@@ -233,7 +233,7 @@ function shouldMapOrUnmapDatabaseTest(databaseName, mappingFlag, callback) {
         {
             map: !!mappingFlag,
             unmap: !mappingFlag,
-            database: databaseName,
+            database: databaseName
         },
         function(err) {
             if (err) {
@@ -273,7 +273,7 @@ function shouldNotMapOrUnmapDatabaseTest(databaseName, mappingFlag, callback) {
         {
             map: !!mappingFlag,
             unmap: !mappingFlag,
-            database: databaseName,
+            database: databaseName
         },
         function(err) {
             if (err) {
@@ -303,7 +303,7 @@ function shouldMapOrUnmapCollectionTest(databaseName, collectionName, mappingFla
             map: !!mappingFlag,
             unmap: !mappingFlag,
             database: databaseName,
-            collection: collectionName,
+            collection: collectionName
         },
         function(err) {
             if (err) {
@@ -353,7 +353,7 @@ function shouldNotMapOrUnmapCollectionTest(databaseName, collectionName, mapping
             map: !!mappingFlag,
             unmap: !mappingFlag,
             database: databaseName,
-            collection: collectionName,
+            collection: collectionName
         },
         function(err) {
             if (err) {
@@ -394,7 +394,7 @@ describe('sthDatabaseNameMapperTool tests', function() {
             it("should not detect database '" + DATABASE_NAME + "' as susceptible of being mapped", function(done) {
                 sthDatabaseNameMapperTool.getMappingAnalysis(
                     {
-                        map: true,
+                        map: true
                     },
                     function(err, analysis) {
                         if (err) {
@@ -412,7 +412,7 @@ describe('sthDatabaseNameMapperTool tests', function() {
                     sthDatabaseNameMapperTool.getMappingAnalysis(
                         {
                             map: true,
-                            database: sthConfig.DB_PREFIX + 'inexistent_database',
+                            database: sthConfig.DB_PREFIX + 'inexistent_database'
                         },
                         function(err, analysis) {
                             if (err) {
@@ -512,7 +512,7 @@ describe('sthDatabaseNameMapperTool tests', function() {
                     sthDatabaseNameMapperTool.getMappingAnalysis(
                         {
                             map: false,
-                            unmap: true,
+                            unmap: true
                         },
                         function(err, analysis) {
                             if (err) {
@@ -536,7 +536,7 @@ describe('sthDatabaseNameMapperTool tests', function() {
                         {
                             map: false,
                             unmap: true,
-                            database: sthConfig.DB_PREFIX + 'inexistent_database',
+                            database: sthConfig.DB_PREFIX + 'inexistent_database'
                         },
                         function(err, analysis) {
                             if (err) {

--- a/test/unit/sthDatabaseNameMapperTool_test.js
+++ b/test/unit/sthDatabaseNameMapperTool_test.js
@@ -37,18 +37,18 @@ var sthTestConfig = require(ROOT_PATH + '/test/unit/sthTestConfiguration');
 var DEFAULT_SERVICE = sthConfig.DEFAULT_SERVICE;
 var DATABASE_NAME = sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE);
 var DATABASE_CONNECTION_PARAMS = {
-  authentication: sthConfig.DB_AUTHENTICATION,
-  dbURI: sthConfig.DB_URI,
-  replicaSet: sthConfig.REPLICA_SET,
-  database: DATABASE_NAME,
-  poolSize: sthConfig.POOL_SIZE
+    authentication: sthConfig.DB_AUTHENTICATION,
+    dbURI: sthConfig.DB_URI,
+    replicaSet: sthConfig.REPLICA_SET,
+    database: DATABASE_NAME,
+    poolSize: sthConfig.POOL_SIZE,
 };
 var COLLECTION_NAME_PARAMS = {
-  service: DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME
+    service: DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
 };
 
 /**
@@ -56,10 +56,13 @@ var COLLECTION_NAME_PARAMS = {
  * @param  {Function} callback The callblack
  */
 function connectToDatabase(callback) {
-  if (sthDatabase.connection) {
-    return process.nextTick(callback.bind(null, null, sthDatabase.connection));
-  }
-  sthDatabase.connect(DATABASE_CONNECTION_PARAMS, callback);
+    if (sthDatabase.connection) {
+        return process.nextTick(callback.bind(null, null, sthDatabase.connection));
+    }
+    sthDatabase.connect(
+        DATABASE_CONNECTION_PARAMS,
+        callback
+    );
 }
 
 /**
@@ -67,26 +70,18 @@ function connectToDatabase(callback) {
  * @param  {Function} callback The callback
  */
 function createRawAndAggregatedCollections(callback) {
-  async.series(
-    [
-      async.apply(
-        sthDatabase.getCollection,
-        COLLECTION_NAME_PARAMS,
-        {
-          shouldCreate: true
-        }
-      ),
-      async.apply(
-        sthDatabase.getCollection,
-        COLLECTION_NAME_PARAMS,
-        {
-          shouldCreate: true,
-          isAggregated: true
-        }
-      )
-    ],
-    callback
-  );
+    async.series(
+        [
+            async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
+                shouldCreate: true,
+            }),
+            async.apply(sthDatabase.getCollection, COLLECTION_NAME_PARAMS, {
+                shouldCreate: true,
+                isAggregated: true,
+            }),
+        ],
+        callback
+    );
 }
 
 /**
@@ -96,12 +91,15 @@ function createRawAndAggregatedCollections(callback) {
  * @param  {Function} callback       The callback
  */
 function checkCollectionExists(databaseName, collectionName, callback) {
-  sthDatabase.connection.db(databaseName).listCollections({name: collectionName}).toArray(function(err, collections) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    return process.nextTick(callback.bind(null, err, collections.length === 1));
-  });
+    sthDatabase.connection
+        .db(databaseName)
+        .listCollections({ name: collectionName })
+        .toArray(function(err, collections) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            return process.nextTick(callback.bind(null, err, collections.length === 1));
+        });
 }
 
 /**
@@ -109,17 +107,17 @@ function checkCollectionExists(databaseName, collectionName, callback) {
  * @param  {Function} callback The callback
  */
 function dropDatabases(callback) {
-  sthDatabase.connection.db(DATABASE_NAME.toLowerCase()).dropDatabase(function(err) {
-    if (err) {
-      return process.nextTick(callback.bind(null, err));
-    }
-    sthDatabase.connection.db(DATABASE_NAME).dropDatabase(function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      sthDatabase.connection.db(sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME)).dropDatabase(callback);
+    sthDatabase.connection.db(DATABASE_NAME.toLowerCase()).dropDatabase(function(err) {
+        if (err) {
+            return process.nextTick(callback.bind(null, err));
+        }
+        sthDatabase.connection.db(DATABASE_NAME).dropDatabase(function(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            sthDatabase.connection.db(sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME)).dropDatabase(callback);
+        });
     });
-  });
 }
 
 /**
@@ -128,14 +126,10 @@ function dropDatabases(callback) {
  * @param  {Function} callback      The callback
  */
 function mapUnmapMandatoryOptionsTest(function2Test, callback) {
-  function2Test(
-    {
-    },
-    function(err) {
-      expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
-      process.nextTick(callback);
-    }
-  );
+    function2Test({}, function(err) {
+        expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
+        process.nextTick(callback);
+    });
 }
 
 /**
@@ -144,15 +138,15 @@ function mapUnmapMandatoryOptionsTest(function2Test, callback) {
  * @param  {Function} callback      The callback
  */
 function collectionAndDatabaseMandatoryOptionsTest(function2Test, callback) {
-  function2Test(
-    {
-      collection: sthConfig.COLLECTION_PREFIX + 'any_collection'
-    },
-    function(err) {
-      expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
-      process.nextTick(callback);
-    }
-  );
+    function2Test(
+        {
+            collection: sthConfig.COLLECTION_PREFIX + 'any_collection',
+        },
+        function(err) {
+            expect(err instanceof sthErrors.MandatoryOptionNotFound).to.be.ok();
+            process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -162,22 +156,21 @@ function collectionAndDatabaseMandatoryOptionsTest(function2Test, callback) {
  * @param  {Function} callback       The callback
  */
 function shouldDetectCollectionTest(mappingFlag, databaseName, collectionName, callback) {
-  sthDatabaseNameMapperTool.getMappingAnalysis(
-    {
-      map: !!mappingFlag,
-      unmap: !mappingFlag
-    },
-    function(err, analysis) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      expect(analysis[databaseName]).to.not.be(undefined);
-      expect(analysis[databaseName].collections).to.not.be(undefined);
-      expect(analysis[databaseName].collections[collectionName].
-        name).to.not.equal(collectionName);
-      return process.nextTick(callback);
-    }
-  );
+    sthDatabaseNameMapperTool.getMappingAnalysis(
+        {
+            map: !!mappingFlag,
+            unmap: !mappingFlag,
+        },
+        function(err, analysis) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            expect(analysis[databaseName]).to.not.be(undefined);
+            expect(analysis[databaseName].collections).to.not.be(undefined);
+            expect(analysis[databaseName].collections[collectionName].name).to.not.equal(collectionName);
+            return process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -186,22 +179,25 @@ function shouldDetectCollectionTest(mappingFlag, databaseName, collectionName, c
  * @param  {Function} callback     The callback
  */
 function shouldNotDetectCollectionTest(mappingFlag, databaseName, collectionName, callback) {
-  sthDatabaseNameMapperTool.getMappingAnalysis(
-    {
-      map: !!mappingFlag,
-      unmap: !mappingFlag,
-      database: databaseName,
-      collection: collectionName
-    },
-    function(err, analysis) {
-     if (err) {
-       return process.nextTick(callback.bind(null, err));
-      }
-     expect(!analysis[databaseName] || !analysis[databaseName].collections ||
-       !analysis[databaseName].collections[collectionName]).to.be(true);
-     return process.nextTick(callback);
-    }
-  );
+    sthDatabaseNameMapperTool.getMappingAnalysis(
+        {
+            map: !!mappingFlag,
+            unmap: !mappingFlag,
+            database: databaseName,
+            collection: collectionName,
+        },
+        function(err, analysis) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            expect(
+                !analysis[databaseName] ||
+                    !analysis[databaseName].collections ||
+                    !analysis[databaseName].collections[collectionName]
+            ).to.be(true);
+            return process.nextTick(callback);
+        }
+    );
 }
 
 /**
@@ -210,19 +206,19 @@ function shouldNotDetectCollectionTest(mappingFlag, databaseName, collectionName
  * @param  {Function} callback     The callback
  */
 function checkDatabaseExists(databaseName, callback) {
-  var adminDB = sthDatabase.connection.admin();
-  adminDB.listDatabases(function(err, databases) {
-    var databaseFound = false;
-    databases.databases.forEach(function (database) {
-      if (database.name === databaseName) {
-        databaseFound = true;
-        return process.nextTick(callback.bind(null, null, databaseFound));
-      }
+    var adminDB = sthDatabase.connection.admin();
+    adminDB.listDatabases(function(err, databases) {
+        var databaseFound = false;
+        databases.databases.forEach(function(database) {
+            if (database.name === databaseName) {
+                databaseFound = true;
+                return process.nextTick(callback.bind(null, null, databaseFound));
+            }
+        });
+        if (!databaseFound) {
+            return process.nextTick(callback.bind(null, null, false));
+        }
     });
-    if (!databaseFound) {
-      return process.nextTick(callback.bind(null, null, false));
-    }
-  });
 }
 
 /**
@@ -233,38 +229,36 @@ function checkDatabaseExists(databaseName, callback) {
  * @param  {Function} callback       The callback
  */
 function shouldMapOrUnmapDatabaseTest(databaseName, mappingFlag, callback) {
-  sthDatabaseNameMapperTool.mapOrUnmap(
-    {
-      map: !!mappingFlag,
-      unmap: !mappingFlag,
-      database: databaseName
-    },
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      checkDatabaseExists(
-        databaseName,
-        function(err, exists) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          expect(exists).to.be.equal(false);
-          checkDatabaseExists(
-            mappingFlag ? sthDatabaseNameMapper.mapDatabaseName(databaseName) :
-              sthDatabaseNameMapper.unmapDatabaseName(databaseName),
-            function(err, exists) {
-              if (err) {
+    sthDatabaseNameMapperTool.mapOrUnmap(
+        {
+            map: !!mappingFlag,
+            unmap: !mappingFlag,
+            database: databaseName,
+        },
+        function(err) {
+            if (err) {
                 return process.nextTick(callback.bind(null, err));
-              }
-              expect(exists).to.be.equal(true);
-              process.nextTick(callback);
             }
-          );
+            checkDatabaseExists(databaseName, function(err, exists) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                expect(exists).to.be.equal(false);
+                checkDatabaseExists(
+                    mappingFlag
+                        ? sthDatabaseNameMapper.mapDatabaseName(databaseName)
+                        : sthDatabaseNameMapper.unmapDatabaseName(databaseName),
+                    function(err, exists) {
+                        if (err) {
+                            return process.nextTick(callback.bind(null, err));
+                        }
+                        expect(exists).to.be.equal(true);
+                        process.nextTick(callback);
+                    }
+                );
+            });
         }
-      );
-    }
-  );
+    );
 }
 
 /**
@@ -275,28 +269,25 @@ function shouldMapOrUnmapDatabaseTest(databaseName, mappingFlag, callback) {
  * @param  {Function} callback       The callback
  */
 function shouldNotMapOrUnmapDatabaseTest(databaseName, mappingFlag, callback) {
-  sthDatabaseNameMapperTool.mapOrUnmap(
-    {
-      map: !!mappingFlag,
-      unmap: !mappingFlag,
-      database: databaseName
-    },
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      checkDatabaseExists(
-        databaseName,
-        function(err, exists) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          expect(exists).to.be.equal(true);
-          process.nextTick(callback);
+    sthDatabaseNameMapperTool.mapOrUnmap(
+        {
+            map: !!mappingFlag,
+            unmap: !mappingFlag,
+            database: databaseName,
+        },
+        function(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            checkDatabaseExists(databaseName, function(err, exists) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                expect(exists).to.be.equal(true);
+                process.nextTick(callback);
+            });
         }
-      );
-    }
-  );
+    );
 }
 
 /**
@@ -307,43 +298,46 @@ function shouldNotMapOrUnmapDatabaseTest(databaseName, mappingFlag, callback) {
  * @param  {Function} callback       The callback
  */
 function shouldMapOrUnmapCollectionTest(databaseName, collectionName, mappingFlag, callback) {
-  sthDatabaseNameMapperTool.mapOrUnmap(
-    {
-      map: !!mappingFlag,
-      unmap: !mappingFlag,
-      database: databaseName,
-      collection: collectionName
-    },
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      checkCollectionExists(databaseName, collectionName,
-        function(err, exists) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          expect(exists).to.be.equal(false);
-          checkCollectionExists(
-            mappingFlag ? sthDatabaseNameMapper.mapDatabaseName(databaseName) :
-              sthDatabaseNameMapper.unmapDatabaseName(databaseName),
-            mappingFlag ?
-              sthDatabaseNameMapper.mapCollectionName(sthDatabaseNaming.getService(databaseName), collectionName) :
-              sthDatabaseNameMapper.unmapCollectionName(
-                sthDatabaseNameMapper.mapService(sthDatabaseNaming.getService(databaseName)),
-                collectionName),
-            function(err, exists) {
-              if (err) {
+    sthDatabaseNameMapperTool.mapOrUnmap(
+        {
+            map: !!mappingFlag,
+            unmap: !mappingFlag,
+            database: databaseName,
+            collection: collectionName,
+        },
+        function(err) {
+            if (err) {
                 return process.nextTick(callback.bind(null, err));
-              }
-              expect(exists).to.be.equal(true);
-              process.nextTick(callback);
             }
-          );
+            checkCollectionExists(databaseName, collectionName, function(err, exists) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                expect(exists).to.be.equal(false);
+                checkCollectionExists(
+                    mappingFlag
+                        ? sthDatabaseNameMapper.mapDatabaseName(databaseName)
+                        : sthDatabaseNameMapper.unmapDatabaseName(databaseName),
+                    mappingFlag
+                        ? sthDatabaseNameMapper.mapCollectionName(
+                              sthDatabaseNaming.getService(databaseName),
+                              collectionName
+                          )
+                        : sthDatabaseNameMapper.unmapCollectionName(
+                              sthDatabaseNameMapper.mapService(sthDatabaseNaming.getService(databaseName)),
+                              collectionName
+                          ),
+                    function(err, exists) {
+                        if (err) {
+                            return process.nextTick(callback.bind(null, err));
+                        }
+                        expect(exists).to.be.equal(true);
+                        process.nextTick(callback);
+                    }
+                );
+            });
         }
-      );
-    }
-  );
+    );
 }
 
 /**
@@ -354,309 +348,401 @@ function shouldMapOrUnmapCollectionTest(databaseName, collectionName, mappingFla
  * @param  {Function} callback       The callback
  */
 function shouldNotMapOrUnmapCollectionTest(databaseName, collectionName, mappingFlag, callback) {
-  sthDatabaseNameMapperTool.mapOrUnmap(
-    {
-      map: !!mappingFlag,
-      unmap: !mappingFlag,
-      database: databaseName,
-      collection: collectionName
-    },
-    function(err) {
-      if (err) {
-        return process.nextTick(callback.bind(null, err));
-      }
-      checkCollectionExists(databaseName, collectionName,
-        function(err, exists) {
-          if (err) {
-            return process.nextTick(callback.bind(null, err));
-          }
-          expect(exists).to.be.equal(true);
-          process.nextTick(callback);
+    sthDatabaseNameMapperTool.mapOrUnmap(
+        {
+            map: !!mappingFlag,
+            unmap: !mappingFlag,
+            database: databaseName,
+            collection: collectionName,
+        },
+        function(err) {
+            if (err) {
+                return process.nextTick(callback.bind(null, err));
+            }
+            checkCollectionExists(databaseName, collectionName, function(err, exists) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                expect(exists).to.be.equal(true);
+                process.nextTick(callback);
+            });
         }
-      );
-    }
-  );
+    );
 }
 
 describe('sthDatabaseNameMapperTool tests', function() {
-  var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING;
+    var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING;
 
-  describe('getMappingAnalysis tests', function() {
-    describe('name mapping disabled', function() {
-      sthConfig.NAME_MAPPING = undefined;
-      before(function(done) {
-        sthConfig.NAME_MAPPING = undefined;
-        async.series(
-          [
-            connectToDatabase,
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
+    describe('getMappingAnalysis tests', function() {
+        describe('name mapping disabled', function() {
+            sthConfig.NAME_MAPPING = undefined;
+            before(function(done) {
+                sthConfig.NAME_MAPPING = undefined;
+                async.series([connectToDatabase, dropDatabases, createRawAndAggregatedCollections], done);
+            });
 
-      it('should raise an error if neither -m, --map or -u, --unmap options are set',
-        mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis));
+            it(
+                'should raise an error if neither -m, --map or -u, --unmap options are set',
+                mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
+            );
 
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis));
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
+            );
 
-      it('should not detect database \'' + DATABASE_NAME + '\' as susceptible of being mapped', function(done) {
-        sthDatabaseNameMapperTool.getMappingAnalysis(
-          {
-            map: true
-          },
-          function(err, analysis) {
-            if (err) {
-              return done(err);
-            }
-            expect(analysis[DATABASE_NAME]).to.equal(undefined);
-            done();
-          }
-        );
-      });
+            it("should not detect database '" + DATABASE_NAME + "' as susceptible of being mapped", function(done) {
+                sthDatabaseNameMapperTool.getMappingAnalysis(
+                    {
+                        map: true,
+                    },
+                    function(err, analysis) {
+                        if (err) {
+                            return done(err);
+                        }
+                        expect(analysis[DATABASE_NAME]).to.equal(undefined);
+                        done();
+                    }
+                );
+            });
 
-      it('should not detect database \'' + DATABASE_NAME + '\' as susceptible of being mapped if filtered out',
-        function(done) {
-          sthDatabaseNameMapperTool.getMappingAnalysis(
-            {
-              map: true,
-              database: sthConfig.DB_PREFIX + 'inexistent_database'
-            },
-            function(err, analysis) {
-              if (err) {
-                return done(err);
-              }
-              expect(analysis[DATABASE_NAME]).to.be(undefined);
-              done();
-            }
-          );
-        }
-      );
+            it(
+                "should not detect database '" + DATABASE_NAME + "' as susceptible of being mapped if filtered out",
+                function(done) {
+                    sthDatabaseNameMapperTool.getMappingAnalysis(
+                        {
+                            map: true,
+                            database: sthConfig.DB_PREFIX + 'inexistent_database',
+                        },
+                        function(err, analysis) {
+                            if (err) {
+                                return done(err);
+                            }
+                            expect(analysis[DATABASE_NAME]).to.be(undefined);
+                            done();
+                        }
+                    );
+                }
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being mapped',
-         shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME,
-           sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being mapped",
+                shouldNotDetectCollectionTest.bind(
+                    null,
+                    true,
+                    DATABASE_NAME,
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being mapped if filtered out',
-        shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME,
-          sthConfig.COLLECTION_PREFIX + 'inexistent_collection'));
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being mapped if filtered out",
+                shouldNotDetectCollectionTest.bind(
+                    null,
+                    true,
+                    DATABASE_NAME,
+                    sthConfig.COLLECTION_PREFIX + 'inexistent_collection'
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being mapped',
-        shouldNotDetectCollectionTest.bind(
-          null, true, DATABASE_NAME, sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being mapped",
+                shouldNotDetectCollectionTest.bind(
+                    null,
+                    true,
+                    DATABASE_NAME,
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + DATABASE_NAME + '\' as susceptible of being mapped if filtered out',
-        shouldNotDetectCollectionTest.bind(null, true, DATABASE_NAME,
-          sthConfig.COLLECTION_PREFIX + 'inexistent_collection'));
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    DATABASE_NAME +
+                    "' as susceptible of being mapped if filtered out",
+                shouldNotDetectCollectionTest.bind(
+                    null,
+                    true,
+                    DATABASE_NAME,
+                    sthConfig.COLLECTION_PREFIX + 'inexistent_collection'
+                )
+            );
 
-      after(function() {
-        sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-      });
-      sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+            after(function() {
+                sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+            });
+            sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+        });
+
+        describe('name mapping enabled', function() {
+            sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+            before(function(done) {
+                sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+                async.series([dropDatabases, createRawAndAggregatedCollections], done);
+            });
+
+            it(
+                'should raise an error if neither -m, --map or -u, --unmap options are set',
+                mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
+            );
+
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
+            );
+
+            it(
+                "should detect database '" +
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
+                    "' as susceptible of being unmapped",
+                function(done) {
+                    sthDatabaseNameMapperTool.getMappingAnalysis(
+                        {
+                            map: false,
+                            unmap: true,
+                        },
+                        function(err, analysis) {
+                            if (err) {
+                                return done(err);
+                            }
+                            expect(analysis[sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME)]).to.not.equal(
+                                undefined
+                            );
+                            done();
+                        }
+                    );
+                }
+            );
+
+            it(
+                "should not detect database '" +
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
+                    "' as susceptible of being mapped if filtered out",
+                function(done) {
+                    sthDatabaseNameMapperTool.getMappingAnalysis(
+                        {
+                            map: false,
+                            unmap: true,
+                            database: sthConfig.DB_PREFIX + 'inexistent_database',
+                        },
+                        function(err, analysis) {
+                            if (err) {
+                                return done(err);
+                            }
+                            expect(analysis[sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME)]).to.be(undefined);
+                            done();
+                        }
+                    );
+                }
+            );
+
+            it(
+                "should detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of " +
+                    'being unmapped',
+                shouldDetectCollectionTest.bind(
+                    null,
+                    false,
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
+
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of being unmapped if filtered out",
+                shouldNotDetectCollectionTest.bind(
+                    null,
+                    false,
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
+                    sthConfig.COLLECTION_PREFIX + 'inexistent_collection'
+                )
+            );
+
+            it(
+                "should detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of being unmapped",
+                shouldDetectCollectionTest.bind(
+                    null,
+                    false,
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                )
+            );
+
+            it(
+                "should not detect collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' of database '" +
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
+                    "' as susceptible of being unmapped if filtered out",
+                shouldNotDetectCollectionTest.bind(
+                    null,
+                    false,
+                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
+                    sthConfig.COLLECTION_PREFIX + 'inexistent_collection'
+                )
+            );
+
+            after(function() {
+                sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+            });
+            sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+        });
     });
 
-    describe('name mapping enabled', function() {
-      sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-      before(function(done) {
-        sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-        async.series(
-          [
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
+    describe('mapOrUnmap tests', function() {
+        describe('name mapping disabled', function() {
+            sthConfig.NAME_MAPPING = undefined;
+            before(function(done) {
+                sthConfig.NAME_MAPPING = undefined;
+                async.series([dropDatabases, createRawAndAggregatedCollections], done);
+            });
 
-      it('should raise an error if neither -m, --map or -u, --unmap options are set',
-        mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis));
+            it(
+                'should raise an error if neither -m, --map or -u, --unmap options are set',
+                mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
+            );
 
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis));
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
+            );
 
-      it('should detect database \'' + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-         '\' as susceptible of being unmapped', function(done) {
-        sthDatabaseNameMapperTool.getMappingAnalysis(
-          {
-            map: false,
-            unmap: true
-          },
-          function(err, analysis) {
-            if (err) {
-              return done(err);
-            }
-            expect(analysis[sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME)]).to.not.equal(undefined);
-            done();
-          }
-        );
-      });
+            it(
+                "should not map the database '" + DATABASE_NAME,
+                shouldNotMapOrUnmapDatabaseTest.bind(null, DATABASE_NAME, true)
+            );
 
-      it('should not detect database \'' + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-         '\' as susceptible of being mapped if filtered out',
-        function(done) {
-          sthDatabaseNameMapperTool.getMappingAnalysis(
-            {
-              map: false,
-              unmap: true,
-              database: sthConfig.DB_PREFIX + 'inexistent_database'
-            },
-            function(err, analysis) {
-              if (err) {
-                return done(err);
-              }
-              expect(analysis[sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME)]).to.be(undefined);
-              done();
-            }
-          );
-        }
-      );
+            it(
+                "should not map the collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    " of database '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldNotMapOrUnmapCollectionTest.bind(
+                    null,
+                    DATABASE_NAME,
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS),
+                    true
+                )
+            );
 
-      it('should detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + '\' as susceptible of ' +
-         'being unmapped',
-         shouldDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)));
+            it(
+                "should not map the collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    " of database '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldNotMapOrUnmapCollectionTest.bind(
+                    null,
+                    DATABASE_NAME,
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS),
+                    true
+                )
+            );
 
-      it('should not detect collection \'' + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-         '\' as susceptible of being unmapped if filtered out',
-        shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
-          sthConfig.COLLECTION_PREFIX + 'inexistent_collection')
-      );
+            after(function() {
+                sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+            });
+            sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+        });
 
-      it('should detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-         '\' as susceptible of being unmapped',
-        shouldDetectCollectionTest.bind(
-          null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)));
+        describe('name mapping enabled', function() {
+            sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+            before(function(done) {
+                sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+                async.series([dropDatabases, createRawAndAggregatedCollections], done);
+            });
 
-      it('should not detect collection \'' + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         '\' of database \'' + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-         '\' as susceptible of being unmapped if filtered out',
-        shouldNotDetectCollectionTest.bind(null, false, sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE),
-          sthConfig.COLLECTION_PREFIX + 'inexistent_collection')
-        );
+            it(
+                'should raise an error if neither -m, --map or -u, --unmap options are set',
+                mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
+            );
 
-      after(function() {
-        sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-      });
-      sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+            it(
+                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+                collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
+            );
+
+            it(
+                "should unmap the database '" +
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
+                    "' as '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldMapOrUnmapDatabaseTest.bind(null, sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME), false)
+            );
+
+            it(
+                "should unmap the collection '" +
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' as '" +
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
+                        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                    ) +
+                    "' and the database '" +
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
+                    "' as '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldMapOrUnmapCollectionTest.bind(
+                    null,
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME),
+                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS),
+                    false
+                )
+            );
+
+            it(
+                "should unmap the collection '" +
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                    "' as '" +
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
+                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
+                    ) +
+                    "' and the database '" +
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
+                    "' as '" +
+                    DATABASE_NAME +
+                    "'",
+                shouldMapOrUnmapCollectionTest.bind(
+                    null,
+                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME),
+                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS),
+                    false
+                )
+            );
+
+            after(function(done) {
+                sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+                dropDatabases(done);
+            });
+            sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+        });
     });
-  });
-
-  describe('mapOrUnmap tests', function() {
-    describe('name mapping disabled', function() {
-      sthConfig.NAME_MAPPING = undefined;
-      before(function(done) {
-        sthConfig.NAME_MAPPING = undefined;
-        async.series(
-          [
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
-
-      it('should raise an error if neither -m, --map or -u, --unmap options are set',
-        mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap));
-
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap));
-
-      it('should not map the database \'' + DATABASE_NAME,
-        shouldNotMapOrUnmapDatabaseTest.bind(null, DATABASE_NAME, true));
-
-      it('should not map the collection \'' +
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-          ' of database \'' + DATABASE_NAME + '\'',
-        shouldNotMapOrUnmapCollectionTest.bind(
-          null, DATABASE_NAME, sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS),
-          true)
-      );
-
-      it('should not map the collection \'' +
-         sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-         ' of database \'' + DATABASE_NAME + '\'',
-         shouldNotMapOrUnmapCollectionTest.bind(
-           null, DATABASE_NAME, sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS),
-           true)
-      );
-
-      after(function() {
-        sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-      });
-      sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-    });
-
-    describe('name mapping enabled', function() {
-      sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-      before(function(done) {
-        sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-        async.series(
-          [
-            dropDatabases,
-            createRawAndAggregatedCollections
-          ],
-          done
-        );
-      });
-
-      it('should raise an error if neither -m, --map or -u, --unmap options are set',
-        mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap));
-
-      it('should raise an error if the -b, --database is not set when the -c, --collection is set',
-        collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap));
-
-      it('should unmap the database \'' + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + '\' as \'' +
-        DATABASE_NAME + '\'',
-        shouldMapOrUnmapDatabaseTest.bind(
-          null, sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME), false));
-
-      it('should unmap the collection \'' +
-        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-        '\' as \'' +
-        sthDatabaseNameMapper.unmapCollectionName(
-          sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
-          sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)) +
-          '\' and the database \'' + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + '\' as \'' +
-          DATABASE_NAME + '\'',
-          shouldMapOrUnmapCollectionTest.bind(
-            null,
-            sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME),
-            sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS),
-            false
-          )
-      );
-
-      it('should unmap the collection \'' +
-        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-        '\' as \'' +
-        sthDatabaseNameMapper.unmapCollectionName(
-          sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
-          sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)) +
-        '\' and the database \'' + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + '\' as \'' +
-          DATABASE_NAME + '\'',
-          shouldMapOrUnmapCollectionTest.bind(
-            null,
-            sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME),
-            sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS),
-            false
-          )
-      );
-
-      after(function(done) {
-        sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-        dropDatabases(done);
-      });
-      sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-    });
-  });
 });

--- a/test/unit/sthDatabaseNameMapperTool_test.js
+++ b/test/unit/sthDatabaseNameMapperTool_test.js
@@ -381,13 +381,13 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 async.series([connectToDatabase, dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -m, --map or -u, --unmap options are set',
+            // prettier-ignore
+            it('should raise an error if neither -m, --map or -u, --unmap options are set',
                 mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
             );
 
@@ -406,8 +406,8 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 );
             });
 
-            it(
-                "should not detect database '" + DATABASE_NAME + "' as susceptible of being mapped if filtered out",
+            // prettier-ignore
+            it("should not detect database '" + DATABASE_NAME + "' as susceptible of being mapped if filtered out",
                 function(done) {
                     sthDatabaseNameMapperTool.getMappingAnalysis(
                         {
@@ -425,12 +425,9 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 }
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being mapped",
+            // prettier-ignore
+            it("should not detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + DATABASE_NAME + "' as susceptible of being mapped",
                 shouldNotDetectCollectionTest.bind(
                     null,
                     true,
@@ -439,12 +436,9 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being mapped if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + DATABASE_NAME + "' as susceptible of being mapped if filtered out",
                 shouldNotDetectCollectionTest.bind(
                     null,
                     true,
@@ -453,12 +447,10 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being mapped",
+            // prettier-ignore
+            it("should not detect collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + "' of database '" + 
+                DATABASE_NAME + "' as susceptible of being mapped",
                 shouldNotDetectCollectionTest.bind(
                     null,
                     true,
@@ -467,12 +459,10 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    DATABASE_NAME +
-                    "' as susceptible of being mapped if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + "' of database '" + 
+                DATABASE_NAME + "' as susceptible of being mapped if filtered out",
                 shouldNotDetectCollectionTest.bind(
                     null,
                     true,
@@ -494,20 +484,19 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 async.series([dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -m, --map or -u, --unmap options are set',
+            // prettier-ignore
+            it('should raise an error if neither -m, --map or -u, --unmap options are set',
                 mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.getMappingAnalysis)
             );
 
-            it(
-                "should detect database '" +
-                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-                    "' as susceptible of being unmapped",
+            // prettier-ignore
+            it("should detect database '" + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + 
+                "' as susceptible of being unmapped",
                 function(done) {
                     sthDatabaseNameMapperTool.getMappingAnalysis(
                         {
@@ -527,10 +516,9 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 }
             );
 
-            it(
-                "should not detect database '" +
-                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-                    "' as susceptible of being mapped if filtered out",
+            // prettier-ignore
+            it("should not detect database '" + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + 
+                "' as susceptible of being mapped if filtered out",
                 function(done) {
                     sthDatabaseNameMapperTool.getMappingAnalysis(
                         {
@@ -549,13 +537,10 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 }
             );
 
-            it(
-                "should detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of " +
-                    'being unmapped',
+            // prettier-ignore
+            it("should detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + "' as susceptible of " + 
+                'being unmapped',
                 shouldDetectCollectionTest.bind(
                     null,
                     false,
@@ -564,12 +549,10 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of being unmapped if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + 
+                "' as susceptible of being unmapped if filtered out",
                 shouldNotDetectCollectionTest.bind(
                     null,
                     false,
@@ -578,12 +561,10 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of being unmapped",
+            // prettier-ignore
+            it("should detect collection '" + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' of database '" + sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + 
+                "' as susceptible of being unmapped",
                 shouldDetectCollectionTest.bind(
                     null,
                     false,
@@ -592,12 +573,11 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should not detect collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' of database '" +
-                    sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) +
-                    "' as susceptible of being unmapped if filtered out",
+            // prettier-ignore
+            it("should not detect collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + "' of database '" + 
+                sthDatabaseNaming.getDatabaseName(DEFAULT_SERVICE) + 
+                "' as susceptible of being unmapped if filtered out",
                 shouldNotDetectCollectionTest.bind(
                     null,
                     false,
@@ -621,27 +601,24 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 async.series([dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -m, --map or -u, --unmap options are set',
+            // prettier-ignore
+            it('should raise an error if neither -m, --map or -u, --unmap options are set',
                 mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
             );
 
-            it(
-                "should not map the database '" + DATABASE_NAME,
+            // prettier-ignore
+            it("should not map the database '" + DATABASE_NAME,
                 shouldNotMapOrUnmapDatabaseTest.bind(null, DATABASE_NAME, true)
             );
 
-            it(
-                "should not map the collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    " of database '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should not map the collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                " of database '" + DATABASE_NAME + "'",
                 shouldNotMapOrUnmapCollectionTest.bind(
                     null,
                     DATABASE_NAME,
@@ -650,12 +627,10 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should not map the collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    " of database '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should not map the collection '" + 
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) + " of database '" + 
+                DATABASE_NAME + "'",
                 shouldNotMapOrUnmapCollectionTest.bind(
                     null,
                     DATABASE_NAME,
@@ -677,38 +652,27 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 async.series([dropDatabases, createRawAndAggregatedCollections], done);
             });
 
-            it(
-                'should raise an error if neither -m, --map or -u, --unmap options are set',
+            // prettier-ignore
+            it('should raise an error if neither -m, --map or -u, --unmap options are set',
                 mapUnmapMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
             );
 
-            it(
-                'should raise an error if the -b, --database is not set when the -c, --collection is set',
+            // prettier-ignore
+            it('should raise an error if the -b, --database is not set when the -c, --collection is set',
                 collectionAndDatabaseMandatoryOptionsTest.bind(null, sthDatabaseNameMapperTool.mapOrUnmap)
             );
 
-            it(
-                "should unmap the database '" +
-                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-                    "' as '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should unmap the database '" + sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + "' as '" + 
+                DATABASE_NAME + "'",
                 shouldMapOrUnmapDatabaseTest.bind(null, sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME), false)
             );
 
-            it(
-                "should unmap the collection '" +
-                    sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' as '" +
-                    sthDatabaseNameMapper.unmapCollectionName(
-                        sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
-                        sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
-                    ) +
-                    "' and the database '" +
-                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-                    "' as '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should unmap the collection '" + sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) + 
+                "' as '" + sthDatabaseNameMapper.unmapCollectionName(sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
+                sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)) + "' and the database '" + 
+                sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + "' as '" + DATABASE_NAME + "'",
                 shouldMapOrUnmapCollectionTest.bind(
                     null,
                     sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME),
@@ -717,19 +681,11 @@ describe('sthDatabaseNameMapperTool tests', function() {
                 )
             );
 
-            it(
-                "should unmap the collection '" +
-                    sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
-                    "' as '" +
-                    sthDatabaseNameMapper.unmapCollectionName(
-                        sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
-                        sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)
-                    ) +
-                    "' and the database '" +
-                    sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) +
-                    "' as '" +
-                    DATABASE_NAME +
-                    "'",
+            // prettier-ignore
+            it("should unmap the collection '" + sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS) +
+                "' as '" + sthDatabaseNameMapper.unmapCollectionName(sthDatabaseNameMapper.mapService(DEFAULT_SERVICE),
+                sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS)) + "' and the database '" + 
+                sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME) + "' as '" + DATABASE_NAME + "'",
                 shouldMapOrUnmapCollectionTest.bind(
                     null,
                     sthDatabaseNameMapper.mapDatabaseName(DATABASE_NAME),

--- a/test/unit/sthDatabaseNameMapper_test.js
+++ b/test/unit/sthDatabaseNameMapper_test.js
@@ -29,319 +29,558 @@ var sthDatabaseNameMapper = require(ROOT_PATH + '/lib/database/model/sthDatabase
 var expect = require('expect.js');
 
 describe('sthDatabaseNameMapper tests', function() {
-  describe('mapping tests', function() {
-    var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
-    var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING;
+    describe('mapping tests', function() {
+        var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
+        var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING;
 
-    before(function() {
-      sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+        before(function() {
+            sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+        });
+
+        it("should map the 'testservice' service as 'mappedtestservice'", function() {
+            expect(sthDatabaseNameMapper.mapService('testservice')).to.equal('mappedtestservice');
+        });
+
+        it("should map the 'testservicepath' service path as '/mappedtestservicepath'", function() {
+            expect(sthDatabaseNameMapper.mapServicePath('testservice', '/testservicepath')).to.equal(
+                '/mappedtestservicepath'
+            );
+        });
+
+        it("should map the 'entityId' entity id or name as 'mappedEntityId'", function() {
+            expect(sthDatabaseNameMapper.mapEntityName('testservice', '/testservicepath', 'entityId')).to.equal(
+                'mappedEntityId'
+            );
+        });
+
+        it("should map the 'entityType' entity type as 'mappedEntityType'", function() {
+            expect(sthDatabaseNameMapper.mapEntityType('testservice', '/testservicepath', 'entityType')).to.equal(
+                'mappedEntityType'
+            );
+        });
+
+        it("should map the 'attrName' attribute name as 'mappedAttrName'", function() {
+            expect(
+                sthDatabaseNameMapper.mapAttributeName('testservice', '/testservicepath', 'entityId', 'attrName')
+            ).to.equal('mappedAttrName');
+        });
+
+        it("should map the 'attrType' attribute type as 'mappedAttrType'", function() {
+            expect(
+                sthDatabaseNameMapper.mapAttributeType('testservice', '/testservicepath', 'entityId', 'attrType')
+            ).to.equal('mappedAttrType');
+        });
+
+        it(
+            "should map the '" +
+                sthConfig.DB_PREFIX +
+                "testservice' database as '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice'",
+            function() {
+                expect(sthDatabaseNameMapper.mapDatabaseName(sthConfig.DB_PREFIX + 'testservice')).to.equal(
+                    sthConfig.DB_PREFIX + 'mappedtestservice'
+                );
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath' collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per service path data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath.aggr' collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per service path data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath.aggr');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId' collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId.aggr' collection " +
+                "of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId.aggr');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType' collection " +
+                "of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType.aggr' collection " +
+                "of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_attrName' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedAttrName'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_attrName.aggr' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr');
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType_attrName' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName'
+                    )
+                ).to.equal(
+                    sthConfig.COLLECTION_PREFIX +
+                        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'
+                );
+            }
+        );
+
+        it(
+            "should map the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType_attrName.aggr' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "testservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.mapCollectionName(
+                        'testservice',
+                        sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr'
+                    )
+                ).to.equal(
+                    sthConfig.COLLECTION_PREFIX +
+                        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'
+                );
+            }
+        );
+
+        after(function() {
+            sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
+            sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+        });
     });
 
-    it('should map the \'testservice\' service as \'mappedtestservice\'', function() {
-      expect(sthDatabaseNameMapper.mapService('testservice')).to.equal('mappedtestservice');
-    });
+    describe('unmapping tests', function() {
+        var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
+        var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING;
 
-    it('should map the \'testservicepath\' service path as \'/mappedtestservicepath\'', function() {
-      expect(sthDatabaseNameMapper.mapServicePath('testservice', '/testservicepath')).
-        to.equal('/mappedtestservicepath');
-    });
+        before(function() {
+            sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+        });
 
-    it('should map the \'entityId\' entity id or name as \'mappedEntityId\'', function() {
-      expect(sthDatabaseNameMapper.mapEntityName('testservice', '/testservicepath', 'entityId')).
-        to.equal('mappedEntityId');
-    });
+        it("should unmap the 'mappedtestservice' service as 'testservice'", function() {
+            expect(sthDatabaseNameMapper.unmapService('mappedtestservice')).to.equal('testservice');
+        });
 
-    it('should map the \'entityType\' entity type as \'mappedEntityType\'', function() {
-      expect(sthDatabaseNameMapper.mapEntityType('testservice', '/testservicepath', 'entityType')).
-        to.equal('mappedEntityType');
-    });
+        it("should unmap the 'testservicepath' service path as '/mappedtestservicepath'", function() {
+            expect(sthDatabaseNameMapper.unmapServicePath('mappedtestservice', '/mappedtestservicepath')).to.equal(
+                '/testservicepath'
+            );
+        });
 
-    it('should map the \'attrName\' attribute name as \'mappedAttrName\'', function() {
-      expect(sthDatabaseNameMapper.mapAttributeName('testservice', '/testservicepath', 'entityId', 'attrName')).
-        to.equal('mappedAttrName');
-    });
+        it("should unmap the 'mappedEntityId' entity id or name as '/entityId'", function() {
+            expect(
+                sthDatabaseNameMapper.unmapEntityName('mappedtestservice', '/mappedtestservicepath', 'mappedEntityId')
+            ).to.equal('entityId');
+        });
 
-    it('should map the \'attrType\' attribute type as \'mappedAttrType\'', function() {
-      expect(sthDatabaseNameMapper.mapAttributeType('testservice', '/testservicepath', 'entityId', 'attrType')).
-        to.equal('mappedAttrType');
-    });
+        it("should unmap the 'mappedEntityType' entity type as '/entityType'", function() {
+            expect(
+                sthDatabaseNameMapper.unmapEntityType('mappedtestservice', '/mappedtestservicepath', 'mappedEntityType')
+            ).to.equal('entityType');
+        });
 
-    it('should map the \'' + sthConfig.DB_PREFIX + 'testservice\' database as \'' +
-      sthConfig.DB_PREFIX + 'mappedtestservice\'', function() {
-      expect(sthDatabaseNameMapper.mapDatabaseName(sthConfig.DB_PREFIX + 'testservice')).
-        to.equal(sthConfig.DB_PREFIX + 'mappedtestservice');
-    });
+        it("should unmap the 'mappedAttrName' attribute name as '/attrName'", function() {
+            expect(
+                sthDatabaseNameMapper.unmapAttributeName(
+                    'mappedtestservice',
+                    '/mappedtestservicepath',
+                    'mappedEntityId',
+                    'mappedAttrName'
+                )
+            ).to.equal('attrName');
+        });
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath\' collection of database \'' +
-      sthConfig.DB_PREFIX + 'testservice\' with the collection per service path data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
-      expect(sthDatabaseNameMapper.mapCollectionName('testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath')).
-        to.equal(sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath');
-    });
+        it("should unmap the 'mappedAttrType' attribute type as '/attrType'", function() {
+            expect(
+                sthDatabaseNameMapper.unmapAttributeType(
+                    'mappedtestservice',
+                    '/mappedtestservicepath',
+                    'mappedEntityId',
+                    'mappedAttrType'
+                )
+            ).to.equal('attrType');
+        });
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath.aggr\' collection of database \'' +
-      sthConfig.DB_PREFIX + 'testservice\' with the collection per service path data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath.aggr');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' database as '" +
+                sthConfig.DB_PREFIX +
+                "testservice'",
+            function() {
+                expect(sthDatabaseNameMapper.unmapDatabaseName(sthConfig.DB_PREFIX + 'mappedtestservice')).to.equal(
+                    sthConfig.DB_PREFIX + 'testservice'
+                );
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId\' collection of database \'' +
-      sthConfig.DB_PREFIX + 'testservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath' collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per service path data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId.aggr\' collection ' +
-      'of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId.aggr');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath.aggr' collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per service path data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath.aggr');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType\' collection ' +
-      'of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_entityId' collection " +
+                "of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_mappedEntityId'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType.aggr\' collection ' +
-      'of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId.aggr' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per " +
+                "entity data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId.aggr');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedAttrName\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType' collection " +
+                "of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName.aggr\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr' collection " +
+                "of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per entity data model as " +
+                "'" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType.aggr');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedentityId_mappedattrName' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_attrName'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName');
+            }
+        );
 
-    it('should map the \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'testservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.mapCollectionName(
-        'testservice', sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr');
-    });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedentityId_mappedattrName.aggr' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_attrName.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName.aggr');
+            }
+        );
 
-    after(function() {
-      sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-      sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-    });
-  });
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType_attrName'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX +
+                            '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName');
+            }
+        );
 
-  describe('unmapping tests', function() {
-    var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
-    var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING;
+        it(
+            "should unmap the '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr' " +
+                "collection of database '" +
+                sthConfig.DB_PREFIX +
+                "mappedtestservice' with the collection per attribute " +
+                "data model as '" +
+                sthConfig.COLLECTION_PREFIX +
+                "/testservicepath_entityId_entityType_attrName.aggr'",
+            function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
+                expect(
+                    sthDatabaseNameMapper.unmapCollectionName(
+                        'mappedtestservice',
+                        sthConfig.COLLECTION_PREFIX +
+                            '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'
+                    )
+                ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr');
+            }
+        );
 
-    before(function() {
-      sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+        after(function() {
+            sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
+            sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+        });
     });
-
-    it('should unmap the \'mappedtestservice\' service as \'testservice\'', function() {
-      expect(sthDatabaseNameMapper.unmapService('mappedtestservice')).to.equal('testservice');
-    });
-
-    it('should unmap the \'testservicepath\' service path as \'/mappedtestservicepath\'', function() {
-      expect(sthDatabaseNameMapper.unmapServicePath('mappedtestservice', '/mappedtestservicepath')).
-        to.equal('/testservicepath');
-    });
-
-    it('should unmap the \'mappedEntityId\' entity id or name as \'/entityId\'', function() {
-      expect(sthDatabaseNameMapper.unmapEntityName('mappedtestservice', '/mappedtestservicepath', 'mappedEntityId')).
-        to.equal('entityId');
-    });
-
-    it('should unmap the \'mappedEntityType\' entity type as \'/entityType\'', function() {
-      expect(sthDatabaseNameMapper.unmapEntityType('mappedtestservice', '/mappedtestservicepath', 'mappedEntityType')).
-        to.equal('entityType');
-    });
-
-    it('should unmap the \'mappedAttrName\' attribute name as \'/attrName\'', function() {
-      expect(sthDatabaseNameMapper.unmapAttributeName('mappedtestservice', '/mappedtestservicepath', 'mappedEntityId',
-        'mappedAttrName')).
-        to.equal('attrName');
-    });
-
-    it('should unmap the \'mappedAttrType\' attribute type as \'/attrType\'', function() {
-      expect(sthDatabaseNameMapper.unmapAttributeType('mappedtestservice', '/mappedtestservicepath', 'mappedEntityId',
-        'mappedAttrType')).
-        to.equal('attrType');
-    });
-
-    it('should unmap the \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' database as \'' +
-      sthConfig.DB_PREFIX + 'testservice\'', function() {
-      expect(sthDatabaseNameMapper.unmapDatabaseName(sthConfig.DB_PREFIX + 'mappedtestservice')).
-        to.equal(sthConfig.DB_PREFIX + 'testservice');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath\' collection of database \'' +
-      sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per service path data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/testservicepath\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath.aggr\' collection of database \'' +
-      sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per service path data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/testservicepath.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath.aggr');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_entityId\' collection ' +
-      'of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_mappedEntityId\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId.aggr\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per ' +
-      'entity data model as \'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId.aggr');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedEntityType\' collection ' +
-      'of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedEntityType')).
-        to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr\' collection ' +
-      'of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per entity data model as ' +
-      '\'' + sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX +
-        '/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType.aggr');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedentityId_mappedattrName\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/testservicepath_entityId_attrName\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX + '/mappedtestservicepath_mappedEntityId_mappedAttrName')).
-        to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedentityId_mappedattrName.aggr\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/testservicepath_entityId_attrName.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX +
-        '/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_attrName.aggr');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/testservicepath_entityId_entityType_attrName\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX +
-        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName');
-    });
-
-    it('should unmap the \'' + sthConfig.COLLECTION_PREFIX +
-      '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr\' ' +
-      'collection of database \'' + sthConfig.DB_PREFIX + 'mappedtestservice\' with the collection per attribute ' +
-      'data model as \'' + sthConfig.COLLECTION_PREFIX +
-      '/testservicepath_entityId_entityType_attrName.aggr\'',
-      function() {
-      sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
-      expect(sthDatabaseNameMapper.unmapCollectionName(
-        'mappedtestservice', sthConfig.COLLECTION_PREFIX +
-        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr')).to.equal(
-          sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr');
-    });
-
-    after(function() {
-      sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-      sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-    });
-  });
 });

--- a/test/unit/sthDatabaseNameMapper_test.js
+++ b/test/unit/sthDatabaseNameMapper_test.js
@@ -71,12 +71,9 @@ describe('sthDatabaseNameMapper tests', function() {
             ).to.equal('mappedAttrType');
         });
 
-        it(
-            "should map the '" +
-                sthConfig.DB_PREFIX +
-                "testservice' database as '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.DB_PREFIX + "testservice' database as '" + sthConfig.DB_PREFIX + 
+            "mappedtestservice'",
             function() {
                 expect(sthDatabaseNameMapper.mapDatabaseName(sthConfig.DB_PREFIX + 'testservice')).to.equal(
                     sthConfig.DB_PREFIX + 'mappedtestservice'
@@ -84,15 +81,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath' collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per service path data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath' collection of database '" + 
+            sthConfig.DB_PREFIX + "testservice' with the collection per service path data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
                 expect(
@@ -104,15 +96,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath.aggr' collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per service path data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath.aggr'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath.aggr' collection of database '" + 
+            sthConfig.DB_PREFIX + "testservice' with the collection per service path data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
                 expect(
@@ -124,15 +111,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId' collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId' collection of database '" + 
+            sthConfig.DB_PREFIX + "testservice' with the collection per entity data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_mappedEntityId'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -144,16 +126,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId.aggr' collection " +
-                "of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId.aggr'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId.aggr' collection " + 
+            "of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per entity data model as " + 
+            "'" + sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_mappedEntityId.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -165,16 +141,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType' collection " +
-                "of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType' collection " + 
+            "of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per entity data model as " + 
+            "'" + sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_mappedEntityId_mappedEntityType'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -186,16 +156,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType.aggr' collection " +
-                "of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType.aggr' collection " +
+         "of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per entity data model as " + "'" + 
+         sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -207,16 +171,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_attrName' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedAttrName'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_attrName' " + 
+            "collection of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per attribute " + 
+            "data model as '" + sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_mappedEntityId_mappedAttrName'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
@@ -228,16 +186,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_attrName.aggr' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_attrName.aggr' " + 
+            "collection of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per attribute " + 
+            "data model as '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedAttrName.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
@@ -249,16 +202,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType_attrName' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType_attrName' " + 
+            "collection of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per attribute " + 
+            "data model as '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
@@ -267,22 +215,17 @@ describe('sthDatabaseNameMapper tests', function() {
                         sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName'
                     )
                 ).to.equal(
-                    sthConfig.COLLECTION_PREFIX +
-                        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'
+                    sthConfig.COLLECTION_PREFIX + 
+                    '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'
                 );
             }
         );
 
-        it(
-            "should map the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType_attrName.aggr' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "testservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'",
+        // prettier-ignore
+        it("should map the '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType_attrName.aggr' " + 
+            "collection of database '" + sthConfig.DB_PREFIX + "testservice' with the collection per attribute " + 
+            "data model as '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
@@ -291,8 +234,8 @@ describe('sthDatabaseNameMapper tests', function() {
                         sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr'
                     )
                 ).to.equal(
-                    sthConfig.COLLECTION_PREFIX +
-                        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'
+                    sthConfig.COLLECTION_PREFIX + 
+                    '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'
                 );
             }
         );
@@ -355,12 +298,9 @@ describe('sthDatabaseNameMapper tests', function() {
             ).to.equal('attrType');
         });
 
-        it(
-            "should unmap the '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' database as '" +
-                sthConfig.DB_PREFIX +
-                "testservice'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.DB_PREFIX + "mappedtestservice' database as '" + sthConfig.DB_PREFIX + 
+            "testservice'",
             function() {
                 expect(sthDatabaseNameMapper.unmapDatabaseName(sthConfig.DB_PREFIX + 'mappedtestservice')).to.equal(
                     sthConfig.DB_PREFIX + 'testservice'
@@ -368,15 +308,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath' collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per service path data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath' collection of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per service path data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
                 expect(
@@ -388,15 +323,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath.aggr' collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per service path data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath.aggr'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath.aggr' collection of database '" + sthConfig.DB_PREFIX + 
+            "mappedtestservice' with the collection per service path data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH;
                 expect(
@@ -408,16 +339,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_entityId' collection " +
-                "of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_mappedEntityId'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_entityId' collection " + 
+            "of database '" + sthConfig.DB_PREFIX + "mappedtestservice' with the collection per entity data model as " +
+             "'" + sthConfig.COLLECTION_PREFIX + "/testservicepath_mappedEntityId'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -429,16 +354,10 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId.aggr' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per " +
-                "entity data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId.aggr'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + "/mappedtestservicepath_mappedEntityId.aggr' " + 
+            "collection of database '" + sthConfig.DB_PREFIX + "mappedtestservice' with the collection per " + 
+            "entity data model as '" + sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -450,16 +369,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType' collection " +
-                "of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedEntityType' collection " + "of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per entity data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -471,16 +385,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr' collection " +
-                "of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per entity data model as " +
-                "'" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType.aggr'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedEntityType.aggr' collection of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per entity data model as " + "'" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY;
                 expect(
@@ -492,16 +401,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedentityId_mappedattrName' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_attrName'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedentityId_mappedattrName' " + "collection of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per attribute " + "data model as '" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_attrName'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
@@ -513,16 +417,11 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedentityId_mappedattrName.aggr' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_attrName.aggr'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedentityId_mappedattrName.aggr' " + "collection of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per attribute " + "data model as '" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_attrName.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
@@ -534,45 +433,35 @@ describe('sthDatabaseNameMapper tests', function() {
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType_attrName'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName' collection of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per attribute " + "data model as '" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType_attrName'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
                     sthDatabaseNameMapper.unmapCollectionName(
                         'mappedtestservice',
                         sthConfig.COLLECTION_PREFIX +
-                            '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'
+                        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName'
                     )
                 ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName');
             }
         );
 
-        it(
-            "should unmap the '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr' " +
-                "collection of database '" +
-                sthConfig.DB_PREFIX +
-                "mappedtestservice' with the collection per attribute " +
-                "data model as '" +
-                sthConfig.COLLECTION_PREFIX +
-                "/testservicepath_entityId_entityType_attrName.aggr'",
+        // prettier-ignore
+        it("should unmap the '" + sthConfig.COLLECTION_PREFIX + 
+            "/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr' collection of database '" + 
+            sthConfig.DB_PREFIX + "mappedtestservice' with the collection per attribute " + "data model as '" + 
+            sthConfig.COLLECTION_PREFIX + "/testservicepath_entityId_entityType_attrName.aggr'",
             function() {
                 sthConfig.DATA_MODEL = sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE;
                 expect(
                     sthDatabaseNameMapper.unmapCollectionName(
                         'mappedtestservice',
                         sthConfig.COLLECTION_PREFIX +
-                            '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'
+                        '/mappedtestservicepath_mappedEntityId_mappedEntityType_mappedAttrName.aggr'
                     )
                 ).to.equal(sthConfig.COLLECTION_PREFIX + '/testservicepath_entityId_entityType_attrName.aggr');
             }

--- a/test/unit/sthDatabaseNaming_test.js
+++ b/test/unit/sthDatabaseNaming_test.js
@@ -40,7 +40,7 @@ var COLLECTION_NAME_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME,
-    attrType: sthTestConfig.ATTRIBUTE_TYPE,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE
 };
 var VERY_LONG_COLLECTION_NAME_PARAMS = {
     service: sthConfig.DEFAULT_SERVICE,
@@ -55,7 +55,7 @@ var VERY_LONG_COLLECTION_NAME_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME,
-    attrType: sthTestConfig.ATTRIBUTE_TYPE,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE
 };
 
 /**

--- a/test/unit/sthDatabaseNaming_test.js
+++ b/test/unit/sthDatabaseNaming_test.js
@@ -32,25 +32,30 @@ var sthTestConfig = require(ROOT_PATH + '/test/unit/sthTestConfiguration');
 var expect = require('expect.js');
 
 var INVALID_SERVICE = sthConfig.DEFAULT_SERVICE.replace(/s/g, 'S');
-var VERY_LONG_SERVICE = INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE +
-  INVALID_SERVICE;
+var VERY_LONG_SERVICE =
+    INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE + INVALID_SERVICE;
 var COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME,
-  attrType: sthTestConfig.ATTRIBUTE_TYPE
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE,
 };
 var VERY_LONG_COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH +
-    sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH +
-    sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME,
-  attrType: sthTestConfig.ATTRIBUTE_TYPE
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath:
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE,
 };
 
 /**
@@ -59,21 +64,20 @@ var VERY_LONG_COLLECTION_NAME_PARAMS = {
  * @param  {string} databaseName The database name
  */
 function expectDatabaseName(service, databaseName) {
-  var newService, finalDatabaseName;
-  if (sthConfig.NAME_MAPPING) {
-    newService = sthDatabaseNameMapper.mapService(service);
-  }
-  if (sthConfig.NAME_ENCODING) {
-    newService = sthDatabaseNameCodec.encodeDatabaseName(newService || service);
-  }
-  newService = newService || service;
+    var newService, finalDatabaseName;
+    if (sthConfig.NAME_MAPPING) {
+        newService = sthDatabaseNameMapper.mapService(service);
+    }
+    if (sthConfig.NAME_ENCODING) {
+        newService = sthDatabaseNameCodec.encodeDatabaseName(newService || service);
+    }
+    newService = newService || service;
 
-  finalDatabaseName = (sthConfig.NAME_ENCODING ?
-    sthDatabaseNameCodec.encodeDatabaseName(sthConfig.DB_PREFIX) :
-    sthConfig.DB_PREFIX) +
-    newService;
+    finalDatabaseName =
+        (sthConfig.NAME_ENCODING ? sthDatabaseNameCodec.encodeDatabaseName(sthConfig.DB_PREFIX) : sthConfig.DB_PREFIX) +
+        newService;
 
-  expect(finalDatabaseName).to.equal(databaseName);
+    expect(finalDatabaseName).to.equal(databaseName);
 }
 
 /**
@@ -84,194 +88,227 @@ function expectDatabaseName(service, databaseName) {
  * @param  {string} dataModel            The data model
  */
 function expectCollectionName(collectionNameParams, collectionName, dataType, dataModel) {
-  var collectionName4Events, finalCollectionName;
-  var newServicePath, newEntityId, newEntityType, newAttrName;
-  if (sthConfig.NAME_MAPPING) {
-    newServicePath = sthDatabaseNameMapper.mapServicePath(
-      collectionNameParams.service, collectionNameParams.servicePath);
-    newEntityId = sthDatabaseNameMapper.mapEntityName(
-      collectionNameParams.service, collectionNameParams.servicePath, collectionNameParams.entityId);
-    newEntityType = sthDatabaseNameMapper.mapEntityType(
-      collectionNameParams.service, collectionNameParams.servicePath, collectionNameParams.entityType);
-    newAttrName = sthDatabaseNameMapper.mapAttributeName(
-      collectionNameParams.service, collectionNameParams.servicePath, collectionNameParams.entityId,
-      collectionNameParams.attrName);
-  }
-  if (sthConfig.NAME_ENCODING) {
-    newServicePath = sthDatabaseNameCodec.encodeCollectionName(newServicePath || collectionNameParams.servicePath);
-    newEntityId = sthDatabaseNameCodec.encodeCollectionName(newEntityId || collectionNameParams.entityId);
-    newEntityType = sthDatabaseNameCodec.encodeCollectionName(newEntityType || collectionNameParams.entityType);
-    newAttrName = sthDatabaseNameCodec.encodeCollectionName(newAttrName || collectionNameParams.attrName);
-  }
-  newServicePath = newServicePath || collectionNameParams.servicePath;
-  newEntityId = newEntityId || collectionNameParams.entityId;
-  newEntityType = newEntityType || collectionNameParams.entityType;
-  newAttrName = newAttrName || collectionNameParams.attrName;
+    var collectionName4Events, finalCollectionName;
+    var newServicePath, newEntityId, newEntityType, newAttrName;
+    if (sthConfig.NAME_MAPPING) {
+        newServicePath = sthDatabaseNameMapper.mapServicePath(
+            collectionNameParams.service,
+            collectionNameParams.servicePath
+        );
+        newEntityId = sthDatabaseNameMapper.mapEntityName(
+            collectionNameParams.service,
+            collectionNameParams.servicePath,
+            collectionNameParams.entityId
+        );
+        newEntityType = sthDatabaseNameMapper.mapEntityType(
+            collectionNameParams.service,
+            collectionNameParams.servicePath,
+            collectionNameParams.entityType
+        );
+        newAttrName = sthDatabaseNameMapper.mapAttributeName(
+            collectionNameParams.service,
+            collectionNameParams.servicePath,
+            collectionNameParams.entityId,
+            collectionNameParams.attrName
+        );
+    }
+    if (sthConfig.NAME_ENCODING) {
+        newServicePath = sthDatabaseNameCodec.encodeCollectionName(newServicePath || collectionNameParams.servicePath);
+        newEntityId = sthDatabaseNameCodec.encodeCollectionName(newEntityId || collectionNameParams.entityId);
+        newEntityType = sthDatabaseNameCodec.encodeCollectionName(newEntityType || collectionNameParams.entityType);
+        newAttrName = sthDatabaseNameCodec.encodeCollectionName(newAttrName || collectionNameParams.attrName);
+    }
+    newServicePath = newServicePath || collectionNameParams.servicePath;
+    newEntityId = newEntityId || collectionNameParams.entityId;
+    newEntityType = newEntityType || collectionNameParams.entityType;
+    newAttrName = newAttrName || collectionNameParams.attrName;
 
-  switch (dataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      collectionName4Events = newServicePath + sthConfig.NAME_SEPARATOR + newEntityId +
-        (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '') + sthConfig.NAME_SEPARATOR +
-        newAttrName;
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      collectionName4Events = newServicePath + sthConfig.NAME_SEPARATOR + newEntityId +
-        (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '');
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      collectionName4Events = newServicePath;
-      break;
-    default:
-      throw new Error(dataModel + ' is not a valid data model value');
-  }
+    switch (dataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            collectionName4Events =
+                newServicePath +
+                sthConfig.NAME_SEPARATOR +
+                newEntityId +
+                (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '') +
+                sthConfig.NAME_SEPARATOR +
+                newAttrName;
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            collectionName4Events =
+                newServicePath +
+                sthConfig.NAME_SEPARATOR +
+                newEntityId +
+                (newEntityType ? sthConfig.NAME_SEPARATOR + newEntityType : '');
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            collectionName4Events = newServicePath;
+            break;
+        default:
+            throw new Error(dataModel + ' is not a valid data model value');
+    }
 
-  finalCollectionName = (sthConfig.NAME_ENCODING ?
-    sthDatabaseNameCodec.encodeCollectionName(sthConfig.COLLECTION_PREFIX) :
-    sthConfig.COLLECTION_PREFIX) +
-    collectionName4Events +
-    (dataType === sthTestConfig.DATA_TYPES.AGGREGATED ?
-      (sthConfig.NAME_ENCODING ? sthDatabaseNameCodec.encodeCollectionName('.aggr') : '.aggr') : '');
+    finalCollectionName =
+        (sthConfig.NAME_ENCODING
+            ? sthDatabaseNameCodec.encodeCollectionName(sthConfig.COLLECTION_PREFIX)
+            : sthConfig.COLLECTION_PREFIX) +
+        collectionName4Events +
+        (dataType === sthTestConfig.DATA_TYPES.AGGREGATED
+            ? sthConfig.NAME_ENCODING
+                ? sthDatabaseNameCodec.encodeCollectionName('.aggr')
+                : '.aggr'
+            : '');
 
-  expect(finalCollectionName).to.equal(collectionName);
+    expect(finalCollectionName).to.equal(collectionName);
 }
 
 /**
  * Battery of tests to check the database name generation
  */
 function databaseNameTests() {
-  var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING,
-      ORIGINAL_NAME_ENCODING = sthConfig.NAME_ENCODING;
+    var ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING,
+        ORIGINAL_NAME_ENCODING = sthConfig.NAME_ENCODING;
 
-  ['name mapping and encoding', 'name mapping', 'name encoding', 'no mapping or encoding'].forEach(
-    function(mechanism) {
-    describe(mechanism, function() {
-      before(function() {
-        switch(mechanism) {
-          case 'name mapping and encoding':
-            sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-            sthConfig.NAME_ENCODING = true;
-            break;
-          case 'name mapping':
-            sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-            sthConfig.NAME_ENCODING = false;
-            break;
-          case 'name encoding':
-            sthConfig.NAME_MAPPING = undefined;
-            sthConfig.NAME_ENCODING = true;
-            break;
-          case 'no mapping or encoding':
-            sthConfig.NAME_MAPPING = undefined;
-            sthConfig.NAME_ENCODING = false;
-            break;
-        }
-      });
+    ['name mapping and encoding', 'name mapping', 'name encoding', 'no mapping or encoding'].forEach(function(
+        mechanism
+    ) {
+        describe(mechanism, function() {
+            before(function() {
+                switch (mechanism) {
+                    case 'name mapping and encoding':
+                        sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+                        sthConfig.NAME_ENCODING = true;
+                        break;
+                    case 'name mapping':
+                        sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
+                        sthConfig.NAME_ENCODING = false;
+                        break;
+                    case 'name encoding':
+                        sthConfig.NAME_MAPPING = undefined;
+                        sthConfig.NAME_ENCODING = true;
+                        break;
+                    case 'no mapping or encoding':
+                        sthConfig.NAME_MAPPING = undefined;
+                        sthConfig.NAME_ENCODING = false;
+                        break;
+                }
+            });
 
-      it('should compose the database name',
-        function(done) {
-          var databaseName = sthDatabaseNaming.getDatabaseName(INVALID_SERVICE);
-          expectDatabaseName(
-            INVALID_SERVICE, databaseName);
-          done();
-        }
-      );
+            it('should compose the database name', function(done) {
+                var databaseName = sthDatabaseNaming.getDatabaseName(INVALID_SERVICE);
+                expectDatabaseName(INVALID_SERVICE, databaseName);
+                done();
+            });
 
-      it('should not compose the database name for a very long service',
-        function(done) {
-          var databaseName = sthDatabaseNaming.getDatabaseName(VERY_LONG_SERVICE);
-          expect(databaseName).to.be(null);
-          done();
-        }
-      );
+            it('should not compose the database name for a very long service', function(done) {
+                var databaseName = sthDatabaseNaming.getDatabaseName(VERY_LONG_SERVICE);
+                expect(databaseName).to.be(null);
+                done();
+            });
 
-      after(function() {
-        sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-        sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
-      });
+            after(function() {
+                sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+                sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+            });
+        });
     });
-  });
 }
 
 /**
  * Battery of tests to check the collection name generation
  */
 function collectionNameTests() {
-  var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL,
-      ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING,
-      ORIGINAL_NAME_ENCODING = sthConfig.NAME_ENCODING,
-      dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
-      dataModels = Object.keys(sthConfig.DATA_MODELS);
+    var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL,
+        ORIGINAL_NAME_MAPPING = sthConfig.NAME_MAPPING,
+        ORIGINAL_NAME_ENCODING = sthConfig.NAME_ENCODING,
+        dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
+        dataModels = Object.keys(sthConfig.DATA_MODELS);
 
-  dataModels.forEach(function(dataModel) {
-    describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
-      before(function() {
-        sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
-      });
-
-      dataTypes.forEach(function(dataType) {
-        ['name mapping and encoding', 'name mapping', 'name encoding', 'no mapping or encoding'].forEach(
-          function(mechanism) {
-          describe(mechanism, function() {
+    dataModels.forEach(function(dataModel) {
+        describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
             before(function() {
-              switch(mechanism) {
-                case 'name mapping and encoding':
-                  sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-                  sthConfig.NAME_ENCODING = true;
-                  break;
-                case 'name mapping':
-                  sthConfig.NAME_MAPPING = require(ROOT_PATH + '/test/unit/nameMappings/name-mapping.json');
-                  sthConfig.NAME_ENCODING = false;
-                  break;
-                case 'name encoding':
-                  sthConfig.NAME_MAPPING = undefined;
-                  sthConfig.NAME_ENCODING = true;
-                  break;
-                case 'no mapping or encoding':
-                  sthConfig.NAME_MAPPING = undefined;
-                  sthConfig.NAME_ENCODING = false;
-                  break;
-              }
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
             });
 
-            it('should compose the collection name for ' + sthTestConfig.DATA_TYPES[dataType] + ' data',
-              function(done) {
-                var collectionName = sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW ?
-                  sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS) :
-                  sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
-                expectCollectionName(
-                  COLLECTION_NAME_PARAMS, collectionName, sthTestConfig.DATA_TYPES[dataType],
-                  sthConfig.DATA_MODELS[dataModel]);
-                done();
-              }
-            );
+            dataTypes.forEach(function(dataType) {
+                ['name mapping and encoding', 'name mapping', 'name encoding', 'no mapping or encoding'].forEach(
+                    function(mechanism) {
+                        describe(mechanism, function() {
+                            before(function() {
+                                switch (mechanism) {
+                                    case 'name mapping and encoding':
+                                        sthConfig.NAME_MAPPING = require(ROOT_PATH +
+                                            '/test/unit/nameMappings/name-mapping.json');
+                                        sthConfig.NAME_ENCODING = true;
+                                        break;
+                                    case 'name mapping':
+                                        sthConfig.NAME_MAPPING = require(ROOT_PATH +
+                                            '/test/unit/nameMappings/name-mapping.json');
+                                        sthConfig.NAME_ENCODING = false;
+                                        break;
+                                    case 'name encoding':
+                                        sthConfig.NAME_MAPPING = undefined;
+                                        sthConfig.NAME_ENCODING = true;
+                                        break;
+                                    case 'no mapping or encoding':
+                                        sthConfig.NAME_MAPPING = undefined;
+                                        sthConfig.NAME_ENCODING = false;
+                                        break;
+                                }
+                            });
 
-            it('should not compose the collection name for ' +
-              sthTestConfig.DATA_TYPES[dataType] + ' data if very long service path',
-              function(done) {
-                var collectionName = sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW ?
-                  sthDatabaseNaming.getRawCollectionName(VERY_LONG_COLLECTION_NAME_PARAMS) :
-                  sthDatabaseNaming.getAggregatedCollectionName(VERY_LONG_COLLECTION_NAME_PARAMS);
-                expect(collectionName).to.be(null);
-                done();
-              }
-            );
+                            it(
+                                'should compose the collection name for ' +
+                                    sthTestConfig.DATA_TYPES[dataType] +
+                                    ' data',
+                                function(done) {
+                                    var collectionName =
+                                        sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW
+                                            ? sthDatabaseNaming.getRawCollectionName(COLLECTION_NAME_PARAMS)
+                                            : sthDatabaseNaming.getAggregatedCollectionName(COLLECTION_NAME_PARAMS);
+                                    expectCollectionName(
+                                        COLLECTION_NAME_PARAMS,
+                                        collectionName,
+                                        sthTestConfig.DATA_TYPES[dataType],
+                                        sthConfig.DATA_MODELS[dataModel]
+                                    );
+                                    done();
+                                }
+                            );
+
+                            it(
+                                'should not compose the collection name for ' +
+                                    sthTestConfig.DATA_TYPES[dataType] +
+                                    ' data if very long service path',
+                                function(done) {
+                                    var collectionName =
+                                        sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW
+                                            ? sthDatabaseNaming.getRawCollectionName(VERY_LONG_COLLECTION_NAME_PARAMS)
+                                            : sthDatabaseNaming.getAggregatedCollectionName(
+                                                  VERY_LONG_COLLECTION_NAME_PARAMS
+                                              );
+                                    expect(collectionName).to.be(null);
+                                    done();
+                                }
+                            );
+
+                            after(function() {
+                                sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
+                                sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+                            });
+                        });
+                    }
+                );
+            });
 
             after(function() {
-              sthConfig.NAME_MAPPING = ORIGINAL_NAME_MAPPING;
-              sthConfig.NAME_ENCODING = ORIGINAL_NAME_ENCODING;
+                sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
             });
-          });
         });
-      });
-
-      after(function() {
-        sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-      });
     });
-  });
 }
 
 describe('sthDatabaseNaming tests', function() {
-  describe('database names', databaseNameTests);
+    describe('database names', databaseNameTests);
 
-  describe('collection names', collectionNameTests);
+    describe('collection names', collectionNameTests);
 });

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -39,7 +39,7 @@ var DATABASE_CONNECTION_PARAMS = {
     dbURI: sthConfig.DB_URI,
     replicaSet: sthConfig.REPLICA_SET,
     database: DATABASE_NAME,
-    poolSize: sthConfig.POOL_SIZE,
+    poolSize: sthConfig.POOL_SIZE
 };
 var COLLECTION_NAME_PARAMS = {
     service: sthConfig.DEFAULT_SERVICE,
@@ -47,7 +47,7 @@ var COLLECTION_NAME_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME,
-    attrType: sthTestConfig.ATTRIBUTE_TYPE,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE
 };
 var NUMERIC_COLLECTION_NAME_PARAMS = {
     service: sthConfig.DEFAULT_SERVICE,
@@ -55,7 +55,7 @@ var NUMERIC_COLLECTION_NAME_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME + sthConfig.AGGREGATIONS.NUMERIC,
-    attrType: sthTestConfig.ATTRIBUTE_TYPE,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE
 };
 var TEXTUAL_COLLECTION_NAME_PARAMS = {
     service: sthConfig.DEFAULT_SERVICE,
@@ -63,7 +63,7 @@ var TEXTUAL_COLLECTION_NAME_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME + sthConfig.AGGREGATIONS.TEXTUAL,
-    attrType: sthTestConfig.ATTRIBUTE_TYPE,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE
 };
 var VERY_LONG_COLLECTION_NAME_PARAMS = {
     service: sthConfig.DEFAULT_SERVICE,
@@ -78,7 +78,7 @@ var VERY_LONG_COLLECTION_NAME_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME,
-    attrType: sthTestConfig.ATTRIBUTE_TYPE,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE
 };
 var DATE = new Date(Date.UTC(1970, 1, 3, 4, 5, 6, 777));
 var DELAY = 100;
@@ -86,8 +86,8 @@ var LIMIT = 10;
 var PAGINATION = 0;
 var ATTRIBUTE = {
     VALUE: {
-        NUMERIC: 666,
-    },
+        NUMERIC: 666
+    }
 };
 var STORE_DATA_PARAMS = {
     recvTime: DATE,
@@ -95,13 +95,13 @@ var STORE_DATA_PARAMS = {
     entityType: sthTestConfig.ENTITY_TYPE,
     attribute: {
         name: sthTestConfig.ATTRIBUTE_NAME,
-        type: sthTestConfig.ATTRIBUTE_TYPE,
-    },
+        type: sthTestConfig.ATTRIBUTE_TYPE
+    }
 };
 var RETRIEVAL_DATA_PARAMS = {
     entityId: sthTestConfig.ENTITY_ID,
     entityType: sthTestConfig.ENTITY_TYPE,
-    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrName: sthTestConfig.ATTRIBUTE_NAME
 };
 
 /**
@@ -243,7 +243,7 @@ function collectionAccessTests() {
                                 shouldCreate: false,
                                 isAggregated:
                                     sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-                                shouldTruncate: false,
+                                shouldTruncate: false
                             },
                             function(err, collection) {
                                 expect(err).to.not.be(null);
@@ -267,7 +267,7 @@ function collectionAccessTests() {
                                 shouldCreate: true,
                                 isAggregated:
                                     sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-                                shouldTruncate: false,
+                                shouldTruncate: false
                             },
                             function(err, collection) {
                                 expect(err).to.be(null);
@@ -533,7 +533,7 @@ function shouldStoreTest(aggregation, dataType, position, done) {
         {
             shouldCreate: true,
             isAggregated: dataType === sthTestConfig.DATA_TYPES.AGGREGATED,
-            shouldTruncate: false,
+            shouldTruncate: false
         },
         function(err, collection) {
             if (err) {
@@ -551,7 +551,7 @@ function shouldStoreTest(aggregation, dataType, position, done) {
                         {
                             collection: collection,
                             dataType: dataType,
-                            aggregation: aggregation,
+                            aggregation: aggregation
                         },
                         position,
                         done
@@ -566,7 +566,7 @@ function shouldStoreTest(aggregation, dataType, position, done) {
                         {
                             collection: collection,
                             dataType: dataType,
-                            aggregation: aggregation,
+                            aggregation: aggregation
                         },
                         position,
                         done
@@ -612,7 +612,7 @@ function storageTests() {
                                         shouldCreate: true,
                                         isAggregated:
                                             sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-                                        shouldTruncate: false,
+                                        shouldTruncate: false
                                     },
                                     function(err, theCollection) {
                                         if (err) {
@@ -775,7 +775,7 @@ function retrievalTest(params, options, count, done) {
         {
             shouldCreate: true,
             isAggregated: params.dataType === sthTestConfig.DATA_TYPES.AGGREGATED,
-            shouldTruncate: false,
+            shouldTruncate: false
         },
         function(err, collection) {
             if (err) {
@@ -840,7 +840,7 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 null,
                 count
@@ -861,10 +861,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
-                    lastN: LIMIT,
+                    lastN: LIMIT
                 },
                 count
             )
@@ -884,11 +884,11 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
                     hLimit: LIMIT,
-                    hOffset: PAGINATION,
+                    hOffset: PAGINATION
                 },
                 count
             )
@@ -908,10 +908,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
-                    dateFrom: DATE,
+                    dateFrom: DATE
                 },
                 count
             )
@@ -931,10 +931,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
-                    dateFrom: new Date(DATE.getTime() + 1000 * 60 * 60),
+                    dateFrom: new Date(DATE.getTime() + 1000 * 60 * 60)
                 },
                 0
             )
@@ -954,10 +954,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
-                    dateTo: new Date(),
+                    dateTo: new Date()
                 },
                 count
             )
@@ -977,10 +977,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
-                    dateTo: new Date(DATE.getTime() - 1000 * 60 * 60),
+                    dateTo: new Date(DATE.getTime() - 1000 * 60 * 60)
                 },
                 0
             )
@@ -1000,10 +1000,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                 null,
                 {
                     aggregation: aggregation,
-                    dataType: dataType,
+                    dataType: dataType
                 },
                 {
-                    filetype: 'csv',
+                    filetype: 'csv'
                 },
                 count
             )
@@ -1027,11 +1027,11 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'sum',
-                            aggrPeriod: aggregationBy,
+                            aggrPeriod: aggregationBy
                         },
                         count
                     )
@@ -1053,12 +1053,12 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'sum',
                             aggrPeriod: aggregationBy,
-                            dateFrom: DATE,
+                            dateFrom: DATE
                         },
                         count
                     )
@@ -1080,12 +1080,12 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'sum',
                             aggrPeriod: aggregationBy,
-                            dateTo: new Date(),
+                            dateTo: new Date()
                         },
                         count
                     )
@@ -1107,11 +1107,11 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'sum2',
-                            aggrPeriod: aggregationBy,
+                            aggrPeriod: aggregationBy
                         },
                         count
                     )
@@ -1133,11 +1133,11 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'min',
-                            aggrPeriod: aggregationBy,
+                            aggrPeriod: aggregationBy
                         },
                         count
                     )
@@ -1159,11 +1159,11 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'max',
-                            aggrPeriod: aggregationBy,
+                            aggrPeriod: aggregationBy
                         },
                         count
                     )
@@ -1185,11 +1185,11 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                         null,
                         {
                             aggregation: aggregation,
-                            dataType: dataType,
+                            dataType: dataType
                         },
                         {
                             aggrMethod: 'occur',
-                            aggrPeriod: aggregationBy,
+                            aggrPeriod: aggregationBy
                         },
                         count
                     )

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -155,12 +155,9 @@ function cleanDatabaseTests() {
     describe('database clean up', function() {
         dataModelsKeys.forEach(function(dataModel) {
             dataTypeKeys.forEach(function(dataType) {
-                it(
-                    'should drop the ' +
-                        sthConfig.DATA_MODELS[dataModel] +
-                        ' ' +
-                        sthTestConfig.DATA_TYPES[dataType] +
-                        ' data collection if it exists',
+                //prettier-ignore
+                it('should drop the ' + sthConfig.DATA_MODELS[dataModel] + ' ' + sthTestConfig.DATA_TYPES[dataType] + 
+                    ' data collection if it exists',
                     dropCollection.bind(
                         null,
                         COLLECTION_NAME_PARAMS,
@@ -169,12 +166,9 @@ function cleanDatabaseTests() {
                     )
                 );
 
-                it(
-                    'should drop the numeric ' +
-                        sthConfig.DATA_MODELS[dataModel] +
-                        ' ' +
-                        sthTestConfig.DATA_TYPES[dataType] +
-                        ' data collection if it exists',
+                //prettier-ignore
+                it('should drop the numeric ' + sthConfig.DATA_MODELS[dataModel] + ' ' + 
+                    sthTestConfig.DATA_TYPES[dataType] + ' data collection if it exists',
                     dropCollection.bind(
                         null,
                         NUMERIC_COLLECTION_NAME_PARAMS,
@@ -183,12 +177,9 @@ function cleanDatabaseTests() {
                     )
                 );
 
-                it(
-                    'should drop the textual ' +
-                        sthConfig.DATA_MODELS[dataModel] +
-                        ' ' +
-                        sthTestConfig.DATA_TYPES[dataType] +
-                        ' data collection if it exists',
+                //prettier-ignore
+                it('should drop the textual ' + sthConfig.DATA_MODELS[dataModel] + ' ' + 
+                    sthTestConfig.DATA_TYPES[dataType] + ' data collection if it exists',
                     dropCollection.bind(
                         null,
                         TEXTUAL_COLLECTION_NAME_PARAMS,
@@ -197,12 +188,9 @@ function cleanDatabaseTests() {
                     )
                 );
 
-                it(
-                    'should drop the very long service path ' +
-                        sthConfig.DATA_MODELS[dataModel] +
-                        ' ' +
-                        sthTestConfig.DATA_TYPES[dataType] +
-                        ' data collection if it exists',
+                //prettier-ignore
+                it('should drop the very long service path ' + sthConfig.DATA_MODELS[dataModel] + ' ' + 
+                    sthTestConfig.DATA_TYPES[dataType] + ' data collection if it exists',
                     dropCollection.bind(
                         null,
                         VERY_LONG_COLLECTION_NAME_PARAMS,
@@ -232,10 +220,9 @@ function collectionAccessTests() {
             });
 
             dataTypes.forEach(function(dataType) {
-                it(
-                    'should notify as error a non-existent ' +
-                        sthTestConfig.DATA_TYPES[dataType] +
-                        ' data collection if it should not be created',
+                //prettier-ignore
+                it('should notify as error a non-existent ' + sthTestConfig.DATA_TYPES[dataType] + 
+                    ' data collection if it should not be created',
                     function(done) {
                         sthDatabase.getCollection(
                             COLLECTION_NAME_PARAMS,
@@ -256,10 +243,9 @@ function collectionAccessTests() {
                     }
                 );
 
-                it(
-                    'should create a ' +
-                        sthTestConfig.DATA_TYPES[dataType] +
-                        ' data collection if non-existent and requested',
+                //prettier-ignore
+                it('should create a ' + sthTestConfig.DATA_TYPES[dataType] + 
+                    ' data collection if non-existent and requested',
                     function(done) {
                         sthDatabase.getCollection(
                             COLLECTION_NAME_PARAMS,
@@ -628,8 +614,7 @@ function storageTests() {
                                 it(
                                     'should detect a new ' +
                                         sthConfig.AGGREGATIONS[aggregation] +
-                                        ' attribute value notification is ' +
-                                        'susceptible of being inserted',
+                                        ' attribute value notification is susceptible of being inserted',
                                     function(done) {
                                         var notificationInfoParams = getDataStoreParams(
                                             collection,
@@ -645,13 +630,9 @@ function storageTests() {
                                     }
                                 );
                             }
-
-                            it(
-                                'should store ' +
-                                    sthConfig.AGGREGATIONS[aggregation] +
-                                    ' ' +
-                                    sthTestConfig.DATA_TYPES[dataType] +
-                                    ' data',
+                            //prettier-ignore
+                            it('should store ' + sthConfig.AGGREGATIONS[aggregation] + ' ' + 
+                                sthTestConfig.DATA_TYPES[dataType] + ' data',
                                 shouldStoreTest.bind(
                                     null,
                                     sthConfig.AGGREGATIONS[aggregation],
@@ -661,11 +642,9 @@ function storageTests() {
                             );
 
                             if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
-                                it(
-                                    'should detect an already inserted ' +
-                                        sthConfig.AGGREGATIONS[aggregation] +
-                                        ' attribute value ' +
-                                        'notification already exists',
+                                //prettier-ignore
+                                it('should detect an already inserted ' +  sthConfig.AGGREGATIONS[aggregation] +
+                                    ' attribute value notification already exists',
                                     function(done) {
                                         var notificationInfoParams = getDataStoreParams(
                                             collection,
@@ -684,14 +663,9 @@ function storageTests() {
                                 );
                             }
 
-                            it(
-                                'should store a second entry of ' +
-                                    sthConfig.AGGREGATIONS[aggregation] +
-                                    ' ' +
-                                    sthTestConfig.DATA_TYPES[dataType] +
-                                    ' data with a ' +
-                                    DELAY +
-                                    ' ms delay',
+                            //prettier-ignore
+                            it('should store a second entry of ' + sthConfig.AGGREGATIONS[aggregation] + ' ' + 
+                                sthTestConfig.DATA_TYPES[dataType] + ' data with a ' + DELAY + ' ms delay',
                                 shouldStoreTest.bind(
                                     null,
                                     sthConfig.AGGREGATIONS[aggregation],
@@ -701,10 +675,9 @@ function storageTests() {
                             );
 
                             if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
-                                it(
-                                    'should detect as updatable an updated ' +
-                                        sthConfig.AGGREGATIONS[aggregation] +
-                                        ' attribute value',
+                                //prettier-ignore
+                                it('should detect as updatable an updated ' + sthConfig.AGGREGATIONS[aggregation] + 
+                                    ' attribute value',
                                     function(done) {
                                         var notificationInfoParams = getDataStoreParams(
                                             collection,
@@ -826,16 +799,9 @@ function retrievalTest(params, options, count, done) {
  */
 function shouldRetrieveTests(count, aggregation, dataType) {
     if (dataType === sthTestConfig.DATA_TYPES.RAW) {
-        it(
-            'should retrieve ' +
-                count +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with no params if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data with no params if ' + count + 
+            ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -847,16 +813,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                count +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with lastN if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data with lastN if ' + count + 
+            ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -870,16 +829,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                count +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with hLimit and hOffset if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data with hLimit and hOffset if ' + 
+            count + ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -894,16 +846,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                count +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with dateFrom if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data with dateFrom if ' + count + 
+            ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -917,16 +862,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                0 +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with dateFrom is beyond if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + 0 + ' ' + aggregation + ' ' + dataType + ' data with dateFrom is beyond if ' + count + 
+            ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -940,16 +878,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                count +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with dateTo if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data with dateTo if ' + count + 
+            ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -963,16 +894,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                0 +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with dateTo if previous if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + 0 + ' ' + aggregation + ' ' + dataType + ' data with dateTo if previous if ' + 
+            count + ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -986,16 +910,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
             )
         );
 
-        it(
-            'should retrieve ' +
-                count +
-                ' ' +
-                aggregation +
-                ' ' +
-                dataType +
-                ' data with csv if ' +
-                count +
-                ' data is inserted',
+        //prettier-ignore
+        it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data with csv if ' + count + 
+            ' data is inserted',
             retrievalTest.bind(
                 null,
                 {
@@ -1011,18 +928,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
     } else {
         sthConfig.AGGREGATION_BY.forEach(function(aggregationBy) {
             if (aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of sum if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of sum if ' + count + ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1037,18 +945,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                     )
                 );
 
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of sum with dataFrom set if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of sum with dataFrom set if ' + count + 
+                    ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1064,18 +964,10 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                     )
                 );
 
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of sum with dataTo set if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of sum with dataTo set if ' + count + 
+                    ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1091,18 +983,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                     )
                 );
 
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of sum2 if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of sum2 if ' + count + ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1117,18 +1000,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                     )
                 );
 
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of min if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of min if ' + count + ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1143,18 +1017,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                     )
                 );
 
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of max if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of max if ' + count + ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1169,18 +1034,9 @@ function shouldRetrieveTests(count, aggregation, dataType) {
                     )
                 );
             } else {
-                it(
-                    'should retrieve ' +
-                        count +
-                        ' ' +
-                        aggregation +
-                        ' ' +
-                        dataType +
-                        ' data for a resolution of ' +
-                        aggregationBy +
-                        ' and an aggregation method of occur if ' +
-                        count +
-                        ' data is inserted',
+                //prettier-ignore
+                it('should retrieve ' + count + ' ' + aggregation + ' ' + dataType + ' data for a resolution of ' + 
+                    aggregationBy + ' and an aggregation method of occur if ' + count + ' data is inserted',
                     retrievalTest.bind(
                         null,
                         {
@@ -1231,16 +1087,10 @@ function retrievalTests() {
                             );
 
                             for (var i = 1; i <= 5; i++) {
-                                it(
-                                    'should store ' +
-                                        (i === 1 ? i : 'another (' + i + ')') +
-                                        ' ' +
-                                        sthConfig.AGGREGATIONS[aggregation] +
-                                        ' ' +
-                                        sthTestConfig.DATA_TYPES[dataType] +
-                                        ' data with ' +
-                                        (i - 1) * DELAY +
-                                        'ms delay',
+                                //prettier-ignore
+                                it('should store ' + (i === 1 ? i : 'another (' + i + ')') + ' ' +  
+                                    sthConfig.AGGREGATIONS[aggregation] + ' ' +  sthTestConfig.DATA_TYPES[dataType] + 
+                                    ' data with ' + (i - 1) * DELAY +  'ms delay',
                                     shouldStoreTest.bind(
                                         null,
                                         sthConfig.AGGREGATIONS[aggregation],

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -35,68 +35,73 @@ var _ = require('lodash');
 
 var DATABASE_NAME = sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE);
 var DATABASE_CONNECTION_PARAMS = {
-  authentication: sthConfig.DB_AUTHENTICATION,
-  dbURI: sthConfig.DB_URI,
-  replicaSet: sthConfig.REPLICA_SET,
-  database: DATABASE_NAME,
-  poolSize: sthConfig.POOL_SIZE
+    authentication: sthConfig.DB_AUTHENTICATION,
+    dbURI: sthConfig.DB_URI,
+    replicaSet: sthConfig.REPLICA_SET,
+    database: DATABASE_NAME,
+    poolSize: sthConfig.POOL_SIZE,
 };
 var COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME,
-  attrType: sthTestConfig.ATTRIBUTE_TYPE
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE,
 };
 var NUMERIC_COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME + sthConfig.AGGREGATIONS.NUMERIC,
-  attrType: sthTestConfig.ATTRIBUTE_TYPE
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME + sthConfig.AGGREGATIONS.NUMERIC,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE,
 };
 var TEXTUAL_COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME + sthConfig.AGGREGATIONS.TEXTUAL,
-  attrType: sthTestConfig.ATTRIBUTE_TYPE
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME + sthConfig.AGGREGATIONS.TEXTUAL,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE,
 };
 var VERY_LONG_COLLECTION_NAME_PARAMS = {
-  service: sthConfig.DEFAULT_SERVICE,
-  servicePath: sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH +
-    sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH + sthConfig.DEFAULT_SERVICE_PATH +
-    sthConfig.DEFAULT_SERVICE_PATH,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME,
-  attrType: sthTestConfig.ATTRIBUTE_TYPE
+    service: sthConfig.DEFAULT_SERVICE,
+    servicePath:
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH +
+        sthConfig.DEFAULT_SERVICE_PATH,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
+    attrType: sthTestConfig.ATTRIBUTE_TYPE,
 };
 var DATE = new Date(Date.UTC(1970, 1, 3, 4, 5, 6, 777));
 var DELAY = 100;
 var LIMIT = 10;
 var PAGINATION = 0;
 var ATTRIBUTE = {
-  VALUE: {
-    NUMERIC: 666
-  }
+    VALUE: {
+        NUMERIC: 666,
+    },
 };
 var STORE_DATA_PARAMS = {
-  recvTime: DATE,
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attribute: {
-    name: sthTestConfig.ATTRIBUTE_NAME,
-    type: sthTestConfig.ATTRIBUTE_TYPE
-  }
+    recvTime: DATE,
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attribute: {
+        name: sthTestConfig.ATTRIBUTE_NAME,
+        type: sthTestConfig.ATTRIBUTE_TYPE,
+    },
 };
 var RETRIEVAL_DATA_PARAMS = {
-  entityId: sthTestConfig.ENTITY_ID,
-  entityType: sthTestConfig.ENTITY_TYPE,
-  attrName: sthTestConfig.ATTRIBUTE_NAME
+    entityId: sthTestConfig.ENTITY_ID,
+    entityType: sthTestConfig.ENTITY_TYPE,
+    attrName: sthTestConfig.ATTRIBUTE_NAME,
 };
 
 /**
@@ -104,10 +109,13 @@ var RETRIEVAL_DATA_PARAMS = {
  * @param  {Function} callback The callblack
  */
 function connectToDatabase(callback) {
-  if (sthDatabase.connection) {
-    return process.nextTick(callback.bind(null, null, sthDatabase.connection));
-  }
-  sthDatabase.connect(DATABASE_CONNECTION_PARAMS, callback);
+    if (sthDatabase.connection) {
+        return process.nextTick(callback.bind(null, null, sthDatabase.connection));
+    }
+    sthDatabase.connect(
+        DATABASE_CONNECTION_PARAMS,
+        callback
+    );
 }
 
 /**
@@ -118,117 +126,164 @@ function connectToDatabase(callback) {
  * @param  {Function} callback             The callback
  */
 function dropCollection(collectionNameParams, dataType, dataModel, callback) {
-  sthConfig.DATA_MODEL = dataModel;
-  var collectionName = (dataType === sthTestConfig.DATA_TYPES.RAW) ?
-    sthDatabaseNaming.getRawCollectionName(collectionNameParams) :
-    sthDatabaseNaming.getAggregatedCollectionName(collectionNameParams);
+    sthConfig.DATA_MODEL = dataModel;
+    var collectionName =
+        dataType === sthTestConfig.DATA_TYPES.RAW
+            ? sthDatabaseNaming.getRawCollectionName(collectionNameParams)
+            : sthDatabaseNaming.getAggregatedCollectionName(collectionNameParams);
 
-  if (collectionName) {
-    sthDatabase.connection.dropCollection(collectionName, function (err) {
-      if (err && err.code === 26 && err.name === 'MongoError' && err.message === 'ns not found') {
-        // The collection does not exist
+    if (collectionName) {
+        sthDatabase.connection.dropCollection(collectionName, function(err) {
+            if (err && err.code === 26 && err.name === 'MongoError' && err.message === 'ns not found') {
+                // The collection does not exist
+                return process.nextTick(callback);
+            }
+            return process.nextTick(callback.bind(null, err));
+        });
+    } else {
         return process.nextTick(callback);
-      }
-      return process.nextTick(callback.bind(null, err));
-    });
-  } else {
-    return process.nextTick(callback);
-  }
+    }
 }
 
 /**
  * Set of tests to drop the test collections from the database
  */
 function cleanDatabaseTests() {
-  var dataModelsKeys = Object.keys(sthConfig.DATA_MODELS),
-      dataTypeKeys = Object.keys(sthTestConfig.DATA_TYPES);
+    var dataModelsKeys = Object.keys(sthConfig.DATA_MODELS),
+        dataTypeKeys = Object.keys(sthTestConfig.DATA_TYPES);
 
-  describe('database clean up', function() {
-    dataModelsKeys.forEach(function(dataModel) {
-      dataTypeKeys.forEach(function(dataType) {
-        it('should drop the ' + sthConfig.DATA_MODELS[dataModel] + ' ' + sthTestConfig.DATA_TYPES[dataType] +
-          ' data collection if it exists',
-          dropCollection.bind(null, COLLECTION_NAME_PARAMS, sthTestConfig.DATA_TYPES[dataType],
-            sthConfig.DATA_MODELS[dataModel]));
+    describe('database clean up', function() {
+        dataModelsKeys.forEach(function(dataModel) {
+            dataTypeKeys.forEach(function(dataType) {
+                it(
+                    'should drop the ' +
+                        sthConfig.DATA_MODELS[dataModel] +
+                        ' ' +
+                        sthTestConfig.DATA_TYPES[dataType] +
+                        ' data collection if it exists',
+                    dropCollection.bind(
+                        null,
+                        COLLECTION_NAME_PARAMS,
+                        sthTestConfig.DATA_TYPES[dataType],
+                        sthConfig.DATA_MODELS[dataModel]
+                    )
+                );
 
-        it('should drop the numeric ' + sthConfig.DATA_MODELS[dataModel] + ' ' + sthTestConfig.DATA_TYPES[dataType] +
-          ' data collection if it exists',
-          dropCollection.bind(null, NUMERIC_COLLECTION_NAME_PARAMS, sthTestConfig.DATA_TYPES[dataType],
-            sthConfig.DATA_MODELS[dataModel]));
+                it(
+                    'should drop the numeric ' +
+                        sthConfig.DATA_MODELS[dataModel] +
+                        ' ' +
+                        sthTestConfig.DATA_TYPES[dataType] +
+                        ' data collection if it exists',
+                    dropCollection.bind(
+                        null,
+                        NUMERIC_COLLECTION_NAME_PARAMS,
+                        sthTestConfig.DATA_TYPES[dataType],
+                        sthConfig.DATA_MODELS[dataModel]
+                    )
+                );
 
-        it('should drop the textual ' + sthConfig.DATA_MODELS[dataModel] + ' ' + sthTestConfig.DATA_TYPES[dataType] +
-          ' data collection if it exists',
-          dropCollection.bind(null, TEXTUAL_COLLECTION_NAME_PARAMS, sthTestConfig.DATA_TYPES[dataType],
-            sthConfig.DATA_MODELS[dataModel]));
+                it(
+                    'should drop the textual ' +
+                        sthConfig.DATA_MODELS[dataModel] +
+                        ' ' +
+                        sthTestConfig.DATA_TYPES[dataType] +
+                        ' data collection if it exists',
+                    dropCollection.bind(
+                        null,
+                        TEXTUAL_COLLECTION_NAME_PARAMS,
+                        sthTestConfig.DATA_TYPES[dataType],
+                        sthConfig.DATA_MODELS[dataModel]
+                    )
+                );
 
-        it('should drop the very long service path ' + sthConfig.DATA_MODELS[dataModel] + ' ' +
-          sthTestConfig.DATA_TYPES[dataType] + ' data collection if it exists',
-          dropCollection.bind(null, VERY_LONG_COLLECTION_NAME_PARAMS, sthTestConfig.DATA_TYPES[dataType],
-            sthConfig.DATA_MODELS[dataModel]));
-      });
+                it(
+                    'should drop the very long service path ' +
+                        sthConfig.DATA_MODELS[dataModel] +
+                        ' ' +
+                        sthTestConfig.DATA_TYPES[dataType] +
+                        ' data collection if it exists',
+                    dropCollection.bind(
+                        null,
+                        VERY_LONG_COLLECTION_NAME_PARAMS,
+                        sthTestConfig.DATA_TYPES[dataType],
+                        sthConfig.DATA_MODELS[dataModel]
+                    )
+                );
+            });
+        });
     });
-  });
 }
 
 /**
  * Battery of tests to check that the access to the collections works as expected
  */
 function collectionAccessTests() {
-  var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL,
-      dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
-      dataModels = Object.keys(sthConfig.DATA_MODELS);
+    var ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL,
+        dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
+        dataModels = Object.keys(sthConfig.DATA_MODELS);
 
-  cleanDatabaseTests();
+    cleanDatabaseTests();
 
-  dataModels.forEach(function(dataModel) {
-    describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
-      before(function() {
-        sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
-      });
+    dataModels.forEach(function(dataModel) {
+        describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
+            before(function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
+            });
 
-      dataTypes.forEach(function(dataType) {
-        it('should notify as error a non-existent ' + sthTestConfig.DATA_TYPES[dataType] +
-          ' data collection if it should not be created', function(done) {
-          sthDatabase.getCollection(
-            COLLECTION_NAME_PARAMS,
-            {
-              shouldCreate: false,
-              isAggregated: sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-              shouldTruncate: false
-            },
-            function(err, collection) {
-              expect(err).to.not.be(null);
-              expect(err.name).to.equal('MongoError');
-              expect(err.message.indexOf('does not exist. Currently in strict mode.')).to.be.above(0);
-              expect(collection).to.be(null);
-              done();
-            }
-          );
+            dataTypes.forEach(function(dataType) {
+                it(
+                    'should notify as error a non-existent ' +
+                        sthTestConfig.DATA_TYPES[dataType] +
+                        ' data collection if it should not be created',
+                    function(done) {
+                        sthDatabase.getCollection(
+                            COLLECTION_NAME_PARAMS,
+                            {
+                                shouldCreate: false,
+                                isAggregated:
+                                    sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
+                                shouldTruncate: false,
+                            },
+                            function(err, collection) {
+                                expect(err).to.not.be(null);
+                                expect(err.name).to.equal('MongoError');
+                                expect(err.message.indexOf('does not exist. Currently in strict mode.')).to.be.above(0);
+                                expect(collection).to.be(null);
+                                done();
+                            }
+                        );
+                    }
+                );
+
+                it(
+                    'should create a ' +
+                        sthTestConfig.DATA_TYPES[dataType] +
+                        ' data collection if non-existent and requested',
+                    function(done) {
+                        sthDatabase.getCollection(
+                            COLLECTION_NAME_PARAMS,
+                            {
+                                shouldCreate: true,
+                                isAggregated:
+                                    sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
+                                shouldTruncate: false,
+                            },
+                            function(err, collection) {
+                                expect(err).to.be(null);
+                                expect(collection).to.be.ok();
+                                return done();
+                            }
+                        );
+                    }
+                );
+            });
+
+            after(function() {
+                sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
+            });
         });
-
-        it('should create a ' + sthTestConfig.DATA_TYPES[dataType] +
-          ' data collection if non-existent and requested', function(done) {
-          sthDatabase.getCollection(
-            COLLECTION_NAME_PARAMS,
-            {
-              shouldCreate: true,
-              isAggregated: sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-              shouldTruncate: false
-            },
-            function(err, collection) {
-              expect(err).to.be(null);
-              expect(collection).to.be.ok();
-              return done();
-            }
-          );
-        });
-      });
-
-      after(function() {
-        sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-      });
     });
-  });
 }
 
 /**
@@ -237,11 +292,11 @@ function collectionAccessTests() {
  * @param {Number} offset The offset
  */
 function getAggregatedEntry4Offset(points, offset) {
-  for (var index = 0; index < points.length; index++) {
-    if (points[index].offset === offset) {
-      return points[index];
+    for (var index = 0; index < points.length; index++) {
+        if (points[index].offset === offset) {
+            return points[index];
+        }
     }
-  }
 }
 
 /**
@@ -251,16 +306,18 @@ function getAggregatedEntry4Offset(points, offset) {
  * @return {object}                 The query object
  */
 function getQuery4ExpectDataStored(dataType, aggregation) {
-  if (sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH ||
-    sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY) {
-      if (dataType === sthTestConfig.DATA_TYPES.RAW) {
-        return {'attrName': STORE_DATA_PARAMS.attribute.name + aggregation};
-      } else {
-        return {'_id.attrName': STORE_DATA_PARAMS.attribute.name + aggregation};
-      }
-  } else {
-    return {};
-  }
+    if (
+        sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH ||
+        sthConfig.DATA_MODEL === sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY
+    ) {
+        if (dataType === sthTestConfig.DATA_TYPES.RAW) {
+            return { attrName: STORE_DATA_PARAMS.attribute.name + aggregation };
+        } else {
+            return { '_id.attrName': STORE_DATA_PARAMS.attribute.name + aggregation };
+        }
+    } else {
+        return {};
+    }
 }
 
 /**
@@ -277,97 +334,102 @@ function getQuery4ExpectDataStored(dataType, aggregation) {
  * @param  {Function} callback The callback
  */
 function expectResult(params, count, result, callback) {
-  if (!Array.isArray(result)) {
-    expect(typeof result).to.be('string');
-    return callback();
-  }
-  if (count === 0) {
-    expect(result.length).to.be(0);
-    return callback();
-  } else {
-    if (params.dataType === sthTestConfig.DATA_TYPES.RAW) {
-      expect(result.length).to.equal(params.limit ? Math.min(params.limit, count) : count);
-      for (var i = 0; i < count; i++) {
-        switch (sthConfig.DATA_MODEL) {
-          case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-            if (params.collection) {
-              expect(result[i].entityId).to.equal(STORE_DATA_PARAMS.entityId);
-              expect(result[i].entityType).to.equal(STORE_DATA_PARAMS.entityType);
-            }
-          /* falls through */
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-            if (params.collection) {
-              expect(result[i].attrName).to.equal(STORE_DATA_PARAMS.attribute.name + params.aggregation);
-            }
-            expect(result[i].attrType).to.equal(STORE_DATA_PARAMS.attribute.type);
-          /* falls through */
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-            expect(result[i].recvTime.getTime()).to.equal(DATE.getTime() + (i * DELAY));
-            expect(result[i].attrValue).to.equal(
-              params.aggregation === sthConfig.AGGREGATIONS.NUMERIC ?
-                ATTRIBUTE.VALUE.NUMERIC : sthConfig.DATA_MODEL);
-            break;
-          default:
-            return callback(new Error('Invalid data model: ' + sthConfig.DATA_MODEL));
-        }
-      }
-      return callback();
+    if (!Array.isArray(result)) {
+        expect(typeof result).to.be('string');
+        return callback();
+    }
+    if (count === 0) {
+        expect(result.length).to.be(0);
+        return callback();
     } else {
-      expect(result.length).to.equal(!params.resolution ? sthConfig.AGGREGATION_BY.length : 1);
-      for (var j = 0; j < result.length; j++) {
-        switch (sthConfig.DATA_MODEL) {
-          case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-            expect(result[j]._id.entityId).to.equal(STORE_DATA_PARAMS.entityId);
-            expect(result[j]._id.entityType).to.equal(STORE_DATA_PARAMS.entityType);
-          /* falls through */
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-            expect(result[j]._id.attrName).to.equal(STORE_DATA_PARAMS.attribute.name + params.aggregation);
-            if (params.collection) {
-              expect(result[j].attrType).to.equal(STORE_DATA_PARAMS.attribute.type);
-              // The previous line should be substituted by the next one when this bug is solved:
-              // expect(result[i]._id.attrType).to.equal(STORE_DATA_PARAMS.attribute.type);
-            }
-          /* falls through */
-          case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-            expect(result[j]._id.origin.getTime()).to.equal(
-              sthUtils.getOrigin(STORE_DATA_PARAMS.recvTime, result[j]._id.resolution).getTime());
-            var point = getAggregatedEntry4Offset(result[j].points,
-            sthUtils.getOffset(result[j]._id.resolution, STORE_DATA_PARAMS.recvTime));
-            expect(point.samples).to.equal(count);
-            switch (params.aggregatedFunction) {
-              case 'sum':
-                expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC * count);
-                break;
-              case 'sum2':
-                expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2) * count);
-                break;
-              case 'min':
-                expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-                break;
-              case 'max':
-                expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-                break;
-              case 'occur':
-                expect(point.occur[sthConfig.DATA_MODEL]).to.equal(count);
-                break;
-              default:
-                if (params.aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
-                  expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC * count);
-                  expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2) * count);
-                  expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-                  expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
-                } else {
-                  expect(point.occur[sthConfig.DATA_MODEL]).to.equal(count);
+        if (params.dataType === sthTestConfig.DATA_TYPES.RAW) {
+            expect(result.length).to.equal(params.limit ? Math.min(params.limit, count) : count);
+            for (var i = 0; i < count; i++) {
+                switch (sthConfig.DATA_MODEL) {
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                        if (params.collection) {
+                            expect(result[i].entityId).to.equal(STORE_DATA_PARAMS.entityId);
+                            expect(result[i].entityType).to.equal(STORE_DATA_PARAMS.entityType);
+                        }
+                    /* falls through */
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                        if (params.collection) {
+                            expect(result[i].attrName).to.equal(STORE_DATA_PARAMS.attribute.name + params.aggregation);
+                        }
+                        expect(result[i].attrType).to.equal(STORE_DATA_PARAMS.attribute.type);
+                    /* falls through */
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                        expect(result[i].recvTime.getTime()).to.equal(DATE.getTime() + i * DELAY);
+                        expect(result[i].attrValue).to.equal(
+                            params.aggregation === sthConfig.AGGREGATIONS.NUMERIC
+                                ? ATTRIBUTE.VALUE.NUMERIC
+                                : sthConfig.DATA_MODEL
+                        );
+                        break;
+                    default:
+                        return callback(new Error('Invalid data model: ' + sthConfig.DATA_MODEL));
                 }
             }
-            break;
-          default:
-            return callback(new Error('Invalid data model: ' + sthConfig.DATA_MODEL));
+            return callback();
+        } else {
+            expect(result.length).to.equal(!params.resolution ? sthConfig.AGGREGATION_BY.length : 1);
+            for (var j = 0; j < result.length; j++) {
+                switch (sthConfig.DATA_MODEL) {
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+                        expect(result[j]._id.entityId).to.equal(STORE_DATA_PARAMS.entityId);
+                        expect(result[j]._id.entityType).to.equal(STORE_DATA_PARAMS.entityType);
+                    /* falls through */
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+                        expect(result[j]._id.attrName).to.equal(STORE_DATA_PARAMS.attribute.name + params.aggregation);
+                        if (params.collection) {
+                            expect(result[j].attrType).to.equal(STORE_DATA_PARAMS.attribute.type);
+                            // The previous line should be substituted by the next one when this bug is solved:
+                            // expect(result[i]._id.attrType).to.equal(STORE_DATA_PARAMS.attribute.type);
+                        }
+                    /* falls through */
+                    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+                        expect(result[j]._id.origin.getTime()).to.equal(
+                            sthUtils.getOrigin(STORE_DATA_PARAMS.recvTime, result[j]._id.resolution).getTime()
+                        );
+                        var point = getAggregatedEntry4Offset(
+                            result[j].points,
+                            sthUtils.getOffset(result[j]._id.resolution, STORE_DATA_PARAMS.recvTime)
+                        );
+                        expect(point.samples).to.equal(count);
+                        switch (params.aggregatedFunction) {
+                            case 'sum':
+                                expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC * count);
+                                break;
+                            case 'sum2':
+                                expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2) * count);
+                                break;
+                            case 'min':
+                                expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                                break;
+                            case 'max':
+                                expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                                break;
+                            case 'occur':
+                                expect(point.occur[sthConfig.DATA_MODEL]).to.equal(count);
+                                break;
+                            default:
+                                if (params.aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
+                                    expect(point.sum).to.equal(ATTRIBUTE.VALUE.NUMERIC * count);
+                                    expect(point.sum2).to.equal(Math.pow(ATTRIBUTE.VALUE.NUMERIC, 2) * count);
+                                    expect(point.min).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                                    expect(point.max).to.equal(ATTRIBUTE.VALUE.NUMERIC);
+                                } else {
+                                    expect(point.occur[sthConfig.DATA_MODEL]).to.equal(count);
+                                }
+                        }
+                        break;
+                    default:
+                        return callback(new Error('Invalid data model: ' + sthConfig.DATA_MODEL));
+                }
+            }
+            return callback();
         }
-      }
-      return callback();
     }
-  }
 }
 
 /**
@@ -380,14 +442,14 @@ function expectResult(params, count, result, callback) {
  * @param {Function} callback The callback
  */
 function expectDataStored(params, count, callback) {
-  params.collection.find(getQuery4ExpectDataStored(params.dataType, params.aggregation)).toArray(
-    function(err, result) {
-      if (err) {
-        return callback(err);
-      }
-      expectResult(params, count, result, callback);
-    }
-  );
+    params.collection
+        .find(getQuery4ExpectDataStored(params.dataType, params.aggregation))
+        .toArray(function(err, result) {
+            if (err) {
+                return callback(err);
+            }
+            expectResult(params, count, result, callback);
+        });
 }
 
 /**
@@ -396,12 +458,12 @@ function expectDataStored(params, count, callback) {
  * @param  {string} aggregation The aggregation type
  */
 function getDataStoreParams(collection, aggregation) {
-  var dataStoreParams = _.cloneDeep(STORE_DATA_PARAMS);
-  dataStoreParams.collection = collection;
-  dataStoreParams.attribute.name += aggregation;
-  dataStoreParams.attribute.value = (aggregation === sthConfig.AGGREGATIONS.NUMERIC ?
-    ATTRIBUTE.VALUE.NUMERIC : sthConfig.DATA_MODEL);
-  return dataStoreParams;
+    var dataStoreParams = _.cloneDeep(STORE_DATA_PARAMS);
+    dataStoreParams.collection = collection;
+    dataStoreParams.attribute.name += aggregation;
+    dataStoreParams.attribute.value =
+        aggregation === sthConfig.AGGREGATIONS.NUMERIC ? ATTRIBUTE.VALUE.NUMERIC : sthConfig.DATA_MODEL;
+    return dataStoreParams;
 }
 
 /**
@@ -411,20 +473,20 @@ function getDataStoreParams(collection, aggregation) {
  * @param  {string} dataModel              The data model
  */
 function expectExistsNotificationInfo(notificationInfoParams, notificationInfo, dataModel) {
-  switch (dataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      expect(notificationInfo.exists).to.have.property('entityId', notificationInfoParams.entityId);
-      expect(notificationInfo.exists).to.have.property('entityType', notificationInfoParams.entityType);
-    /* falls through */
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      expect(notificationInfo.exists).to.have.property('attrName', notificationInfoParams.attribute.name);
-    /* falls through */
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      expect(notificationInfo.exists).to.have.property('_id');
-      expect(notificationInfo.exists.recvTime.getTime()).to.equal(DATE.getTime());
-      expect(notificationInfo.exists).to.have.property('attrType', notificationInfoParams.attribute.type);
-      expect(notificationInfo.exists).to.have.property('attrValue', notificationInfoParams.attribute.value);
-  }
+    switch (dataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            expect(notificationInfo.exists).to.have.property('entityId', notificationInfoParams.entityId);
+            expect(notificationInfo.exists).to.have.property('entityType', notificationInfoParams.entityType);
+        /* falls through */
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            expect(notificationInfo.exists).to.have.property('attrName', notificationInfoParams.attribute.name);
+        /* falls through */
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            expect(notificationInfo.exists).to.have.property('_id');
+            expect(notificationInfo.exists.recvTime.getTime()).to.equal(DATE.getTime());
+            expect(notificationInfo.exists).to.have.property('attrType', notificationInfoParams.attribute.type);
+            expect(notificationInfo.exists).to.have.property('attrValue', notificationInfoParams.attribute.value);
+    }
 }
 
 /**
@@ -435,25 +497,25 @@ function expectExistsNotificationInfo(notificationInfoParams, notificationInfo, 
  * @param  {string} aggregation            The aggregation type
  */
 function expectUpdatesNotificationInfo(notificationInfoParams, notificationInfo, dataModel, aggregation) {
-  switch (dataModel) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      expect(notificationInfo.updates).to.have.property('entityId', notificationInfoParams.entityId);
-      expect(notificationInfo.updates).to.have.property('entityType', notificationInfoParams.entityType);
-    /* falls through */
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      expect(notificationInfo.updates).to.have.property('attrName', notificationInfoParams.attribute.name);
-    /* falls through */
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      expect(notificationInfo.updates).to.have.property('_id');
-      expect(notificationInfo.updates.recvTime.getTime()).to.equal(DATE.getTime());
-      expect(notificationInfo.updates).to.have.property('attrType', notificationInfoParams.attribute.type);
-      expect(notificationInfo.updates).to.have.property('attrValue', notificationInfoParams.attribute.value);
-  }
-  if (aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
-    sthConfig.AGGREGATION_BY.forEach(function(aggregationBy) {
-      expect(notificationInfo.newMinValues[aggregationBy]).to.equal(notificationInfoParams.attribute.value);
-    });
-  }
+    switch (dataModel) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            expect(notificationInfo.updates).to.have.property('entityId', notificationInfoParams.entityId);
+            expect(notificationInfo.updates).to.have.property('entityType', notificationInfoParams.entityType);
+        /* falls through */
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            expect(notificationInfo.updates).to.have.property('attrName', notificationInfoParams.attribute.name);
+        /* falls through */
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            expect(notificationInfo.updates).to.have.property('_id');
+            expect(notificationInfo.updates.recvTime.getTime()).to.equal(DATE.getTime());
+            expect(notificationInfo.updates).to.have.property('attrType', notificationInfoParams.attribute.type);
+            expect(notificationInfo.updates).to.have.property('attrValue', notificationInfoParams.attribute.value);
+    }
+    if (aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
+        sthConfig.AGGREGATION_BY.forEach(function(aggregationBy) {
+            expect(notificationInfo.newMinValues[aggregationBy]).to.equal(notificationInfoParams.attribute.value);
+        });
+    }
 }
 
 /**
@@ -464,178 +526,224 @@ function expectUpdatesNotificationInfo(notificationInfoParams, notificationInfo,
  * @param  {Function} done        The done() function
  */
 function shouldStoreTest(aggregation, dataType, position, done) {
-  sthDatabase.getCollection(
-    (aggregation === sthConfig.AGGREGATIONS.NUMERIC ?
-      NUMERIC_COLLECTION_NAME_PARAMS :
-      TEXTUAL_COLLECTION_NAME_PARAMS),
-    {
-      shouldCreate: true,
-      isAggregated: dataType === sthTestConfig.DATA_TYPES.AGGREGATED,
-      shouldTruncate: false
-    },
-    function(err, collection) {
-      if (err) {
-        return done(err);
-      }
-      var storeDataParams = getDataStoreParams(collection, aggregation);
-      storeDataParams.recvTime = new Date(DATE.getTime() + (position - 1) * DELAY);
-      storeDataParams.notificationInfo = {inserts: true};
-      if (dataType === sthTestConfig.DATA_TYPES.RAW) {
-        sthDatabase.storeRawData(
-          storeDataParams,
-          function(err) {
+    sthDatabase.getCollection(
+        aggregation === sthConfig.AGGREGATIONS.NUMERIC
+            ? NUMERIC_COLLECTION_NAME_PARAMS
+            : TEXTUAL_COLLECTION_NAME_PARAMS,
+        {
+            shouldCreate: true,
+            isAggregated: dataType === sthTestConfig.DATA_TYPES.AGGREGATED,
+            shouldTruncate: false,
+        },
+        function(err, collection) {
             if (err) {
-              return done(err);
+                return done(err);
             }
-            expectDataStored(
-              {
-                collection: collection,
-                dataType: dataType,
-                aggregation: aggregation
-              },
-              position,
-              done
-            );
-          }
-        );
-      } else {
-        sthDatabase.storeAggregatedData(
-          storeDataParams,
-          function(err) {
-            if (err) {
-              return done(err);
+            var storeDataParams = getDataStoreParams(collection, aggregation);
+            storeDataParams.recvTime = new Date(DATE.getTime() + (position - 1) * DELAY);
+            storeDataParams.notificationInfo = { inserts: true };
+            if (dataType === sthTestConfig.DATA_TYPES.RAW) {
+                sthDatabase.storeRawData(storeDataParams, function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    expectDataStored(
+                        {
+                            collection: collection,
+                            dataType: dataType,
+                            aggregation: aggregation,
+                        },
+                        position,
+                        done
+                    );
+                });
+            } else {
+                sthDatabase.storeAggregatedData(storeDataParams, function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    expectDataStored(
+                        {
+                            collection: collection,
+                            dataType: dataType,
+                            aggregation: aggregation,
+                        },
+                        position,
+                        done
+                    );
+                });
             }
-            expectDataStored(
-              {
-                collection: collection,
-                dataType: dataType,
-                aggregation: aggregation
-              },
-              position,
-              done
-            );
-          }
-        );
-      }
-    }
-  );
+        }
+    );
 }
 
 /**
  * Battery of tests to check that the storage of raw and aggregated data works as expected
  */
 function storageTests() {
-  var ORIGINAL_DATA_MODEL,
-      dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
-      dataModels = Object.keys(sthConfig.DATA_MODELS),
-      aggregations = Object.keys(sthConfig.AGGREGATIONS),
-      collection;
+    var ORIGINAL_DATA_MODEL,
+        dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
+        dataModels = Object.keys(sthConfig.DATA_MODELS),
+        aggregations = Object.keys(sthConfig.AGGREGATIONS),
+        collection;
 
-  before(function() {
-    ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
-  });
-
-  cleanDatabaseTests();
-
-  dataModels.forEach(function(dataModel) {
-    describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
-      before(function() {
-        sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
-      });
-
-      aggregations.forEach(function(aggregation) {
-        describe(sthConfig.AGGREGATIONS[aggregation], function() {
-          dataTypes.forEach(function(dataType) {
-            describe(sthTestConfig.DATA_TYPES[dataType] + ' data', function() {
-              before(function(done) {
-                sthDatabase.getCollection(
-                  (sthConfig.AGGREGATIONS[aggregation] === sthConfig.AGGREGATIONS.NUMERIC ?
-                    NUMERIC_COLLECTION_NAME_PARAMS :
-                    TEXTUAL_COLLECTION_NAME_PARAMS),
-                  {
-                    shouldCreate: true,
-                    isAggregated: sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-                    shouldTruncate: false
-                  },
-                  function(err, theCollection) {
-                    if (err) {
-                      return done(err);
-                    }
-                    collection = theCollection;
-                    done();
-                  }
-                );
-              });
-
-              if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
-                it('should detect a new ' + sthConfig.AGGREGATIONS[aggregation] + ' attribute value notification is ' +
-                  'susceptible of being inserted',
-                  function(done) {
-                    var notificationInfoParams = getDataStoreParams(collection, sthConfig.AGGREGATIONS[aggregation]);
-                    sthDatabase.getNotificationInfo(notificationInfoParams, function(err, result) {
-                      if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
-                        expect(err).to.be(null);
-                        expect(result).to.eql({inserts: true});
-                      }
-                      done();
-                    });
-                  }
-                );
-              }
-
-              it('should store ' + sthConfig.AGGREGATIONS[aggregation] + ' ' + sthTestConfig.DATA_TYPES[dataType] +
-                ' data', shouldStoreTest.bind(null, sthConfig.AGGREGATIONS[aggregation],
-                  sthTestConfig.DATA_TYPES[dataType], 1)
-              );
-
-              if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
-                it('should detect an already inserted ' + sthConfig.AGGREGATIONS[aggregation] + ' attribute value ' +
-                  'notification already exists',
-                  function(done) {
-                    var notificationInfoParams = getDataStoreParams(collection, sthConfig.AGGREGATIONS[aggregation]);
-                    sthDatabase.getNotificationInfo(notificationInfoParams, function(err, result) {
-                      expect(err).to.be(null);
-                      expectExistsNotificationInfo(notificationInfoParams, result, sthConfig.DATA_MODELS[dataModel]);
-                      done();
-                    });
-                  }
-                );
-              }
-
-              it('should store a second entry of ' + sthConfig.AGGREGATIONS[aggregation] + ' ' +
-                sthTestConfig.DATA_TYPES[dataType] + ' data with a ' + DELAY + ' ms delay',
-                shouldStoreTest.bind(null, sthConfig.AGGREGATIONS[aggregation],
-                  sthTestConfig.DATA_TYPES[dataType], 2)
-              );
-
-              if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
-                it('should detect as updatable an updated ' + sthConfig.AGGREGATIONS[aggregation] + ' attribute value',
-                  function(done) {
-                    var notificationInfoParams = getDataStoreParams(collection, sthConfig.AGGREGATIONS[aggregation]);
-                    var updatedNotificationInfoParams = getDataStoreParams(
-                      collection, sthConfig.AGGREGATIONS[aggregation]);
-                    updatedNotificationInfoParams.attribute.value +=
-                      (sthConfig.AGGREGATIONS[aggregation] === sthConfig.AGGREGATIONS.NUMERIC ?
-                        ATTRIBUTE.VALUE.NUMERIC : sthConfig.DATA_MODELS[dataModel]);
-                    sthDatabase.getNotificationInfo(updatedNotificationInfoParams, function(err, result) {
-                      expect(err).to.be(null);
-                      expectUpdatesNotificationInfo(notificationInfoParams, result, sthConfig.DATA_MODELS[dataModel],
-                        sthConfig.AGGREGATIONS[aggregation]);
-                      done();
-                    });
-                  }
-                );
-              }
-            });
-          });
-        });
-      });
-
-      after(function() {
-        sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-      });
+    before(function() {
+        ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
     });
-  });
+
+    cleanDatabaseTests();
+
+    dataModels.forEach(function(dataModel) {
+        describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
+            before(function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
+            });
+
+            aggregations.forEach(function(aggregation) {
+                describe(sthConfig.AGGREGATIONS[aggregation], function() {
+                    dataTypes.forEach(function(dataType) {
+                        describe(sthTestConfig.DATA_TYPES[dataType] + ' data', function() {
+                            before(function(done) {
+                                sthDatabase.getCollection(
+                                    sthConfig.AGGREGATIONS[aggregation] === sthConfig.AGGREGATIONS.NUMERIC
+                                        ? NUMERIC_COLLECTION_NAME_PARAMS
+                                        : TEXTUAL_COLLECTION_NAME_PARAMS,
+                                    {
+                                        shouldCreate: true,
+                                        isAggregated:
+                                            sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
+                                        shouldTruncate: false,
+                                    },
+                                    function(err, theCollection) {
+                                        if (err) {
+                                            return done(err);
+                                        }
+                                        collection = theCollection;
+                                        done();
+                                    }
+                                );
+                            });
+
+                            if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
+                                it(
+                                    'should detect a new ' +
+                                        sthConfig.AGGREGATIONS[aggregation] +
+                                        ' attribute value notification is ' +
+                                        'susceptible of being inserted',
+                                    function(done) {
+                                        var notificationInfoParams = getDataStoreParams(
+                                            collection,
+                                            sthConfig.AGGREGATIONS[aggregation]
+                                        );
+                                        sthDatabase.getNotificationInfo(notificationInfoParams, function(err, result) {
+                                            if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
+                                                expect(err).to.be(null);
+                                                expect(result).to.eql({ inserts: true });
+                                            }
+                                            done();
+                                        });
+                                    }
+                                );
+                            }
+
+                            it(
+                                'should store ' +
+                                    sthConfig.AGGREGATIONS[aggregation] +
+                                    ' ' +
+                                    sthTestConfig.DATA_TYPES[dataType] +
+                                    ' data',
+                                shouldStoreTest.bind(
+                                    null,
+                                    sthConfig.AGGREGATIONS[aggregation],
+                                    sthTestConfig.DATA_TYPES[dataType],
+                                    1
+                                )
+                            );
+
+                            if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
+                                it(
+                                    'should detect an already inserted ' +
+                                        sthConfig.AGGREGATIONS[aggregation] +
+                                        ' attribute value ' +
+                                        'notification already exists',
+                                    function(done) {
+                                        var notificationInfoParams = getDataStoreParams(
+                                            collection,
+                                            sthConfig.AGGREGATIONS[aggregation]
+                                        );
+                                        sthDatabase.getNotificationInfo(notificationInfoParams, function(err, result) {
+                                            expect(err).to.be(null);
+                                            expectExistsNotificationInfo(
+                                                notificationInfoParams,
+                                                result,
+                                                sthConfig.DATA_MODELS[dataModel]
+                                            );
+                                            done();
+                                        });
+                                    }
+                                );
+                            }
+
+                            it(
+                                'should store a second entry of ' +
+                                    sthConfig.AGGREGATIONS[aggregation] +
+                                    ' ' +
+                                    sthTestConfig.DATA_TYPES[dataType] +
+                                    ' data with a ' +
+                                    DELAY +
+                                    ' ms delay',
+                                shouldStoreTest.bind(
+                                    null,
+                                    sthConfig.AGGREGATIONS[aggregation],
+                                    sthTestConfig.DATA_TYPES[dataType],
+                                    2
+                                )
+                            );
+
+                            if (sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.RAW) {
+                                it(
+                                    'should detect as updatable an updated ' +
+                                        sthConfig.AGGREGATIONS[aggregation] +
+                                        ' attribute value',
+                                    function(done) {
+                                        var notificationInfoParams = getDataStoreParams(
+                                            collection,
+                                            sthConfig.AGGREGATIONS[aggregation]
+                                        );
+                                        var updatedNotificationInfoParams = getDataStoreParams(
+                                            collection,
+                                            sthConfig.AGGREGATIONS[aggregation]
+                                        );
+                                        updatedNotificationInfoParams.attribute.value +=
+                                            sthConfig.AGGREGATIONS[aggregation] === sthConfig.AGGREGATIONS.NUMERIC
+                                                ? ATTRIBUTE.VALUE.NUMERIC
+                                                : sthConfig.DATA_MODELS[dataModel];
+                                        sthDatabase.getNotificationInfo(updatedNotificationInfoParams, function(
+                                            err,
+                                            result
+                                        ) {
+                                            expect(err).to.be(null);
+                                            expectUpdatesNotificationInfo(
+                                                notificationInfoParams,
+                                                result,
+                                                sthConfig.DATA_MODELS[dataModel],
+                                                sthConfig.AGGREGATIONS[aggregation]
+                                            );
+                                            done();
+                                        });
+                                    }
+                                );
+                            }
+                        });
+                    });
+                });
+            });
+
+            after(function() {
+                sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
+            });
+        });
+    });
 }
 
 /**
@@ -644,10 +752,10 @@ function storageTests() {
  * @param  {string} aggregation The aggregation type
  */
 function getDataRetrievalParams(collection, aggregation) {
-  var dataRetrievalParams = _.cloneDeep(RETRIEVAL_DATA_PARAMS);
-  dataRetrievalParams.collection = collection;
-  dataRetrievalParams.attrName += aggregation;
-  return dataRetrievalParams;
+    var dataRetrievalParams = _.cloneDeep(RETRIEVAL_DATA_PARAMS);
+    dataRetrievalParams.collection = collection;
+    dataRetrievalParams.attrName += aggregation;
+    return dataRetrievalParams;
 }
 
 /**
@@ -660,60 +768,54 @@ function getDataRetrievalParams(collection, aggregation) {
  * @param  {Function} done         The done() function
  */
 function retrievalTest(params, options, count, done) {
-  sthDatabase.getCollection(
-    (params.aggregation === sthConfig.AGGREGATIONS.NUMERIC ?
-      NUMERIC_COLLECTION_NAME_PARAMS :
-      TEXTUAL_COLLECTION_NAME_PARAMS),
-    {
-      shouldCreate: true,
-      isAggregated: params.dataType === sthTestConfig.DATA_TYPES.AGGREGATED,
-      shouldTruncate: false
-    },
-    function(err, collection) {
-      if (err) {
-        return done(err);
-      }
-      var retrievalDataParams = getDataRetrievalParams(collection, params.aggregation);
-      if (params.dataType === sthTestConfig.DATA_TYPES.RAW) {
-        if (options) {
-          retrievalDataParams.lastN = options.lastN;
-          retrievalDataParams.hLimit = options.hLimit;
-          retrievalDataParams.hOffset = options.hOffset;
-          retrievalDataParams.from = options.dateFrom;
-          retrievalDataParams.to = options.dateTo;
-          retrievalDataParams.filetype = options.filetype;
-          params.limit = options.lastN || options.hLimit;
-        }
-        sthDatabase.getRawData(
-          retrievalDataParams,
-          function(err, results) {
+    sthDatabase.getCollection(
+        params.aggregation === sthConfig.AGGREGATIONS.NUMERIC
+            ? NUMERIC_COLLECTION_NAME_PARAMS
+            : TEXTUAL_COLLECTION_NAME_PARAMS,
+        {
+            shouldCreate: true,
+            isAggregated: params.dataType === sthTestConfig.DATA_TYPES.AGGREGATED,
+            shouldTruncate: false,
+        },
+        function(err, collection) {
             if (err) {
-              return done(err);
+                return done(err);
             }
-            expectResult(params, count, results, done);
-          }
-        );
-      } else {
-        if (options) {
-          retrievalDataParams.aggregatedFunction = options.aggrMethod;
-          retrievalDataParams.resolution = options.aggrPeriod;
-          retrievalDataParams.from = options.dateFrom;
-          retrievalDataParams.to = options.dateTo;
-          params.aggregatedFunction = options.aggrMethod;
-          params.resolution = options.aggrPeriod;
+            var retrievalDataParams = getDataRetrievalParams(collection, params.aggregation);
+            if (params.dataType === sthTestConfig.DATA_TYPES.RAW) {
+                if (options) {
+                    retrievalDataParams.lastN = options.lastN;
+                    retrievalDataParams.hLimit = options.hLimit;
+                    retrievalDataParams.hOffset = options.hOffset;
+                    retrievalDataParams.from = options.dateFrom;
+                    retrievalDataParams.to = options.dateTo;
+                    retrievalDataParams.filetype = options.filetype;
+                    params.limit = options.lastN || options.hLimit;
+                }
+                sthDatabase.getRawData(retrievalDataParams, function(err, results) {
+                    if (err) {
+                        return done(err);
+                    }
+                    expectResult(params, count, results, done);
+                });
+            } else {
+                if (options) {
+                    retrievalDataParams.aggregatedFunction = options.aggrMethod;
+                    retrievalDataParams.resolution = options.aggrPeriod;
+                    retrievalDataParams.from = options.dateFrom;
+                    retrievalDataParams.to = options.dateTo;
+                    params.aggregatedFunction = options.aggrMethod;
+                    params.resolution = options.aggrPeriod;
+                }
+                sthDatabase.getAggregatedData(retrievalDataParams, function(err, results) {
+                    if (err) {
+                        return done(err);
+                    }
+                    expectResult(params, count, results, done);
+                });
+            }
         }
-        sthDatabase.getAggregatedData(
-          retrievalDataParams,
-          function(err, results) {
-            if (err) {
-              return done(err);
-            }
-            expectResult(params, count, results, done);
-          }
-        );
-      }
-    }
-  );
+    );
 }
 
 /**
@@ -723,372 +825,535 @@ function retrievalTest(params, options, count, done) {
  * @param  {string} dataType    The data type
  */
 function shouldRetrieveTests(count, aggregation, dataType) {
-  if (dataType === sthTestConfig.DATA_TYPES.RAW) {
-    it('should retrieve ' + count + ' ' + aggregation + ' ' +
-      dataType + ' data with no params if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        null,
-        count
-      )
-    );
-
-    it('should retrieve ' + count + ' ' + aggregation + ' ' +
-      dataType + ' data with lastN if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          lastN: LIMIT
-        },
-        count
-      )
-    );
-
-    it('should retrieve ' + count + ' ' + aggregation + ' ' +
-      dataType + ' data with hLimit and hOffset if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          hLimit: LIMIT,
-          hOffset: PAGINATION
-        },
-        count
-      )
-    );
-
-    it('should retrieve ' + count + ' ' + aggregation + ' ' +
-      dataType + ' data with dateFrom if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          dateFrom: DATE
-        },
-        count
-      )
-    );
-
-    it('should retrieve ' + 0 + ' ' + aggregation + ' ' +
-      dataType + ' data with dateFrom is beyond if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          dateFrom: new Date(DATE.getTime() + (1000 * 60 * 60))
-        },
-        0
-      )
-    );
-
-    it('should retrieve ' + count + ' ' + aggregation + ' ' +
-      dataType + ' data with dateTo if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          dateTo: new Date()
-        },
-        count
-      )
-    );
-
-    it('should retrieve ' + 0 + ' ' + aggregation + ' ' +
-      dataType + ' data with dateTo if previous if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          dateTo: new Date(DATE.getTime() - (1000 * 60 * 60))
-        },
-        0
-      )
-    );
-
-    it('should retrieve ' + count + ' ' + aggregation + ' ' +
-      dataType + ' data with csv if ' + count + ' data is inserted',
-      retrievalTest.bind(
-        null,
-        {
-          aggregation: aggregation,
-          dataType: dataType
-        },
-        {
-          filetype: 'csv'
-        },
-        count
-      )
-    );
-  } else {
-    sthConfig.AGGREGATION_BY.forEach(function(aggregationBy) {
-      if (aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of sum if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'sum',
-              aggrPeriod: aggregationBy
-            },
-            count
-          )
+    if (dataType === sthTestConfig.DATA_TYPES.RAW) {
+        it(
+            'should retrieve ' +
+                count +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with no params if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                null,
+                count
+            )
         );
 
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of sum with dataFrom set if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'sum',
-              aggrPeriod: aggregationBy,
-              dateFrom: DATE
-            },
-            count
-          )
+        it(
+            'should retrieve ' +
+                count +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with lastN if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    lastN: LIMIT,
+                },
+                count
+            )
         );
 
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of sum with dataTo set if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'sum',
-              aggrPeriod: aggregationBy,
-              dateTo: new Date()
-            },
-            count
-          )
+        it(
+            'should retrieve ' +
+                count +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with hLimit and hOffset if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    hLimit: LIMIT,
+                    hOffset: PAGINATION,
+                },
+                count
+            )
         );
 
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of sum2 if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'sum2',
-              aggrPeriod: aggregationBy
-            },
-            count
-          )
+        it(
+            'should retrieve ' +
+                count +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with dateFrom if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    dateFrom: DATE,
+                },
+                count
+            )
         );
 
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of min if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'min',
-              aggrPeriod: aggregationBy
-            },
-            count
-          )
+        it(
+            'should retrieve ' +
+                0 +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with dateFrom is beyond if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    dateFrom: new Date(DATE.getTime() + 1000 * 60 * 60),
+                },
+                0
+            )
         );
 
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of max if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'max',
-              aggrPeriod: aggregationBy
-            },
-            count
-          )
+        it(
+            'should retrieve ' +
+                count +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with dateTo if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    dateTo: new Date(),
+                },
+                count
+            )
         );
-      } else {
-        it('should retrieve ' + count + ' ' + aggregation + ' ' +
-          dataType + ' data for a resolution of ' + aggregationBy +
-          ' and an aggregation method of occur if ' + count + ' data is inserted',
-          retrievalTest.bind(
-            null,
-            {
-              aggregation: aggregation,
-              dataType: dataType
-            },
-            {
-              aggrMethod: 'occur',
-              aggrPeriod: aggregationBy
-            },
-            count
-          )
+
+        it(
+            'should retrieve ' +
+                0 +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with dateTo if previous if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    dateTo: new Date(DATE.getTime() - 1000 * 60 * 60),
+                },
+                0
+            )
         );
-      }
-    });
-  }
+
+        it(
+            'should retrieve ' +
+                count +
+                ' ' +
+                aggregation +
+                ' ' +
+                dataType +
+                ' data with csv if ' +
+                count +
+                ' data is inserted',
+            retrievalTest.bind(
+                null,
+                {
+                    aggregation: aggregation,
+                    dataType: dataType,
+                },
+                {
+                    filetype: 'csv',
+                },
+                count
+            )
+        );
+    } else {
+        sthConfig.AGGREGATION_BY.forEach(function(aggregationBy) {
+            if (aggregation === sthConfig.AGGREGATIONS.NUMERIC) {
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of sum if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'sum',
+                            aggrPeriod: aggregationBy,
+                        },
+                        count
+                    )
+                );
+
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of sum with dataFrom set if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'sum',
+                            aggrPeriod: aggregationBy,
+                            dateFrom: DATE,
+                        },
+                        count
+                    )
+                );
+
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of sum with dataTo set if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'sum',
+                            aggrPeriod: aggregationBy,
+                            dateTo: new Date(),
+                        },
+                        count
+                    )
+                );
+
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of sum2 if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'sum2',
+                            aggrPeriod: aggregationBy,
+                        },
+                        count
+                    )
+                );
+
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of min if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'min',
+                            aggrPeriod: aggregationBy,
+                        },
+                        count
+                    )
+                );
+
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of max if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'max',
+                            aggrPeriod: aggregationBy,
+                        },
+                        count
+                    )
+                );
+            } else {
+                it(
+                    'should retrieve ' +
+                        count +
+                        ' ' +
+                        aggregation +
+                        ' ' +
+                        dataType +
+                        ' data for a resolution of ' +
+                        aggregationBy +
+                        ' and an aggregation method of occur if ' +
+                        count +
+                        ' data is inserted',
+                    retrievalTest.bind(
+                        null,
+                        {
+                            aggregation: aggregation,
+                            dataType: dataType,
+                        },
+                        {
+                            aggrMethod: 'occur',
+                            aggrPeriod: aggregationBy,
+                        },
+                        count
+                    )
+                );
+            }
+        });
+    }
 }
 
 /**
  * Battery of tests to check that the retrieval of raw and aggregated data works as expected
  */
 function retrievalTests() {
-  var ORIGINAL_DATA_MODEL,
-      dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
-      dataModels = Object.keys(sthConfig.DATA_MODELS),
-      aggregations = Object.keys(sthConfig.AGGREGATIONS);
+    var ORIGINAL_DATA_MODEL,
+        dataTypes = Object.keys(sthTestConfig.DATA_TYPES),
+        dataModels = Object.keys(sthConfig.DATA_MODELS),
+        aggregations = Object.keys(sthConfig.AGGREGATIONS);
 
-  before(function() {
-    ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
-  });
-
-  cleanDatabaseTests();
-
-  dataModels.forEach(function(dataModel) {
-    describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
-      before(function() {
-        sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
-      });
-
-      aggregations.forEach(function(aggregation) {
-        describe(sthConfig.AGGREGATIONS[aggregation], function() {
-          dataTypes.forEach(function(dataType) {
-            describe(sthTestConfig.DATA_TYPES[dataType] + ' data', function() {
-              shouldRetrieveTests(0, sthConfig.AGGREGATIONS[aggregation], sthTestConfig.DATA_TYPES[dataType]);
-
-              for (var i = 1; i <= 5; i++) {
-                it('should store ' + (i === 1 ? i : 'another (' + i + ')') + ' ' + sthConfig.AGGREGATIONS[aggregation] +
-                  ' ' + sthTestConfig.DATA_TYPES[dataType] + ' data with ' + (i - 1) * DELAY + 'ms delay',
-                  shouldStoreTest.bind(null, sthConfig.AGGREGATIONS[aggregation],
-                    sthTestConfig.DATA_TYPES[dataType], i)
-                );
-
-                shouldRetrieveTests(i, sthConfig.AGGREGATIONS[aggregation], sthTestConfig.DATA_TYPES[dataType]);
-              }
-            });
-          });
-        });
-      });
-
-      after(function() {
-        sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-      });
+    before(function() {
+        ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
     });
-  });
+
+    cleanDatabaseTests();
+
+    dataModels.forEach(function(dataModel) {
+        describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
+            before(function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
+            });
+
+            aggregations.forEach(function(aggregation) {
+                describe(sthConfig.AGGREGATIONS[aggregation], function() {
+                    dataTypes.forEach(function(dataType) {
+                        describe(sthTestConfig.DATA_TYPES[dataType] + ' data', function() {
+                            shouldRetrieveTests(
+                                0,
+                                sthConfig.AGGREGATIONS[aggregation],
+                                sthTestConfig.DATA_TYPES[dataType]
+                            );
+
+                            for (var i = 1; i <= 5; i++) {
+                                it(
+                                    'should store ' +
+                                        (i === 1 ? i : 'another (' + i + ')') +
+                                        ' ' +
+                                        sthConfig.AGGREGATIONS[aggregation] +
+                                        ' ' +
+                                        sthTestConfig.DATA_TYPES[dataType] +
+                                        ' data with ' +
+                                        (i - 1) * DELAY +
+                                        'ms delay',
+                                    shouldStoreTest.bind(
+                                        null,
+                                        sthConfig.AGGREGATIONS[aggregation],
+                                        sthTestConfig.DATA_TYPES[dataType],
+                                        i
+                                    )
+                                );
+
+                                shouldRetrieveTests(
+                                    i,
+                                    sthConfig.AGGREGATIONS[aggregation],
+                                    sthTestConfig.DATA_TYPES[dataType]
+                                );
+                            }
+                        });
+                    });
+                });
+            });
+
+            after(function() {
+                sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
+            });
+        });
+    });
 }
 
 describe('sthDatabase tests', function() {
-  this.timeout(5000);
-  describe('database connection', function() {
-    it('should connect to the database', function(done) {
-      sthDatabase.connect(DATABASE_CONNECTION_PARAMS, function(err, connection) {
-        expect(err).to.be(null);
-        expect(connection).to.equal(sthDatabase.connection);
-        done();
-      });
+    this.timeout(5000);
+    describe('database connection', function() {
+        it('should connect to the database', function(done) {
+            sthDatabase.connect(
+                DATABASE_CONNECTION_PARAMS,
+                function(err, connection) {
+                    expect(err).to.be(null);
+                    expect(connection).to.equal(sthDatabase.connection);
+                    done();
+                }
+            );
+        });
+
+        it('should disconnect from the database', function(done) {
+            sthDatabase.closeConnection(function(err) {
+                expect(err).to.be(null);
+                expect(sthDatabase.connection).to.be(null);
+                done();
+            });
+        });
+
+        it('should notify as error the aim to connect to the database at an unavailable host', function(done) {
+            var INVALID_DATABASE_CONNECTION_PARAMS = _.clone(DATABASE_CONNECTION_PARAMS);
+            INVALID_DATABASE_CONNECTION_PARAMS.dbURI = 'unavailable_localhost:27017';
+            sthDatabase.connect(
+                INVALID_DATABASE_CONNECTION_PARAMS,
+                function(err, connection) {
+                    expect(err).to.exist;
+                    expect(err.name).to.equal('MongoError');
+                    expect(
+                        err.message.indexOf(
+                            'failed to connect to server [' + INVALID_DATABASE_CONNECTION_PARAMS.dbURI + ']'
+                        )
+                    ).to.equal(0);
+                    expect(connection).to.equal(null);
+                    done();
+                }
+            );
+        });
+
+        it('should notify as error the aim to connect to the database at an unavailable port', function(done) {
+            var INVALID_DATABASE_CONNECTION_PARAMS = _.clone(DATABASE_CONNECTION_PARAMS);
+            INVALID_DATABASE_CONNECTION_PARAMS.dbURI = 'localhost:12345';
+            sthDatabase.connect(
+                INVALID_DATABASE_CONNECTION_PARAMS,
+                function(err, connection) {
+                    expect(err).to.exist;
+                    expect(err.name).to.equal('MongoError');
+                    expect(
+                        err.message.indexOf(
+                            'failed to connect to server [' + INVALID_DATABASE_CONNECTION_PARAMS.dbURI + ']'
+                        )
+                    ).to.equal(0);
+                    expect(connection).to.equal(null);
+                    done();
+                }
+            );
+        });
     });
 
-    it('should disconnect from the database', function(done) {
-      sthDatabase.closeConnection(function(err) {
-        expect(err).to.be(null);
-        expect(sthDatabase.connection).to.be(null);
-        done();
-      });
+    describe('helper functions', function() {
+        it('should return the database name for a service', function() {
+            var databaseName = sthConfig.DB_PREFIX + sthConfig.DEFAULT_SERVICE;
+            expect(sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE)).to.equal(
+                sthConfig.NAME_ENCODING ? sthDatabaseNameCodec.encodeDatabaseName(databaseName) : databaseName
+            );
+        });
+
+        describe('collection access', function() {
+            before(function(done) {
+                connectToDatabase(done);
+            });
+
+            describe('access', collectionAccessTests);
+        });
     });
 
-    it('should notify as error the aim to connect to the database at an unavailable host', function(done) {
-      var INVALID_DATABASE_CONNECTION_PARAMS = _.clone(DATABASE_CONNECTION_PARAMS);
-      INVALID_DATABASE_CONNECTION_PARAMS.dbURI = 'unavailable_localhost:27017';
-      sthDatabase.connect(INVALID_DATABASE_CONNECTION_PARAMS, function(err, connection) {
-        expect(err).to.exist;
-        expect(err.name).to.equal('MongoError');
-        expect(err.message.indexOf('failed to connect to server [' + INVALID_DATABASE_CONNECTION_PARAMS.dbURI + ']')).
-          to.equal(0);
-        expect(connection).to.equal(null);
-        done();
-      });
+    describe('storage and retrieval', function() {
+        before(function(done) {
+            connectToDatabase(done);
+        });
+
+        describe('storage', storageTests);
+
+        describe('retrieval', retrievalTests);
+
+        describe('final clean up', cleanDatabaseTests);
     });
-
-    it('should notify as error the aim to connect to the database at an unavailable port', function(done) {
-      var INVALID_DATABASE_CONNECTION_PARAMS = _.clone(DATABASE_CONNECTION_PARAMS);
-      INVALID_DATABASE_CONNECTION_PARAMS.dbURI = 'localhost:12345';
-      sthDatabase.connect(INVALID_DATABASE_CONNECTION_PARAMS, function(err, connection) {
-        expect(err).to.exist;
-        expect(err.name).to.equal('MongoError');
-        expect(err.message.indexOf('failed to connect to server [' + INVALID_DATABASE_CONNECTION_PARAMS.dbURI + ']')).
-          to.equal(0);
-        expect(connection).to.equal(null);
-        done();
-      });
-    });
-  });
-
-  describe('helper functions', function() {
-    it('should return the database name for a service', function() {
-      var databaseName = sthConfig.DB_PREFIX + sthConfig.DEFAULT_SERVICE;
-      expect(sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE)).to.equal(
-        sthConfig.NAME_ENCODING ? sthDatabaseNameCodec.encodeDatabaseName(databaseName) : databaseName);
-    });
-
-    describe('collection access', function() {
-      before(function(done) {
-        connectToDatabase(done);
-      });
-
-      describe('access', collectionAccessTests);
-    });
-  });
-
-  describe('storage and retrieval', function() {
-    before(function(done) {
-      connectToDatabase(done);
-    });
-
-    describe('storage', storageTests);
-
-    describe('retrieval', retrievalTests);
-
-    describe('final clean up', cleanDatabaseTests);
-  });
 });

--- a/test/unit/sthGetLogLevelHandler_test.js
+++ b/test/unit/sthGetLogLevelHandler_test.js
@@ -34,57 +34,53 @@ var expect = require('expect.js');
 var request = require('request');
 
 describe('sthGetLogLevelHandler tests', function() {
-  describe('database connection', function () {
-    it('should be a database available', function (done) {
-      sth.sthDatabase.connect(
-        {
-          authentication: sthConfig.DB_AUTHENTICATION,
-          dbURI: sthConfig.DB_URI,
-          replicaSet: sthConfig.REPLICA_SET,
-          database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-          poolSize: sthConfig.POOL_SIZE
-        },
-        function (err) {
-          done(err);
-        }
-      );
-    });
-  });
-
-  describe('database clean up', function () {
-    it('should drop the event raw data collection if it exists',
-      sthTestHelper.dropRawEventCollectionTest);
-
-    it('should drop the aggregated data collection if it exists',
-      sthTestHelper.dropAggregatedDataCollectionTest);
-  });
-
-  describe('server start', function () {
-    it('should start gracefully', function (done) {
-      sth.sthServer.startServer(
-        sthConfig.STH_HOST,
-        sthConfig.STH_PORT,
-        function (err, server) {
-          expect(err).to.equal(undefined);
-          expect(server).to.be.a(hapi.Server);
-          done();
+    describe('database connection', function() {
+        it('should be a database available', function(done) {
+            sth.sthDatabase.connect(
+                {
+                    authentication: sthConfig.DB_AUTHENTICATION,
+                    dbURI: sthConfig.DB_URI,
+                    replicaSet: sthConfig.REPLICA_SET,
+                    database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+                    poolSize: sthConfig.POOL_SIZE,
+                },
+                function(err) {
+                    done(err);
+                }
+            );
         });
     });
-  });
 
-  describe('GET /admin/log', function() {
-    it('should respond with the logging level', function(done) {
-      request({
-        uri: sthTestHelper.getURL(
-          sthTestConfig.API_OPERATION.ADMIN.GET_LOG_LEVEL
-        ),
-        method: 'GET',
-        json: true
-      }, function (err, response, body) {
-        expect(err).to.equal(null);
-        expect(body.level).to.equal(sthConfig.LOGOPS_LEVEL);
-        done();
-      });
+    describe('database clean up', function() {
+        it('should drop the event raw data collection if it exists', sthTestHelper.dropRawEventCollectionTest);
+
+        it('should drop the aggregated data collection if it exists', sthTestHelper.dropAggregatedDataCollectionTest);
     });
-  });
+
+    describe('server start', function() {
+        it('should start gracefully', function(done) {
+            sth.sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(err, server) {
+                expect(err).to.equal(undefined);
+                expect(server).to.be.a(hapi.Server);
+                done();
+            });
+        });
+    });
+
+    describe('GET /admin/log', function() {
+        it('should respond with the logging level', function(done) {
+            request(
+                {
+                    uri: sthTestHelper.getURL(sthTestConfig.API_OPERATION.ADMIN.GET_LOG_LEVEL),
+                    method: 'GET',
+                    json: true,
+                },
+                function(err, response, body) {
+                    expect(err).to.equal(null);
+                    expect(body.level).to.equal(sthConfig.LOGOPS_LEVEL);
+                    done();
+                }
+            );
+        });
+    });
 });

--- a/test/unit/sthGetLogLevelHandler_test.js
+++ b/test/unit/sthGetLogLevelHandler_test.js
@@ -42,7 +42,7 @@ describe('sthGetLogLevelHandler tests', function() {
                     dbURI: sthConfig.DB_URI,
                     replicaSet: sthConfig.REPLICA_SET,
                     database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-                    poolSize: sthConfig.POOL_SIZE,
+                    poolSize: sthConfig.POOL_SIZE
                 },
                 function(err) {
                     done(err);
@@ -73,7 +73,7 @@ describe('sthGetLogLevelHandler tests', function() {
                 {
                     uri: sthTestHelper.getURL(sthTestConfig.API_OPERATION.ADMIN.GET_LOG_LEVEL),
                     method: 'GET',
-                    json: true,
+                    json: true
                 },
                 function(err, response, body) {
                     expect(err).to.equal(null);

--- a/test/unit/sthTestConfiguration.js
+++ b/test/unit/sthTestConfiguration.js
@@ -26,37 +26,35 @@
 var ENV = process.env;
 
 module.exports = {
-  SAMPLES: ENV.SAMPLES || 1,
-  EVENT_NOTIFICATION_CONTEXT_ELEMENTS: ENV.EVENT_NOTIFICATION_CONTEXT_ELEMENTS || 3,
-  ENTITY_ID: ENV.ENTITY_ID || 'entityId',
-  ENTITY_TYPE: ENV.ENTITY_TYPE || 'entityType',
-  ATTRIBUTE_NAME: ENV.ATTRIBUTE_NAME || 'attrName',
-  ATTRIBUTE_TYPE: ENV.ATTRIBUTE_TYPE || 'attrType',
-  // If not set, the start date for the generation of random events is set
-  //  by default to the beginning of the previous year to avoid collisions
-  //  with the testing of the Orion Context Broker notifications
-  START_DATE: ENV.START_DATE ? new Date(ENV.START_DATE) :
-    new Date(new Date().getFullYear() - 1, 0),
-  // If not set, the start date for the generation of random events is set
-  //  by default to the end of the previous year to avoid collisions
-  //  with the testing of the Orion Context Broker notifications
-  END_DATE: ENV.END_DATE ? new Date(ENV.END_DATE) :
-    new Date(new Date(new Date().getFullYear(), 0) - 1),
-  MIN_VALUE: ENV.MIN_VALUE || 0,
-  MAX_VALUE: ENV.MAX_VALUE || 100,
-  CLEAN: ENV.CLEAN !== 'false',
-  API_OPERATION: {
-    READ: 'read',
-    NOTIFY: 'notify',
-    ADMIN: {
-      GET_LOG_LEVEL: 'getLogLevel',
-      SET_LOG_LEVEL: 'setLogLevel'
+    SAMPLES: ENV.SAMPLES || 1,
+    EVENT_NOTIFICATION_CONTEXT_ELEMENTS: ENV.EVENT_NOTIFICATION_CONTEXT_ELEMENTS || 3,
+    ENTITY_ID: ENV.ENTITY_ID || 'entityId',
+    ENTITY_TYPE: ENV.ENTITY_TYPE || 'entityType',
+    ATTRIBUTE_NAME: ENV.ATTRIBUTE_NAME || 'attrName',
+    ATTRIBUTE_TYPE: ENV.ATTRIBUTE_TYPE || 'attrType',
+    // If not set, the start date for the generation of random events is set
+    //  by default to the beginning of the previous year to avoid collisions
+    //  with the testing of the Orion Context Broker notifications
+    START_DATE: ENV.START_DATE ? new Date(ENV.START_DATE) : new Date(new Date().getFullYear() - 1, 0),
+    // If not set, the start date for the generation of random events is set
+    //  by default to the end of the previous year to avoid collisions
+    //  with the testing of the Orion Context Broker notifications
+    END_DATE: ENV.END_DATE ? new Date(ENV.END_DATE) : new Date(new Date(new Date().getFullYear(), 0) - 1),
+    MIN_VALUE: ENV.MIN_VALUE || 0,
+    MAX_VALUE: ENV.MAX_VALUE || 100,
+    CLEAN: ENV.CLEAN !== 'false',
+    API_OPERATION: {
+        READ: 'read',
+        NOTIFY: 'notify',
+        ADMIN: {
+            GET_LOG_LEVEL: 'getLogLevel',
+            SET_LOG_LEVEL: 'setLogLevel',
+        },
+        VERSION: 'version',
+        DELETE: 'delete',
     },
-    VERSION: 'version',
-    DELETE: 'delete'
-  },
-  DATA_TYPES: {
-    RAW: 'raw',
-    AGGREGATED: 'aggregated'
-  }
+    DATA_TYPES: {
+        RAW: 'raw',
+        AGGREGATED: 'aggregated',
+    },
 };

--- a/test/unit/sthTestConfiguration.js
+++ b/test/unit/sthTestConfiguration.js
@@ -48,13 +48,13 @@ module.exports = {
         NOTIFY: 'notify',
         ADMIN: {
             GET_LOG_LEVEL: 'getLogLevel',
-            SET_LOG_LEVEL: 'setLogLevel',
+            SET_LOG_LEVEL: 'setLogLevel'
         },
         VERSION: 'version',
-        DELETE: 'delete',
+        DELETE: 'delete'
     },
     DATA_TYPES: {
         RAW: 'raw',
-        AGGREGATED: 'aggregated',
-    },
+        AGGREGATED: 'aggregated'
+    }
 };

--- a/test/unit/sthTestUtils.js
+++ b/test/unit/sthTestUtils.js
@@ -41,7 +41,7 @@ var events = [];
  * @returns {Date} The calculated random date
  */
 function getRandomDate(start, end) {
-  return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+    return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
 }
 
 /**
@@ -52,45 +52,49 @@ function getRandomDate(start, end) {
  * @returns {Object} The created raw event
  */
 function createEvent(attrName, attrType, recvTime) {
-  var theEvent;
-  var attrValue = attrType !== 'string' ? (Math.random() *
-  (parseFloat(sthTestConfig.MAX_VALUE) - parseFloat(sthTestConfig.MIN_VALUE)) -
-  Math.abs(parseFloat(sthTestConfig.MIN_VALUE))).toFixed(2) : 'just a string';
-  switch (sthConfig.DATA_MODEL) {
-    case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
-      theEvent = {
-        recvTime: recvTime,
-        entityId: sthTestConfig.ENTITY_ID,
-        entityType: sthTestConfig.ENTITY_TYPE,
-        attrName: attrName,
-        attrType: attrType,
-        attrValue: attrValue
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
-      theEvent = {
-        recvTime: recvTime,
-        attrName: attrName,
-        attrType: attrType,
-        attrValue: attrValue
-      };
-      break;
-    case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
-      theEvent = {
-        recvTime: recvTime,
-        // This property is not really stored for the collections per attribute model.
-        //  It is included just to ease its recovery
-        attrName: attrName,
-        attrType: attrType,
-        attrValue: attrValue
-      };
-      break;
-  }
-  return theEvent;
+    var theEvent;
+    var attrValue =
+        attrType !== 'string'
+            ? (
+                  Math.random() * (parseFloat(sthTestConfig.MAX_VALUE) - parseFloat(sthTestConfig.MIN_VALUE)) -
+                  Math.abs(parseFloat(sthTestConfig.MIN_VALUE))
+              ).toFixed(2)
+            : 'just a string';
+    switch (sthConfig.DATA_MODEL) {
+        case sthConfig.DATA_MODELS.COLLECTION_PER_SERVICE_PATH:
+            theEvent = {
+                recvTime: recvTime,
+                entityId: sthTestConfig.ENTITY_ID,
+                entityType: sthTestConfig.ENTITY_TYPE,
+                attrName: attrName,
+                attrType: attrType,
+                attrValue: attrValue,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
+            theEvent = {
+                recvTime: recvTime,
+                attrName: attrName,
+                attrType: attrType,
+                attrValue: attrValue,
+            };
+            break;
+        case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
+            theEvent = {
+                recvTime: recvTime,
+                // This property is not really stored for the collections per attribute model.
+                //  It is included just to ease its recovery
+                attrName: attrName,
+                attrType: attrType,
+                attrValue: attrValue,
+            };
+            break;
+    }
+    return theEvent;
 }
 
 function cleanEvents() {
-  events = [];
+    events = [];
 }
 
 /**
@@ -99,10 +103,10 @@ function cleanEvents() {
  * @returns {number} The day of the year (a number between 1 and 366)
  */
 function getDayOfYear(date) {
-  var start = new Date(date.getFullYear(), 0, 0);
-  var diff = date - start;
-  var oneDay = 1000 * 60 * 60 * 24;
-  return Math.ceil(diff / oneDay);
+    var start = new Date(date.getFullYear(), 0, 0);
+    var diff = date - start;
+    var oneDay = 1000 * 60 * 60 * 24;
+    return Math.ceil(diff / oneDay);
 }
 
 /**
@@ -112,69 +116,71 @@ function getDayOfYear(date) {
  * @param {Function} done The mocha done() callback function
  */
 function addEventTest(anEvent, includeTimeInstantMetadata, done) {
-  // Check if the collection exists
-  sthDatabase.getCollection(
-    {
-      service: sthConfig.DEFAULT_SERVICE,
-      servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-      entityId: sthTestConfig.ENTITY_ID,
-      entityType: sthTestConfig.ENTITY_TYPE,
-      attrName: anEvent.attrName
-    },
-    {
-      isAggregated: false,
-      shouldCreate: true,
-      shouldTruncate: true
-    },
-    function (err, collection) {
-      if (err) {
-        done(err);
-      } else {
-        if (includeTimeInstantMetadata) {
-          sthDatabase.storeRawData(
-            {
-              collection: collection,
-              recvTime: null,
-              entityId: sthTestConfig.ENTITY_ID,
-              entityType: sthTestConfig.ENTITY_TYPE,
-              attribute: {
-                name: anEvent.attrName,
-                type: anEvent.attrType,
-                value: anEvent.attrValue,
-                metadatas: [
-                  {
-                    name: 'TimeInstant',
-                    type: 'ISO8601',
-                    value: anEvent.recvTime
-                  }
-                ]
-              },
-              notificationInfo: {
-                inserts: true
-              }
-            },
-            done);
-        } else {
-          sthDatabase.storeRawData(
-            {
-              collection: collection,
-              recvTime: anEvent.recvTime,
-              entityId: sthTestConfig.ENTITY_ID,
-              entityType: sthTestConfig.ENTITY_TYPE,
-              attribute: {
-                name: anEvent.attrName,
-                type: anEvent.attrType,
-                value: anEvent.attrValue
-              },
-              notificationInfo: {
-                inserts: true
-              }
-            },
-            done);
+    // Check if the collection exists
+    sthDatabase.getCollection(
+        {
+            service: sthConfig.DEFAULT_SERVICE,
+            servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+            entityId: sthTestConfig.ENTITY_ID,
+            entityType: sthTestConfig.ENTITY_TYPE,
+            attrName: anEvent.attrName,
+        },
+        {
+            isAggregated: false,
+            shouldCreate: true,
+            shouldTruncate: true,
+        },
+        function(err, collection) {
+            if (err) {
+                done(err);
+            } else {
+                if (includeTimeInstantMetadata) {
+                    sthDatabase.storeRawData(
+                        {
+                            collection: collection,
+                            recvTime: null,
+                            entityId: sthTestConfig.ENTITY_ID,
+                            entityType: sthTestConfig.ENTITY_TYPE,
+                            attribute: {
+                                name: anEvent.attrName,
+                                type: anEvent.attrType,
+                                value: anEvent.attrValue,
+                                metadatas: [
+                                    {
+                                        name: 'TimeInstant',
+                                        type: 'ISO8601',
+                                        value: anEvent.recvTime,
+                                    },
+                                ],
+                            },
+                            notificationInfo: {
+                                inserts: true,
+                            },
+                        },
+                        done
+                    );
+                } else {
+                    sthDatabase.storeRawData(
+                        {
+                            collection: collection,
+                            recvTime: anEvent.recvTime,
+                            entityId: sthTestConfig.ENTITY_ID,
+                            entityType: sthTestConfig.ENTITY_TYPE,
+                            attribute: {
+                                name: anEvent.attrName,
+                                type: anEvent.attrType,
+                                value: anEvent.attrValue,
+                            },
+                            notificationInfo: {
+                                inserts: true,
+                            },
+                        },
+                        done
+                    );
+                }
+            }
         }
-      }
-    }
-  );
+    );
 }
 
 /**
@@ -184,116 +190,116 @@ function addEventTest(anEvent, includeTimeInstantMetadata, done) {
  * @param {Function} done The mocha done() callback function
  */
 function addAggregatedDataTest(anEvent, done) {
-  var counter = 0;
-  var callback = function (err) {
-    if (err) {
-      done(err);
-    }
-    if (++counter === 5) {
-      done();
-    }
-  };
-  // Check if the collection exists
-  sthDatabase.getCollection(
-    {
-      service: sthConfig.DEFAULT_SERVICE,
-      servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-      entityId: sthTestConfig.ENTITY_ID,
-      entityType: sthTestConfig.ENTITY_TYPE,
-      attrName: anEvent.attrName
-    },
-    {
-      isAggregated: true,
-      shouldCreate: true,
-      shouldTruncate: true
-    },
-    function (err, collection) {
-      if (err) {
-        done(err);
-      } else {
-        sthDatabase.storeAggregatedData4Resolution(
-          {
-            collection: collection,
+    var counter = 0;
+    var callback = function(err) {
+        if (err) {
+            done(err);
+        }
+        if (++counter === 5) {
+            done();
+        }
+    };
+    // Check if the collection exists
+    sthDatabase.getCollection(
+        {
+            service: sthConfig.DEFAULT_SERVICE,
+            servicePath: sthConfig.DEFAULT_SERVICE_PATH,
             entityId: sthTestConfig.ENTITY_ID,
             entityType: sthTestConfig.ENTITY_TYPE,
             attrName: anEvent.attrName,
-            attrType: anEvent.attrType,
-            attrValue: anEvent.attrValue,
-            resolution: sthConfig.RESOLUTION.SECOND,
-            timestamp: anEvent.recvTime,
-            notificationInfo: {
-              inserts: true
+        },
+        {
+            isAggregated: true,
+            shouldCreate: true,
+            shouldTruncate: true,
+        },
+        function(err, collection) {
+            if (err) {
+                done(err);
+            } else {
+                sthDatabase.storeAggregatedData4Resolution(
+                    {
+                        collection: collection,
+                        entityId: sthTestConfig.ENTITY_ID,
+                        entityType: sthTestConfig.ENTITY_TYPE,
+                        attrName: anEvent.attrName,
+                        attrType: anEvent.attrType,
+                        attrValue: anEvent.attrValue,
+                        resolution: sthConfig.RESOLUTION.SECOND,
+                        timestamp: anEvent.recvTime,
+                        notificationInfo: {
+                            inserts: true,
+                        },
+                    },
+                    callback
+                );
+                sthDatabase.storeAggregatedData4Resolution(
+                    {
+                        collection: collection,
+                        entityId: sthTestConfig.ENTITY_ID,
+                        entityType: sthTestConfig.ENTITY_TYPE,
+                        attrName: anEvent.attrName,
+                        attrType: anEvent.attrType,
+                        attrValue: anEvent.attrValue,
+                        resolution: sthConfig.RESOLUTION.MINUTE,
+                        timestamp: anEvent.recvTime,
+                        notificationInfo: {
+                            inserts: true,
+                        },
+                    },
+                    callback
+                );
+                sthDatabase.storeAggregatedData4Resolution(
+                    {
+                        collection: collection,
+                        entityId: sthTestConfig.ENTITY_ID,
+                        entityType: sthTestConfig.ENTITY_TYPE,
+                        attrName: anEvent.attrName,
+                        attrType: anEvent.attrType,
+                        attrValue: anEvent.attrValue,
+                        resolution: sthConfig.RESOLUTION.HOUR,
+                        timestamp: anEvent.recvTime,
+                        notificationInfo: {
+                            inserts: true,
+                        },
+                    },
+                    callback
+                );
+                sthDatabase.storeAggregatedData4Resolution(
+                    {
+                        collection: collection,
+                        entityId: sthTestConfig.ENTITY_ID,
+                        entityType: sthTestConfig.ENTITY_TYPE,
+                        attrName: anEvent.attrName,
+                        attrType: anEvent.attrType,
+                        attrValue: anEvent.attrValue,
+                        resolution: sthConfig.RESOLUTION.DAY,
+                        timestamp: anEvent.recvTime,
+                        notificationInfo: {
+                            inserts: true,
+                        },
+                    },
+                    callback
+                );
+                sthDatabase.storeAggregatedData4Resolution(
+                    {
+                        collection: collection,
+                        entityId: sthTestConfig.ENTITY_ID,
+                        entityType: sthTestConfig.ENTITY_TYPE,
+                        attrName: anEvent.attrName,
+                        attrType: anEvent.attrType,
+                        attrValue: anEvent.attrValue,
+                        resolution: sthConfig.RESOLUTION.MONTH,
+                        timestamp: anEvent.recvTime,
+                        notificationInfo: {
+                            inserts: true,
+                        },
+                    },
+                    callback
+                );
             }
-          },
-          callback
-        );
-        sthDatabase.storeAggregatedData4Resolution(
-          {
-            collection: collection,
-            entityId: sthTestConfig.ENTITY_ID,
-            entityType: sthTestConfig.ENTITY_TYPE,
-            attrName: anEvent.attrName,
-            attrType: anEvent.attrType,
-            attrValue: anEvent.attrValue,
-            resolution: sthConfig.RESOLUTION.MINUTE,
-            timestamp: anEvent.recvTime,
-            notificationInfo: {
-              inserts: true
-            }
-          },
-          callback
-        );
-        sthDatabase.storeAggregatedData4Resolution(
-          {
-            collection: collection,
-            entityId: sthTestConfig.ENTITY_ID,
-            entityType: sthTestConfig.ENTITY_TYPE,
-            attrName: anEvent.attrName,
-            attrType: anEvent.attrType,
-            attrValue: anEvent.attrValue,
-            resolution: sthConfig.RESOLUTION.HOUR,
-            timestamp: anEvent.recvTime,
-            notificationInfo: {
-              inserts: true
-            }
-          },
-          callback
-        );
-        sthDatabase.storeAggregatedData4Resolution(
-          {
-            collection: collection,
-            entityId: sthTestConfig.ENTITY_ID,
-            entityType: sthTestConfig.ENTITY_TYPE,
-            attrName: anEvent.attrName,
-            attrType: anEvent.attrType,
-            attrValue: anEvent.attrValue,
-            resolution: sthConfig.RESOLUTION.DAY,
-            timestamp: anEvent.recvTime,
-            notificationInfo: {
-              inserts: true
-            }
-          },
-          callback
-        );
-        sthDatabase.storeAggregatedData4Resolution(
-          {
-            collection: collection,
-            entityId: sthTestConfig.ENTITY_ID,
-            entityType: sthTestConfig.ENTITY_TYPE,
-            attrName: anEvent.attrName,
-            attrType: anEvent.attrType,
-            attrValue: anEvent.attrValue,
-            resolution: sthConfig.RESOLUTION.MONTH,
-            timestamp: anEvent.recvTime,
-            notificationInfo: {
-              inserts: true
-            }
-          },
-          callback
-        );
-      }
-    }
-  );
+        }
+    );
 }
 
 /**
@@ -303,27 +309,26 @@ function addAggregatedDataTest(anEvent, done) {
  * @param {boolean} includeTimeInstantMetadata The test case should include a TimeInstant metadata
  */
 function eachEventTestSuite(attrName, attrType, includeTimeInstantMetadata) {
-  var anEvent;
+    var anEvent;
 
-  before(function () {
-    if (events.length === sthTestConfig.SAMPLES) {
-      cleanEvents();
-    }
-    anEvent = events[0] || createEvent(
-        attrName, attrType, getRandomDate(sthTestConfig.START_DATE, sthTestConfig.END_DATE));
-    events.push(anEvent);
-    console.log('New event: %s', JSON.stringify(anEvent));
-  });
+    before(function() {
+        if (events.length === sthTestConfig.SAMPLES) {
+            cleanEvents();
+        }
+        anEvent =
+            events[0] ||
+            createEvent(attrName, attrType, getRandomDate(sthTestConfig.START_DATE, sthTestConfig.END_DATE));
+        events.push(anEvent);
+        console.log('New event: %s', JSON.stringify(anEvent));
+    });
 
-  it('should store the single event', function (done) {
-    addEventTest(anEvent, includeTimeInstantMetadata, done);
-  });
+    it('should store the single event', function(done) {
+        addEventTest(anEvent, includeTimeInstantMetadata, done);
+    });
 
-  it('should store aggregated data for each resolution',
-    function (done) {
-      addAggregatedDataTest(anEvent, done);
-    }
-  );
+    it('should store aggregated data for each resolution', function(done) {
+        addAggregatedDataTest(anEvent, done);
+    });
 }
 
 /**
@@ -331,22 +336,20 @@ function eachEventTestSuite(attrName, attrType, includeTimeInstantMetadata) {
  * @param {Function} done The mocha done() callback function
  */
 function dropRawEventCollectionTest(done) {
-  var collectionName4Events = sthDatabaseNaming.getRawCollectionName(
-    {
-      service: sthConfig.DEFAULT_SERVICE,
-      servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-      entityId: sthTestConfig.ENTITY_ID,
-      entityType: sthTestConfig.ENTITY_TYPE,
-      attrName: sthTestConfig.ATTRIBUTE_NAME
-    }
-  );
-  console.log(collectionName4Events);
-  sthDatabase.connection.dropCollection(collectionName4Events, function (err) {
-    if (err && err.message === 'ns not found') {
-      err = null;
-    }
-    return done(err);
-  });
+    var collectionName4Events = sthDatabaseNaming.getRawCollectionName({
+        service: sthConfig.DEFAULT_SERVICE,
+        servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+        entityId: sthTestConfig.ENTITY_ID,
+        entityType: sthTestConfig.ENTITY_TYPE,
+        attrName: sthTestConfig.ATTRIBUTE_NAME,
+    });
+    console.log(collectionName4Events);
+    sthDatabase.connection.dropCollection(collectionName4Events, function(err) {
+        if (err && err.message === 'ns not found') {
+            err = null;
+        }
+        return done(err);
+    });
 }
 
 /**
@@ -354,21 +357,19 @@ function dropRawEventCollectionTest(done) {
  * @param {Function} done The mocha done() callback function
  */
 function dropAggregatedDataCollectionTest(done) {
-  var collectionName4Aggregated = sthDatabaseNaming.getAggregatedCollectionName(
-    {
-      service: sthConfig.DEFAULT_SERVICE,
-      servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-      entityId: sthTestConfig.ENTITY_ID,
-      entityType: sthTestConfig.ENTITY_TYPE,
-      attrName: sthTestConfig.ATTRIBUTE_NAME
-    }
-  );
-  sthDatabase.connection.dropCollection(collectionName4Aggregated, function (err) {
-    if (err && err.message === 'ns not found') {
-      err = null;
-    }
-    return done(err);
-  });
+    var collectionName4Aggregated = sthDatabaseNaming.getAggregatedCollectionName({
+        service: sthConfig.DEFAULT_SERVICE,
+        servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+        entityId: sthTestConfig.ENTITY_ID,
+        entityType: sthTestConfig.ENTITY_TYPE,
+        attrName: sthTestConfig.ATTRIBUTE_NAME,
+    });
+    sthDatabase.connection.dropCollection(collectionName4Aggregated, function(err) {
+        if (err && err.message === 'ns not found') {
+            err = null;
+        }
+        return done(err);
+    });
 }
 
 /**
@@ -381,93 +382,98 @@ function dropAggregatedDataCollectionTest(done) {
  * @returns {string}
  */
 function getURL(type, options, attrName) {
-  var url = 'http://' + sthConfig.STH_HOST + ':' + sthConfig.STH_PORT,
-    isParams = false;
+    var url = 'http://' + sthConfig.STH_HOST + ':' + sthConfig.STH_PORT,
+        isParams = false;
 
-  function getQuerySeparator() {
-    var separator;
-    if (!isParams) {
-      separator = '?';
-      isParams = true;
-    } else {
-      separator = '&';
+    function getQuerySeparator() {
+        var separator;
+        if (!isParams) {
+            separator = '?';
+            isParams = true;
+        } else {
+            separator = '&';
+        }
+        return separator;
     }
-    return separator;
-  }
 
-  switch (type) {
-    case sthTestConfig.API_OPERATION.READ:
-      if (options && options.invalidPath) {
-        url += '/this/is/an/invalid/path';
-      } else {
-        url += '/STH/v1/contextEntities/type/' +
-          ((options && options.changeEntityCase) ?
-            sthTestConfig.ENTITY_TYPE.toLowerCase() : sthTestConfig.ENTITY_TYPE) +
-          '/id/' + ((options && options.changeEntityCase) ?
-            sthTestConfig.ENTITY_ID.toLowerCase() : sthTestConfig.ENTITY_ID) +
-          '/attributes/' + attrName || sthTestConfig.ATTRIBUTE_NAME;
-      }
-      if (options && (options.lastN || options.lastN === 0)) {
-        url += (getQuerySeparator() + 'lastN=' + options.lastN);
-      }
-      if (options && (options.hLimit || options.hLimit === 0)) {
-        url += (getQuerySeparator() + 'hLimit=' + options.hLimit);
-      }
-      if (options && (options.hOffset || options.hOffset === 0)) {
-        url += (getQuerySeparator() + 'hOffset=' + options.hOffset);
-      }
-      if (options && options.aggrMethod) {
-        url += (getQuerySeparator() + 'aggrMethod=' + options.aggrMethod);
-      }
-      if (options && options.aggrPeriod) {
-        url += (getQuerySeparator() + 'aggrPeriod=' + options.aggrPeriod);
-      }
-      if (options && options.dateFrom) {
-        url += (getQuerySeparator() + 'dateFrom=' + options.dateFrom);
-      }
-      if (options && options.dateTo) {
-        url += (getQuerySeparator() + 'dateTo=' + options.dateTo);
-      }
-      if (options && options.count) {
-        url += (getQuerySeparator() + 'count=' + options.count);
-      }
-      break;
-    case sthTestConfig.API_OPERATION.NOTIFY:
-      if (options && options.invalidPath) {
-        url += '/invalidNotificationPath';
-      } else {
-        url += '/notify';
-      }
-      break;
-    case sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL:
-      url += '/admin/log';
-      if (options && options.level) {
-        url += '?level=' + options.level;
-      }
-      break;
-    case sthTestConfig.API_OPERATION.ADMIN.GET_LOG_LEVEL:
-      url += '/admin/log';
-      break;
-    case sthTestConfig.API_OPERATION.VERSION:
-      if (options && options.invalidPath) {
-        url += '/invalidVersionPath';
-      } else {
-        url += '/version';
-      }
-      break;
-    case sthTestConfig.API_OPERATION.DELETE:
-      url += '/STH/v1/contextEntities';
-      if (options && options.entityType) {
-        url += '/type/' + options.entityType;
-      }
-      if (options && options.entityId) {
-        url += '/id/' + options.entityId;
-      }
-      if (options && options.attrName) {
-        url += '/attributes/' + options.attrName;
-      }
-  }
-  return url;
+    switch (type) {
+        case sthTestConfig.API_OPERATION.READ:
+            if (options && options.invalidPath) {
+                url += '/this/is/an/invalid/path';
+            } else {
+                url +=
+                    '/STH/v1/contextEntities/type/' +
+                        (options && options.changeEntityCase
+                            ? sthTestConfig.ENTITY_TYPE.toLowerCase()
+                            : sthTestConfig.ENTITY_TYPE) +
+                        '/id/' +
+                        (options && options.changeEntityCase
+                            ? sthTestConfig.ENTITY_ID.toLowerCase()
+                            : sthTestConfig.ENTITY_ID) +
+                        '/attributes/' +
+                        attrName || sthTestConfig.ATTRIBUTE_NAME;
+            }
+            if (options && (options.lastN || options.lastN === 0)) {
+                url += getQuerySeparator() + 'lastN=' + options.lastN;
+            }
+            if (options && (options.hLimit || options.hLimit === 0)) {
+                url += getQuerySeparator() + 'hLimit=' + options.hLimit;
+            }
+            if (options && (options.hOffset || options.hOffset === 0)) {
+                url += getQuerySeparator() + 'hOffset=' + options.hOffset;
+            }
+            if (options && options.aggrMethod) {
+                url += getQuerySeparator() + 'aggrMethod=' + options.aggrMethod;
+            }
+            if (options && options.aggrPeriod) {
+                url += getQuerySeparator() + 'aggrPeriod=' + options.aggrPeriod;
+            }
+            if (options && options.dateFrom) {
+                url += getQuerySeparator() + 'dateFrom=' + options.dateFrom;
+            }
+            if (options && options.dateTo) {
+                url += getQuerySeparator() + 'dateTo=' + options.dateTo;
+            }
+            if (options && options.count) {
+                url += getQuerySeparator() + 'count=' + options.count;
+            }
+            break;
+        case sthTestConfig.API_OPERATION.NOTIFY:
+            if (options && options.invalidPath) {
+                url += '/invalidNotificationPath';
+            } else {
+                url += '/notify';
+            }
+            break;
+        case sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL:
+            url += '/admin/log';
+            if (options && options.level) {
+                url += '?level=' + options.level;
+            }
+            break;
+        case sthTestConfig.API_OPERATION.ADMIN.GET_LOG_LEVEL:
+            url += '/admin/log';
+            break;
+        case sthTestConfig.API_OPERATION.VERSION:
+            if (options && options.invalidPath) {
+                url += '/invalidVersionPath';
+            } else {
+                url += '/version';
+            }
+            break;
+        case sthTestConfig.API_OPERATION.DELETE:
+            url += '/STH/v1/contextEntities';
+            if (options && options.entityType) {
+                url += '/type/' + options.entityType;
+            }
+            if (options && options.entityId) {
+                url += '/id/' + options.entityId;
+            }
+            if (options && options.attrName) {
+                url += '/attributes/' + options.attrName;
+            }
+    }
+    return url;
 }
 
 /**
@@ -481,32 +487,36 @@ function getURL(type, options, attrName) {
  * @param {Function} done The mocha done() callback function
  */
 function noRawDataIfEntityCaseChange(params, done) {
-  var service = params.service,
-      servicePath = params.servicePath,
-      attrName = params.attrName,
-      options = params.options;
+    var service = params.service,
+        servicePath = params.servicePath,
+        attrName = params.attrName,
+        options = params.options;
 
-  options.changeEntityCase = true;
+    options.changeEntityCase = true;
 
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.READ, options, attrName),
-    method: 'GET',
-    headers: {
-      'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
-      attrName || sthTestConfig.ATTRIBUTE_NAME);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done();
-  });
+    request(
+        {
+            uri: getURL(sthTestConfig.API_OPERATION.READ, options, attrName),
+            method: 'GET',
+            headers: {
+                'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
+                attrName || sthTestConfig.ATTRIBUTE_NAME
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done();
+        }
+    );
 }
 
 /**
@@ -521,44 +531,53 @@ function noRawDataIfEntityCaseChange(params, done) {
  * @param {Function} done The mocha done() callback function
  */
 function rawDataAvailableDateFilter(params, done) {
-  var service = params.service,
-    servicePath = params.servicePath,
-    attrName = params.attrName,
-    options = params.options,
-    checkRecvTime = params.checkRecvTime;
+    var service = params.service,
+        servicePath = params.servicePath,
+        attrName = params.attrName,
+        options = params.options,
+        checkRecvTime = params.checkRecvTime;
 
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.READ, options, attrName),
-    method: 'GET',
-    headers: {
-      'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    if (options && options.count) {
-      // Check fiware-total-count header
-      expect(response.headers['fiware-total-count']).to.not.be(undefined);
-    }
-    expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
-    expect(bodyJSON.contextResponses[0].contextElement.isPattern).to.equal(false);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
-      attrName || sthTestConfig.ATTRIBUTE_NAME);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(
-      options.lastN ? events.length : 1);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[options.lastN ? events.length - 1 : 0].
-      attrValue).to.equal(events[events.length - 1].attrValue);
-    if (checkRecvTime) {
-      expect(bodyJSON.contextResponses[0].contextElement.attributes[0].
-        values[options.lastN ? events.length - 1 : 0].recvTime).to.equal(
-        sthUtils.getISODateString(events[events.length - 1].recvTime));
-    }
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done();
-  });
+    request(
+        {
+            uri: getURL(sthTestConfig.API_OPERATION.READ, options, attrName),
+            method: 'GET',
+            headers: {
+                'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            if (options && options.count) {
+                // Check fiware-total-count header
+                expect(response.headers['fiware-total-count']).to.not.be(undefined);
+            }
+            expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
+            expect(bodyJSON.contextResponses[0].contextElement.isPattern).to.equal(false);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
+                attrName || sthTestConfig.ATTRIBUTE_NAME
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(
+                options.lastN ? events.length : 1
+            );
+            expect(
+                bodyJSON.contextResponses[0].contextElement.attributes[0].values[options.lastN ? events.length - 1 : 0]
+                    .attrValue
+            ).to.equal(events[events.length - 1].attrValue);
+            if (checkRecvTime) {
+                expect(
+                    bodyJSON.contextResponses[0].contextElement.attributes[0].values[
+                        options.lastN ? events.length - 1 : 0
+                    ].recvTime
+                ).to.equal(sthUtils.getISODateString(events[events.length - 1].recvTime));
+            }
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done();
+        }
+    );
 }
 
 /**
@@ -574,38 +593,43 @@ function rawDataAvailableDateFilter(params, done) {
  * @param {string} done The mocha done() callback function
  */
 function noAggregatedDataIfEntityCaseChangeTest(params, done) {
-  var service = params.service,
-    servicePath = params.servicePath,
-    attrName = params.attrName,
-    aggrMethod = params.aggrMethod,
-    resolution = params.resolution;
+    var service = params.service,
+        servicePath = params.servicePath,
+        attrName = params.attrName,
+        aggrMethod = params.aggrMethod,
+        resolution = params.resolution;
 
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.READ,
-      {
-        aggrMethod: aggrMethod,
-        aggrPeriod: resolution,
-        changeEntityCase: true
-      },
-      attrName
-    ),
-    method: 'GET',
-    headers: {
-      'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
-      attrName || sthTestConfig.ATTRIBUTE_NAME);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done();
-  });
+    request(
+        {
+            uri: getURL(
+                sthTestConfig.API_OPERATION.READ,
+                {
+                    aggrMethod: aggrMethod,
+                    aggrPeriod: resolution,
+                    changeEntityCase: true,
+                },
+                attrName
+            ),
+            method: 'GET',
+            headers: {
+                'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
+                attrName || sthTestConfig.ATTRIBUTE_NAME
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done();
+        }
+    );
 }
 
 /**
@@ -621,68 +645,71 @@ function noAggregatedDataIfEntityCaseChangeTest(params, done) {
  * @param {string} done The mocha done() callback function
  */
 function noAggregatedDataSinceDateTest(params, done) {
-  var service = params.service,
-    servicePath = params.servicePath,
-    attrName = params.attrName,
-    aggrMethod = params.aggrMethod,
-    resolution = params.resolution;
+    var service = params.service,
+        servicePath = params.servicePath,
+        attrName = params.attrName,
+        aggrMethod = params.aggrMethod,
+        resolution = params.resolution;
 
-  var offset;
-  switch (resolution) {
-    case 'second':
-      // 1 minute offset
-      offset = 60 * 1000;
-      break;
-    case 'minute':
-      // 1 hour offset
-      offset = 60 * 60 * 1000;
-      break;
-    case 'hour':
-      // 1 day offset
-      offset = 24 * 60 * 60 * 1000;
-      break;
-    case 'day':
-      // 1 month  offset
-      offset = 31 * 24 * 60 * 60 * 1000;
-      break;
-    case 'month':
-      // 1 year  offset
-      offset = 365 * 31 * 24 * 60 * 60 * 1000;
-      break;
-  }
-
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.READ,
-      {
-        aggrMethod: aggrMethod,
-        aggrPeriod: resolution,
-        dateFrom: sthUtils.getISODateString(
-          sthUtils.getOrigin(
-            new Date(
-              events[events.length - 1].recvTime.getTime() + offset),
-            resolution))
-      },
-      attrName
-    ),
-    method: 'GET',
-    headers: {
-      'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
+    var offset;
+    switch (resolution) {
+        case 'second':
+            // 1 minute offset
+            offset = 60 * 1000;
+            break;
+        case 'minute':
+            // 1 hour offset
+            offset = 60 * 60 * 1000;
+            break;
+        case 'hour':
+            // 1 day offset
+            offset = 24 * 60 * 60 * 1000;
+            break;
+        case 'day':
+            // 1 month  offset
+            offset = 31 * 24 * 60 * 60 * 1000;
+            break;
+        case 'month':
+            // 1 year  offset
+            offset = 365 * 31 * 24 * 60 * 60 * 1000;
+            break;
     }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
-    expect(bodyJSON.contextResponses[0].contextElement.isPattern).to.equal(false);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
-      attrName || sthTestConfig.ATTRIBUTE_NAME);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done();
-  });
+
+    request(
+        {
+            uri: getURL(
+                sthTestConfig.API_OPERATION.READ,
+                {
+                    aggrMethod: aggrMethod,
+                    aggrPeriod: resolution,
+                    dateFrom: sthUtils.getISODateString(
+                        sthUtils.getOrigin(new Date(events[events.length - 1].recvTime.getTime() + offset), resolution)
+                    ),
+                },
+                attrName
+            ),
+            method: 'GET',
+            headers: {
+                'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
+            expect(bodyJSON.contextResponses[0].contextElement.isPattern).to.equal(false);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
+                attrName || sthTestConfig.ATTRIBUTE_NAME
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done();
+        }
+    );
 }
 
 /**
@@ -698,102 +725,117 @@ function noAggregatedDataSinceDateTest(params, done) {
  * @param {Function} done The mocha done() callback function
  */
 function aggregatedDataAvailableSinceDateTest(params, done) {
-  var service = params.service,
-    servicePath = params.servicePath,
-    attrName = params.attrName,
-    attrType = params.attrType,
-    aggrMethod = params.aggrMethod,
-    resolution = params.resolution;
+    var service = params.service,
+        servicePath = params.servicePath,
+        attrName = params.attrName,
+        attrType = params.attrType,
+        aggrMethod = params.aggrMethod,
+        resolution = params.resolution;
 
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.READ,
-      {
-        aggrMethod: aggrMethod,
-        aggrPeriod: resolution,
-        dateFrom: sthUtils.getISODateString(
-          sthUtils.getOrigin(
-            events[events.length - 1].recvTime,
-            resolution))
-      },
-      attrName
-    ),
-    method: 'GET',
-    headers: {
-      'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var theEvent = events[events.length - 1];
-    var index, entries;
-    switch (resolution) {
-      case 'second':
-        index = theEvent.recvTime.getUTCSeconds();
-        entries = 60;
-        break;
-      case 'minute':
-        index = theEvent.recvTime.getUTCMinutes();
-        entries = 60;
-        break;
-      case 'hour':
-        index = theEvent.recvTime.getUTCHours();
-        entries = 24;
-        break;
-      case 'day':
-        index = theEvent.recvTime.getUTCDate() - 1;
-        entries = 31;
-        break;
-      case 'month':
-        index = theEvent.recvTime.getUTCMonth();
-        entries = 12;
-        break;
-    }
-    var bodyJSON = JSON.parse(body);
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
-    expect(bodyJSON.contextResponses[0].contextElement.isPattern).to.equal(false);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
-      attrName || sthTestConfig.ATTRIBUTE_NAME);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.resolution).to.equal(resolution);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.origin).to.be(
-      sthUtils.getISODateString(
-        sthUtils.getOrigin(
-          theEvent.recvTime,
-          resolution
-        )
-      )
+    request(
+        {
+            uri: getURL(
+                sthTestConfig.API_OPERATION.READ,
+                {
+                    aggrMethod: aggrMethod,
+                    aggrPeriod: resolution,
+                    dateFrom: sthUtils.getISODateString(
+                        sthUtils.getOrigin(events[events.length - 1].recvTime, resolution)
+                    ),
+                },
+                attrName
+            ),
+            method: 'GET',
+            headers: {
+                'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var theEvent = events[events.length - 1];
+            var index, entries;
+            switch (resolution) {
+                case 'second':
+                    index = theEvent.recvTime.getUTCSeconds();
+                    entries = 60;
+                    break;
+                case 'minute':
+                    index = theEvent.recvTime.getUTCMinutes();
+                    entries = 60;
+                    break;
+                case 'hour':
+                    index = theEvent.recvTime.getUTCHours();
+                    entries = 24;
+                    break;
+                case 'day':
+                    index = theEvent.recvTime.getUTCDate() - 1;
+                    entries = 31;
+                    break;
+                case 'month':
+                    index = theEvent.recvTime.getUTCMonth();
+                    entries = 12;
+                    break;
+            }
+            var bodyJSON = JSON.parse(body);
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
+            expect(bodyJSON.contextResponses[0].contextElement.isPattern).to.equal(false);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].name).to.equal(
+                attrName || sthTestConfig.ATTRIBUTE_NAME
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.resolution).to.equal(
+                resolution
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.origin).to.be(
+                sthUtils.getISODateString(sthUtils.getOrigin(theEvent.recvTime, resolution))
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points.length).to.equal(
+                sthConfig.FILTER_OUT_EMPTY ? 1 : entries
+            );
+            expect(
+                bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[
+                    sthConfig.FILTER_OUT_EMPTY ? 0 : index
+                ].samples
+            ).to.equal(events.length);
+            var value;
+            switch (aggrMethod) {
+                case 'min':
+                case 'max':
+                    value = parseFloat(theEvent.attrValue).toFixed(2);
+                    break;
+                case 'sum':
+                    value = (events.length * parseFloat(theEvent.attrValue)).toFixed(2);
+                    break;
+                case 'sum2':
+                    value = (events.length * Math.pow(parseFloat(theEvent.attrValue), 2)).toFixed(2);
+                    break;
+                case 'occur':
+                    value = events.length;
+                    break;
+            }
+            if (attrType === 'float') {
+                expect(
+                    parseFloat(
+                        bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[
+                            sthConfig.FILTER_OUT_EMPTY ? 0 : index
+                        ][aggrMethod]
+                    ).toFixed(2)
+                ).to.equal(value);
+            } else if (attrType === 'string') {
+                expect(
+                    parseFloat(
+                        bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[
+                            sthConfig.FILTER_OUT_EMPTY ? 0 : index
+                        ][aggrMethod]['just a string']
+                    )
+                ).to.equal(value);
+            }
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done();
+        }
     );
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].
-      points.length).to.equal(sthConfig.FILTER_OUT_EMPTY ? 1 : entries);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].
-      points[sthConfig.FILTER_OUT_EMPTY ? 0 : index].samples).to.equal(events.length);
-    var value;
-    switch (aggrMethod) {
-      case 'min':
-      case 'max':
-        value = parseFloat(theEvent.attrValue).toFixed(2);
-        break;
-      case 'sum':
-        value = (events.length * parseFloat(theEvent.attrValue)).toFixed(2);
-        break;
-      case 'sum2':
-        value = ((events.length) * (Math.pow(parseFloat(theEvent.attrValue), 2))).toFixed(2);
-        break;
-      case 'occur':
-        value = events.length;
-        break;
-    }
-    if (attrType === 'float') {
-      expect(parseFloat(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].
-        points[sthConfig.FILTER_OUT_EMPTY ? 0 : index][aggrMethod]).toFixed(2)).to.equal(value);
-    } else if (attrType === 'string') {
-      expect(parseFloat(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].
-        points[sthConfig.FILTER_OUT_EMPTY ? 0 : index][aggrMethod]['just a string'])).to.equal(value);
-    }
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done();
-  });
 }
 
 /**
@@ -805,98 +847,88 @@ function aggregatedDataAvailableSinceDateTest(params, done) {
  * @param {boolean} checkRecvTime Flag indicating if the recvTime should be checked
  */
 function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
-  describe('should respond', function () {
-    var optionsForCaseSensitivity = {},
-      optionsWithNoDates = {},
-      optionsWithDateFrom = {},
-      optionsWithDateTo = {},
-      optionsWithFromAndToDate = {};
+    describe('should respond', function() {
+        var optionsForCaseSensitivity = {},
+            optionsWithNoDates = {},
+            optionsWithDateFrom = {},
+            optionsWithDateTo = {},
+            optionsWithFromAndToDate = {};
 
-    before(function () {
-      for (var prop in options) {
-        optionsForCaseSensitivity[prop] = options[prop];
-        optionsWithNoDates[prop] = options[prop];
-        optionsWithDateFrom[prop] = options[prop];
-        optionsWithDateTo[prop] = options[prop];
-        optionsWithFromAndToDate[prop] = options[prop];
-      }
-      if (sthTestConfig.COMPLEX_NOTIFICATION_STARTED && 'hLimit' in optionsWithNoDates) {
-        optionsWithNoDates.hOffset = 0;
-      }
-      optionsWithDateFrom.dateFrom = sthUtils.getISODateString(events[0].recvTime);
-      optionsWithDateTo.dateTo = sthUtils.getISODateString(new Date());
-      if (sthTestConfig.COMPLEX_NOTIFICATION_STARTED && 'hLimit' in optionsWithDateTo) {
-        optionsWithDateTo.hOffset = 0;
-      }
-      optionsWithFromAndToDate.dateFrom = sthUtils.getISODateString(events[0].recvTime);
-      optionsWithFromAndToDate.dateTo = sthUtils.getISODateString(new Date());
+        before(function() {
+            for (var prop in options) {
+                optionsForCaseSensitivity[prop] = options[prop];
+                optionsWithNoDates[prop] = options[prop];
+                optionsWithDateFrom[prop] = options[prop];
+                optionsWithDateTo[prop] = options[prop];
+                optionsWithFromAndToDate[prop] = options[prop];
+            }
+            if (sthTestConfig.COMPLEX_NOTIFICATION_STARTED && 'hLimit' in optionsWithNoDates) {
+                optionsWithNoDates.hOffset = 0;
+            }
+            optionsWithDateFrom.dateFrom = sthUtils.getISODateString(events[0].recvTime);
+            optionsWithDateTo.dateTo = sthUtils.getISODateString(new Date());
+            if (sthTestConfig.COMPLEX_NOTIFICATION_STARTED && 'hLimit' in optionsWithDateTo) {
+                optionsWithDateTo.hOffset = 0;
+            }
+            optionsWithFromAndToDate.dateFrom = sthUtils.getISODateString(events[0].recvTime);
+            optionsWithFromAndToDate.dateTo = sthUtils.getISODateString(new Date());
+        });
+
+        it(
+            'without data if entity id and entity type case does not match',
+            noRawDataIfEntityCaseChange.bind(null, {
+                service: sthConfig.DEFAULT_SERVICE,
+                servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+                attrName: attrName,
+                options: optionsForCaseSensitivity,
+                checkRecvTime: checkRecvTime,
+            })
+        );
+
+        it(
+            'with raw data if data and no dateFrom or dateTo',
+            rawDataAvailableDateFilter.bind(null, {
+                service: sthConfig.DEFAULT_SERVICE,
+                servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+                attrName: attrName,
+                options: optionsWithNoDates,
+                checkRecvTime: checkRecvTime,
+            })
+        );
+
+        it(
+            'with raw data if data since dateFrom',
+            rawDataAvailableDateFilter.bind(null, {
+                service: sthConfig.DEFAULT_SERVICE,
+                servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+                attrName: attrName,
+                options: optionsWithDateFrom,
+                checkRecvTime: checkRecvTime,
+            })
+        );
+
+        it(
+            'with raw data if data before dateTo',
+            rawDataAvailableDateFilter.bind(null, {
+                service: sthConfig.DEFAULT_SERVICE,
+                servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+                attrName: attrName,
+                options: optionsWithDateTo,
+                checkRecvTime: checkRecvTime,
+            })
+        );
+
+        it(
+            'with raw data if data from dateFrom and before dateTo',
+            rawDataAvailableDateFilter.bind(null, {
+                service: sthConfig.DEFAULT_SERVICE,
+                servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+                attrName: attrName,
+                options: optionsWithFromAndToDate,
+                checkRecvTime: checkRecvTime,
+            })
+        );
     });
-
-    it('without data if entity id and entity type case does not match',
-      noRawDataIfEntityCaseChange.bind(
-        null,
-        {
-          service: sthConfig.DEFAULT_SERVICE,
-          servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-          attrName: attrName,
-          options: optionsForCaseSensitivity,
-          checkRecvTime: checkRecvTime
-        }
-      )
-    );
-
-    it('with raw data if data and no dateFrom or dateTo',
-      rawDataAvailableDateFilter.bind(
-        null,
-        {
-          service: sthConfig.DEFAULT_SERVICE,
-          servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-          attrName: attrName,
-          options: optionsWithNoDates,
-          checkRecvTime: checkRecvTime
-        }
-      )
-    );
-
-    it('with raw data if data since dateFrom',
-      rawDataAvailableDateFilter.bind(
-        null,
-        {
-          service: sthConfig.DEFAULT_SERVICE,
-          servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-          attrName: attrName,
-          options: optionsWithDateFrom,
-          checkRecvTime: checkRecvTime
-        }
-      )
-    );
-
-    it('with raw data if data before dateTo',
-      rawDataAvailableDateFilter.bind(
-        null,
-        {
-          service: sthConfig.DEFAULT_SERVICE,
-          servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-          attrName: attrName,
-          options: optionsWithDateTo,
-          checkRecvTime: checkRecvTime
-        }
-      )
-    );
-
-    it('with raw data if data from dateFrom and before dateTo',
-      rawDataAvailableDateFilter.bind(
-        null,
-        {
-          service: sthConfig.DEFAULT_SERVICE,
-          servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-          attrName: attrName,
-          options: optionsWithFromAndToDate,
-          checkRecvTime: checkRecvTime
-        }
-      )
-    );
-  });
 }
 
 /**
@@ -907,45 +939,39 @@ function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
  * @param aggrMethod The aggregation method
  */
 function aggregatedDataRetrievalTests(index, attrName, attrType, aggrMethod) {
-  it('should respond with empty aggregated data if entity id and entity type case does not match',
-    noAggregatedDataIfEntityCaseChangeTest.bind(
-      null,
-      {
-        service: sthConfig.DEFAULT_SERVICE,
-        servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-        attrName: attrName,
-        aggrMethod: aggrMethod,
-        resolution: sthConfig.AGGREGATION_BY[index]
-      }
-    )
-  );
+    it(
+        'should respond with empty aggregated data if entity id and entity type case does not match',
+        noAggregatedDataIfEntityCaseChangeTest.bind(null, {
+            service: sthConfig.DEFAULT_SERVICE,
+            servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+            attrName: attrName,
+            aggrMethod: aggrMethod,
+            resolution: sthConfig.AGGREGATION_BY[index],
+        })
+    );
 
-  it('should respond with empty aggregated data if no data since dateFrom',
-    noAggregatedDataSinceDateTest.bind(
-      null,
-      {
-        service: sthConfig.DEFAULT_SERVICE,
-        servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-        attrName: attrName,
-        aggrMethod: aggrMethod,
-        resolution: sthConfig.AGGREGATION_BY[index]
-      }
-    )
-  );
+    it(
+        'should respond with empty aggregated data if no data since dateFrom',
+        noAggregatedDataSinceDateTest.bind(null, {
+            service: sthConfig.DEFAULT_SERVICE,
+            servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+            attrName: attrName,
+            aggrMethod: aggrMethod,
+            resolution: sthConfig.AGGREGATION_BY[index],
+        })
+    );
 
-  it('should respond with aggregated data if data since dateFrom',
-    aggregatedDataAvailableSinceDateTest.bind(
-      null,
-      {
-        service: sthConfig.DEFAULT_SERVICE,
-        servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-        attrName: attrName,
-        attrType: attrType,
-        aggrMethod: aggrMethod,
-        resolution: sthConfig.AGGREGATION_BY[index]
-      }
-    )
-  );
+    it(
+        'should respond with aggregated data if data since dateFrom',
+        aggregatedDataAvailableSinceDateTest.bind(null, {
+            service: sthConfig.DEFAULT_SERVICE,
+            servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+            attrName: attrName,
+            attrType: attrType,
+            aggrMethod: aggrMethod,
+            resolution: sthConfig.AGGREGATION_BY[index],
+        })
+    );
 }
 
 /**
@@ -956,12 +982,14 @@ function aggregatedDataRetrievalTests(index, attrName, attrType, aggrMethod) {
  * @param {string} aggrMethod The aggregation method
  */
 function aggregatedDataRetrievalSuite(attrName, attrType, aggrMethod) {
-  describe('with aggrMethod as ' + aggrMethod, function () {
-    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-      describe('and aggrPeriod as ' + sthConfig.AGGREGATION_BY[i],
-        aggregatedDataRetrievalTests.bind(null, i, attrName, attrType, aggrMethod));
-    }
-  });
+    describe('with aggrMethod as ' + aggrMethod, function() {
+        for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+            describe(
+                'and aggrPeriod as ' + sthConfig.AGGREGATION_BY[i],
+                aggregatedDataRetrievalTests.bind(null, i, attrName, attrType, aggrMethod)
+            );
+        }
+    });
 }
 
 /**
@@ -969,13 +997,11 @@ function aggregatedDataRetrievalSuite(attrName, attrType, aggrMethod) {
  *  aggregated data collections
  */
 function cleanDatabaseSuite() {
-  if (sthTestConfig.CLEAN) {
-    it('should drop the event raw data collection if it exists',
-      dropRawEventCollectionTest);
+    if (sthTestConfig.CLEAN) {
+        it('should drop the event raw data collection if it exists', dropRawEventCollectionTest);
 
-    it('should drop the aggregated data collection if it exists',
-      dropAggregatedDataCollectionTest);
-  }
+        it('should drop the aggregated data collection if it exists', dropAggregatedDataCollectionTest);
+    }
 }
 
 /**
@@ -985,68 +1011,71 @@ function cleanDatabaseSuite() {
  * @param done The test case callback function
  */
 function noAttributesTest(service, servicePath, done) {
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
-    method: 'POST',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Fiware-Service': service || sthConfig.SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH
-    },
-    json: true,
-    body: {
-      'subscriptionId': '1234567890ABCDF123456789',
-      'originator': 'orion.contextBroker.instance',
-      'contextResponses': [
+    request(
         {
-          'contextElement': {
-            'attributes': [],
-            'type': sthTestConfig.ENTITY_TYPE,
-            'isPattern': 'false',
-            'id': sthTestConfig.ENTITY_ID
-          },
-          'statusCode': {
-            'code': '200',
-            'reasonPhrase': 'OK'
-          }
+            uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Fiware-Service': service || sthConfig.SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH,
+            },
+            json: true,
+            body: {
+                subscriptionId: '1234567890ABCDF123456789',
+                originator: 'orion.contextBroker.instance',
+                contextResponses: [
+                    {
+                        contextElement: {
+                            attributes: [],
+                            type: sthTestConfig.ENTITY_TYPE,
+                            isPattern: 'false',
+                            id: sthTestConfig.ENTITY_ID,
+                        },
+                        statusCode: {
+                            code: '200',
+                            reasonPhrase: 'OK',
+                        },
+                    },
+                    {
+                        contextElement: {
+                            attributes: [],
+                            type: sthTestConfig.ENTITY_TYPE,
+                            isPattern: 'false',
+                            id: sthTestConfig.ENTITY_ID,
+                        },
+                        statusCode: {
+                            code: '200',
+                            reasonPhrase: 'OK',
+                        },
+                    },
+                    {
+                        contextElement: {
+                            attributes: [],
+                            type: sthTestConfig.ENTITY_TYPE,
+                            isPattern: 'false',
+                            id: sthTestConfig.ENTITY_ID,
+                        },
+                        statusCode: {
+                            code: '200',
+                            reasonPhrase: 'OK',
+                        },
+                    },
+                ],
+            },
         },
-        {
-          'contextElement': {
-            'attributes': [],
-            'type': sthTestConfig.ENTITY_TYPE,
-            'isPattern': 'false',
-            'id': sthTestConfig.ENTITY_ID
-          },
-          'statusCode': {
-            'code': '200',
-            'reasonPhrase': 'OK'
-          }
-        },
-        {
-          'contextElement': {
-            'attributes': [],
-            'type': sthTestConfig.ENTITY_TYPE,
-            'isPattern': 'false',
-            'id': sthTestConfig.ENTITY_ID
-          },
-          'statusCode': {
-            'code': '200',
-            'reasonPhrase': 'OK'
-          }
+        function(err, response, body) {
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(400);
+            expect(body.statusCode).to.equal(400);
+            expect(body.error).to.equal('Bad Request');
+            expect(body.validation.source).to.equal('payload');
+            expect(body.validation.keys).to.be.an(Array);
+            expect(body.validation.keys.indexOf('attributes')).to.not.equal(-1);
+            done();
         }
-      ]
-    }
-  }, function (err, response, body) {
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(400);
-    expect(body.statusCode).to.equal(400);
-    expect(body.error).to.equal('Bad Request');
-    expect(body.validation.source).to.equal('payload');
-    expect(body.validation.keys).to.be.an(Array);
-    expect(body.validation.keys.indexOf('attributes')).to.not.equal(-1);
-    done();
-  });
+    );
 }
 
 /**
@@ -1056,124 +1085,127 @@ function noAttributesTest(service, servicePath, done) {
  * @param done The test case callback function
  */
 function nonAggregatableAttributeValuesTest(service, servicePath, done) {
-  var body = {
-    'subscriptionId': '1234567890ABCDF123456789',
-    'originator': 'orion.contextBroker.instance',
-    'contextResponses': [
-      {
-        'contextElement': {
-          'attributes': [
+    var body = {
+        subscriptionId: '1234567890ABCDF123456789',
+        originator: 'orion.contextBroker.instance',
+        contextResponses: [
             {
-              'name': sthTestConfig.ATTRIBUTE_NAME,
-              'type': sthTestConfig.ATTRIBUTE_TYPE,
-              'value': ''
-            }
-          ],
-          'type': sthTestConfig.ENTITY_TYPE,
-          'isPattern': 'false',
-          'id': sthTestConfig.ENTITY_ID
-        },
-        'statusCode': {
-          'code': '200',
-          'reasonPhrase': 'OK'
-        }
-      },
-      {
-        'contextElement': {
-          'attributes': [
+                contextElement: {
+                    attributes: [
+                        {
+                            name: sthTestConfig.ATTRIBUTE_NAME,
+                            type: sthTestConfig.ATTRIBUTE_TYPE,
+                            value: '',
+                        },
+                    ],
+                    type: sthTestConfig.ENTITY_TYPE,
+                    isPattern: 'false',
+                    id: sthTestConfig.ENTITY_ID,
+                },
+                statusCode: {
+                    code: '200',
+                    reasonPhrase: 'OK',
+                },
+            },
             {
-              'name': sthTestConfig.ATTRIBUTE_NAME,
-              'type': sthTestConfig.ATTRIBUTE_TYPE,
-              'value': ['just', 'an', 'array']
-            }
-          ],
-          'type': sthTestConfig.ENTITY_TYPE,
-          'isPattern': 'false',
-          'id': sthTestConfig.ENTITY_ID
-        },
-        'statusCode': {
-          'code': '200',
-          'reasonPhrase': 'OK'
-        }
-      },
-      {
-        'contextElement': {
-          'attributes': [
+                contextElement: {
+                    attributes: [
+                        {
+                            name: sthTestConfig.ATTRIBUTE_NAME,
+                            type: sthTestConfig.ATTRIBUTE_TYPE,
+                            value: ['just', 'an', 'array'],
+                        },
+                    ],
+                    type: sthTestConfig.ENTITY_TYPE,
+                    isPattern: 'false',
+                    id: sthTestConfig.ENTITY_ID,
+                },
+                statusCode: {
+                    code: '200',
+                    reasonPhrase: 'OK',
+                },
+            },
             {
-              'name': sthTestConfig.ATTRIBUTE_NAME,
-              'type': sthTestConfig.ATTRIBUTE_TYPE,
-              'value': {
-                just: 'an object'
-              }
-            }
-          ],
-          'type': sthTestConfig.ENTITY_TYPE,
-          'isPattern': 'false',
-          'id': sthTestConfig.ENTITY_ID
-        },
-        'statusCode': {
-          'code': '200',
-          'reasonPhrase': 'OK'
-        }
-      }
-    ]
-  };
-  if (sthConfig.IGNORE_BLANK_SPACES) {
-    body.contextResponses.push(
-      {
-        'contextElement': {
-          'attributes': [
+                contextElement: {
+                    attributes: [
+                        {
+                            name: sthTestConfig.ATTRIBUTE_NAME,
+                            type: sthTestConfig.ATTRIBUTE_TYPE,
+                            value: {
+                                just: 'an object',
+                            },
+                        },
+                    ],
+                    type: sthTestConfig.ENTITY_TYPE,
+                    isPattern: 'false',
+                    id: sthTestConfig.ENTITY_ID,
+                },
+                statusCode: {
+                    code: '200',
+                    reasonPhrase: 'OK',
+                },
+            },
+        ],
+    };
+    if (sthConfig.IGNORE_BLANK_SPACES) {
+        body.contextResponses.push(
             {
-              'name': sthTestConfig.ATTRIBUTE_NAME,
-              'type': sthTestConfig.ATTRIBUTE_TYPE,
-              'value': ' ' // Blank space
-            }
-          ],
-          'type': sthTestConfig.ENTITY_TYPE,
-          'isPattern': 'false',
-          'id': sthTestConfig.ENTITY_ID
-        },
-        'statusCode': {
-          'code': '200',
-          'reasonPhrase': 'OK'
-        }
-      },
-      {
-        'contextElement': {
-          'attributes': [
+                contextElement: {
+                    attributes: [
+                        {
+                            name: sthTestConfig.ATTRIBUTE_NAME,
+                            type: sthTestConfig.ATTRIBUTE_TYPE,
+                            value: ' ', // Blank space
+                        },
+                    ],
+                    type: sthTestConfig.ENTITY_TYPE,
+                    isPattern: 'false',
+                    id: sthTestConfig.ENTITY_ID,
+                },
+                statusCode: {
+                    code: '200',
+                    reasonPhrase: 'OK',
+                },
+            },
             {
-              'name': sthTestConfig.ATTRIBUTE_NAME,
-              'type': sthTestConfig.ATTRIBUTE_TYPE,
-              'value': '   ' // Several blank space
+                contextElement: {
+                    attributes: [
+                        {
+                            name: sthTestConfig.ATTRIBUTE_NAME,
+                            type: sthTestConfig.ATTRIBUTE_TYPE,
+                            value: '   ', // Several blank space
+                        },
+                    ],
+                    type: sthTestConfig.ENTITY_TYPE,
+                    isPattern: 'false',
+                    id: sthTestConfig.ENTITY_ID,
+                },
+                statusCode: {
+                    code: '200',
+                    reasonPhrase: 'OK',
+                },
             }
-          ],
-          'type': sthTestConfig.ENTITY_TYPE,
-          'isPattern': 'false',
-          'id': sthTestConfig.ENTITY_ID
+        );
+    }
+    request(
+        {
+            uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Fiware-Service': service || sthConfig.SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH,
+            },
+            json: true,
+            body: body,
         },
-        'statusCode': {
-          'code': '200',
-          'reasonPhrase': 'OK'
+        function(err, response) {
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            done();
         }
-      }
     );
-  }
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
-    method: 'POST',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Fiware-Service': service || sthConfig.SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH
-    },
-    json: true,
-    body: body
-  }, function (err, response) {
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    done();
-  });
 }
 
 /**
@@ -1189,50 +1221,69 @@ var complexNotificationTest;
  * @param {boolean} includeTimeInstantMetadata The attribute should include a TimeInstant metadata
  */
 function complexNotificationSuite(attrName, attrType, includeTimeInstantMetadata) {
-  describe('attribute of type ' + attrType, function () {
-    before(function () {
-      sthTestConfig.COMPLEX_NOTIFICATION_STARTED = true;
+    describe('attribute of type ' + attrType, function() {
+        before(function() {
+            sthTestConfig.COMPLEX_NOTIFICATION_STARTED = true;
+        });
+
+        describe('reception', function() {
+            it(
+                'should attend the notification',
+                complexNotificationTest.bind(null, {
+                    service: sthConfig.DEFAULT_SERVICE,
+                    servicePath: sthConfig.DEFAULT_SERVICE_PATH,
+                    attrName: attrName,
+                    attrType: attrType,
+                    includeTimeInstantMetadata: includeTimeInstantMetadata,
+                })
+            );
+        });
+
+        describe('for each new notification', function() {
+            describe(
+                'raw data retrieval with lastN',
+                rawDataRetrievalSuite.bind(
+                    null,
+                    { lastN: sthTestConfig.EVENT_NOTIFICATION_CONTEXT_ELEMENTS },
+                    attrName,
+                    attrType,
+                    false
+                )
+            );
+
+            describe(
+                'raw data retrieval with hLimit and hOffset',
+                rawDataRetrievalSuite.bind(null, { hLimit: 1, hOffset: 0 }, attrName, attrType, false)
+            );
+
+            if (attrType === 'float') {
+                describe(
+                    'aggregated data retrieval',
+                    aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'min')
+                );
+
+                describe(
+                    'aggregated data retrieval',
+                    aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'max')
+                );
+
+                describe(
+                    'aggregated data retrieval',
+                    aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'sum')
+                );
+
+                describe(
+                    'aggregated data retrieval',
+                    aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'sum2')
+                );
+            } else if (attrType === 'string') {
+                describe(
+                    'aggregated data retrieval',
+                    aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'occur')
+                );
+            }
+        });
     });
-
-    describe('reception', function () {
-      it('should attend the notification', complexNotificationTest.bind(
-        null,
-        {
-          service: sthConfig.DEFAULT_SERVICE,
-          servicePath: sthConfig.DEFAULT_SERVICE_PATH,
-          attrName: attrName,
-          attrType: attrType,
-          includeTimeInstantMetadata: includeTimeInstantMetadata
-        }
-      ));
-    });
-
-    describe('for each new notification', function () {
-      describe('raw data retrieval with lastN',
-        rawDataRetrievalSuite.bind(null, {lastN: sthTestConfig.EVENT_NOTIFICATION_CONTEXT_ELEMENTS},
-          attrName, attrType, false));
-
-      describe('raw data retrieval with hLimit and hOffset',
-        rawDataRetrievalSuite.bind(null, {hLimit: 1, hOffset: 0}, attrName, attrType, false));
-
-      if (attrType === 'float') {
-        describe('aggregated data retrieval',
-          aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'min'));
-
-        describe('aggregated data retrieval',
-          aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'max'));
-
-        describe('aggregated data retrieval',
-          aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'sum'));
-
-        describe('aggregated data retrieval',
-          aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'sum2'));
-      } else if (attrType === 'string') {
-        describe('aggregated data retrieval',
-          aggregatedDataRetrievalSuite.bind(null, attrName, attrType, 'occur'));
-      }
-    });
-  });
 }
 
 /**
@@ -1242,21 +1293,25 @@ function complexNotificationSuite(attrName, attrType, includeTimeInstantMetadata
  * @param {boolean} includeTimeInstantMetadata The attribute should include a TimeInstant metadata
  */
 function eventNotificationSuite(attrName, attrType, includeTimeInstantMetadata) {
-  before(function () {
-    cleanEvents();
-  });
+    before(function() {
+        cleanEvents();
+    });
 
-  describe('no attribute values notification', function () {
-    it('should respond with 400 - Bad Request', noAttributesTest.bind(
-      null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH));
-  });
+    describe('no attribute values notification', function() {
+        it(
+            'should respond with 400 - Bad Request',
+            noAttributesTest.bind(null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH)
+        );
+    });
 
-  describe('non-aggretabable values notification', function () {
-    it('should respond with 200 - OK', nonAggregatableAttributeValuesTest.bind(
-      null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH));
-  });
+    describe('non-aggretabable values notification', function() {
+        it(
+            'should respond with 200 - OK',
+            nonAggregatableAttributeValuesTest.bind(null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH)
+        );
+    });
 
-  describe('value changed of', complexNotificationSuite.bind(null, attrName, attrType, includeTimeInstantMetadata));
+    describe('value changed of', complexNotificationSuite.bind(null, attrName, attrType, includeTimeInstantMetadata));
 }
 
 /**
@@ -1270,70 +1325,71 @@ function eventNotificationSuite(attrName, attrType, includeTimeInstantMetadata) 
  * @param {Function} done The mocha done() callback function
  */
 complexNotificationTest = function complexNotificationTest(params, done) {
-  var service = params.service,
-    servicePath = params.servicePath,
-    attrName = params.attrName,
-    attrType = params.attrType,
-    includeTimeInstantMetadata = params.includeTimeInstantMetadata;
-  var now = new Date();
-  var anEvent = createEvent(attrName, attrType, now);
-  var contextResponses = [];
-  var attribute = {
-    'name': anEvent.attrName,
-    'type': anEvent.attrType,
-    'value': anEvent.attrValue
-  };
+    var service = params.service,
+        servicePath = params.servicePath,
+        attrName = params.attrName,
+        attrType = params.attrType,
+        includeTimeInstantMetadata = params.includeTimeInstantMetadata;
+    var now = new Date();
+    var anEvent = createEvent(attrName, attrType, now);
+    var contextResponses = [];
+    var attribute = {
+        name: anEvent.attrName,
+        type: anEvent.attrType,
+        value: anEvent.attrValue,
+    };
 
-  if (includeTimeInstantMetadata) {
-    attribute.metadatas = [
-      {
-        name: 'TimeInstant',
-        type: 'ISO8601',
-        value: now
-      }
-    ];
-  }
+    if (includeTimeInstantMetadata) {
+        attribute.metadatas = [
+            {
+                name: 'TimeInstant',
+                type: 'ISO8601',
+                value: now,
+            },
+        ];
+    }
 
-  for (var i = 0; i < sthTestConfig.EVENT_NOTIFICATION_CONTEXT_ELEMENTS; i++) {
-    contextResponses.push({
-      'contextElement': {
-        'attributes': [
-          attribute
-        ],
-        'type': sthTestConfig.ENTITY_TYPE,
-        'isPattern': 'false',
-        'id': sthTestConfig.ENTITY_ID
-      },
-      'statusCode': {
-        'code': '200',
-        'reasonPhrase': 'OK'
-      }
-    });
-  }
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
-    method: 'POST',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
-    },
-    json: true,
-    body: {
-      'subscriptionId': '1234567890ABCDF123456789',
-      'originator': 'orion.contextBroker.instance',
-      'contextResponses': contextResponses
+    for (var i = 0; i < sthTestConfig.EVENT_NOTIFICATION_CONTEXT_ELEMENTS; i++) {
+        contextResponses.push({
+            contextElement: {
+                attributes: [attribute],
+                type: sthTestConfig.ENTITY_TYPE,
+                isPattern: 'false',
+                id: sthTestConfig.ENTITY_ID,
+            },
+            statusCode: {
+                code: '200',
+                reasonPhrase: 'OK',
+            },
+        });
     }
-  }, function (err, response, body) {
-    for (var i = 0; i < 3; i++) {
-      if (events.indexOf(anEvent) < 0) {
-        events.push(anEvent);
-      }
-    }
-    expect(body).to.be(undefined);
-    done(err);
-  });
+    request(
+        {
+            uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+            },
+            json: true,
+            body: {
+                subscriptionId: '1234567890ABCDF123456789',
+                originator: 'orion.contextBroker.instance',
+                contextResponses: contextResponses,
+            },
+        },
+        function(err, response, body) {
+            for (var i = 0; i < 3; i++) {
+                if (events.indexOf(anEvent) < 0) {
+                    events.push(anEvent);
+                }
+            }
+            expect(body).to.be(undefined);
+            done(err);
+        }
+    );
 };
 
 /**
@@ -1342,29 +1398,31 @@ complexNotificationTest = function complexNotificationTest(params, done) {
  * @param {Function} done Callback
  */
 function status200Test(options, done) {
-  request({
-    uri: getURL(sthTestConfig.API_OPERATION.READ, options),
-    method: 'GET',
-    headers: {
-      'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    if (options && options.count) {
-      // Check fiware-total-count header
-      expect(response.headers['fiware-total-count']).to.not.be(undefined);
-    }
-    expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
-    expect(bodyJSON.contextResponses[0].contextElement.type).to.equal(sthTestConfig.ENTITY_TYPE);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
-    done();
-  });
+    request(
+        {
+            uri: getURL(sthTestConfig.API_OPERATION.READ, options),
+            method: 'GET',
+            headers: {
+                'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            if (options && options.count) {
+                // Check fiware-total-count header
+                expect(response.headers['fiware-total-count']).to.not.be(undefined);
+            }
+            expect(bodyJSON.contextResponses[0].contextElement.id).to.equal(sthTestConfig.ENTITY_ID);
+            expect(bodyJSON.contextResponses[0].contextElement.type).to.equal(sthTestConfig.ENTITY_TYPE);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values).to.be.an(Array);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
+            done();
+        }
+    );
 }
-
 
 /**
  * Test to check that in case of updating a numeric attribute value aggregated data:
@@ -1376,46 +1434,67 @@ function status200Test(options, done) {
  * @param done The done() function
  */
 function numericAggregatedDataUpdatedTest(contextResponseFile, aggrMethod, resolution, done) {
-  var contextResponseNumericWithFixedTimeInstant =
-    require('./contextResponses/' + contextResponseFile);
+    var contextResponseNumericWithFixedTimeInstant = require('./contextResponses/' + contextResponseFile);
 
-  request({
-    uri: getURL(
-      sthTestConfig.API_OPERATION.READ,
-      {
-        aggrMethod: aggrMethod,
-        aggrPeriod: resolution,
-        dateFrom: contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-          metadatas[0].value,
-        dateTo: contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-          metadatas[0].value
-      },
-      contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-    ),
-    method: 'GET',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points.length).to.equal(1);
-    expect(parseInt(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].offset, 10)).
-    to.equal(sthUtils.getOffset(resolution, new Date(contextResponseNumericWithFixedTimeInstant.contextResponses[0].
-      contextElement.attributes[0].metadatas[0].value)));
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].samples).to.equal(1);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0][aggrMethod]).to.equal(
-      aggrMethod === 'sum2' ?
-        Math.pow(parseInt(
-          contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value, 10), 2) :
-        parseInt(contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value,
-          10));
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done(err);
-  });
+    request(
+        {
+            uri: getURL(
+                sthTestConfig.API_OPERATION.READ,
+                {
+                    aggrMethod: aggrMethod,
+                    aggrPeriod: resolution,
+                    dateFrom:
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .metadatas[0].value,
+                    dateTo:
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .metadatas[0].value,
+                },
+                contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+            ),
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points.length).to.equal(1);
+            expect(
+                parseInt(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].offset, 10)
+            ).to.equal(
+                sthUtils.getOffset(
+                    resolution,
+                    new Date(
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].metadatas[0].value
+                    )
+                )
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].samples).to.equal(1);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0][aggrMethod]).to.equal(
+                aggrMethod === 'sum2'
+                    ? Math.pow(
+                          parseInt(
+                              contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement
+                                  .attributes[0].value,
+                              10
+                          ),
+                          2
+                      )
+                    : parseInt(
+                          contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                              .value,
+                          10
+                      )
+            );
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done(err);
+        }
+    );
 }
 
 /**
@@ -1427,43 +1506,56 @@ function numericAggregatedDataUpdatedTest(contextResponseFile, aggrMethod, resol
  * @param done The done() function
  */
 function textualAggregatedDataUpdatedTest(contextResponseFile, resolution, done) {
-  var contextResponseTextualWithFixedTimeInstant =
-    require('./contextResponses/' + contextResponseFile);
+    var contextResponseTextualWithFixedTimeInstant = require('./contextResponses/' + contextResponseFile);
 
-  request({
-    uri: getURL(
-      sthTestConfig.API_OPERATION.READ,
-      {
-        aggrMethod: 'occur',
-        aggrPeriod: resolution,
-        dateFrom: contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-          metadatas[0].value,
-        dateTo: contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-          metadatas[0].value
-      },
-      contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-    ),
-    method: 'GET',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points.length).to.equal(1);
-    expect(parseInt(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].offset, 10)).
-    to.equal(sthUtils.getOffset(resolution, new Date(contextResponseTextualWithFixedTimeInstant.contextResponses[0].
-      contextElement.attributes[0].metadatas[0].value)));
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].samples).to.equal(1);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].
-      occur[contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value]).
-    to.equal(1);
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done(err);
-  });
+    request(
+        {
+            uri: getURL(
+                sthTestConfig.API_OPERATION.READ,
+                {
+                    aggrMethod: 'occur',
+                    aggrPeriod: resolution,
+                    dateFrom:
+                        contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .metadatas[0].value,
+                    dateTo:
+                        contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .metadatas[0].value,
+                },
+                contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+            ),
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points.length).to.equal(1);
+            expect(
+                parseInt(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].offset, 10)
+            ).to.equal(
+                sthUtils.getOffset(
+                    resolution,
+                    new Date(
+                        contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].metadatas[0].value
+                    )
+                )
+            );
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].samples).to.equal(1);
+            expect(
+                bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].points[0].occur[
+                    contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value
+                ]
+            ).to.equal(1);
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done(err);
+        }
+    );
 }
 
 /**
@@ -1476,36 +1568,40 @@ function textualAggregatedDataUpdatedTest(contextResponseFile, resolution, done)
  * @param done The done() function
  */
 function aggregatedDataNonExistentTest(contextResponseFile, aggrMethod, resolution, done) {
-  var contextResponseNumericWithFixedTimeInstant =
-    require('./contextResponses/' + contextResponseFile);
+    var contextResponseNumericWithFixedTimeInstant = require('./contextResponses/' + contextResponseFile);
 
-  request({
-    uri: getURL(
-      sthTestConfig.API_OPERATION.READ,
-      {
-        aggrMethod: aggrMethod,
-        aggrPeriod: resolution,
-        dateFrom: contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-          metadatas[0].value,
-        dateTo: contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-          metadatas[0].value
-      },
-      contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-    ),
-    method: 'GET',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-      'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-    }
-  }, function (err, response, body) {
-    var bodyJSON = JSON.parse(body);
-    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
-    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-    done(err);
-  });
+    request(
+        {
+            uri: getURL(
+                sthTestConfig.API_OPERATION.READ,
+                {
+                    aggrMethod: aggrMethod,
+                    aggrPeriod: resolution,
+                    dateFrom:
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .metadatas[0].value,
+                    dateTo:
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .metadatas[0].value,
+                },
+                contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+            ),
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+            },
+        },
+        function(err, response, body) {
+            var bodyJSON = JSON.parse(body);
+            expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
+            expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+            expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+            done(err);
+        }
+    );
 }
 
 /**
@@ -1514,220 +1610,239 @@ function aggregatedDataNonExistentTest(contextResponseFile, aggrMethod, resoluti
  * @param removalOptions The removal options
  */
 function dataRemovalSuite(aggregationType, removalOptions) {
-  var contextResponsesObj;
+    var contextResponsesObj;
 
-  before(function() {
-    var contextResponseFile = './contextResponses/contextResponse' +
-      (aggregationType === sthConfig.AGGREGATIONS.NUMERIC ? 'Numeric' : 'Textual') +
-      'WithFixedTimeInstant';
-    contextResponsesObj =
-      require(contextResponseFile);
-  });
-
-  it('should store the raw and aggregated data for some ' + aggregationType + ' entity attribute', function (done) {
-    request({
-      uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-      },
-      json: true,
-      body: {
-        'subscriptionId' : '1234567890ABCDF123456789',
-        'originator' : 'orion.contextBroker.instance',
-        'contextResponses' : contextResponsesObj.contextResponses
-      }
-    }, function (err, response, body) {
-      expect(body).to.be(undefined);
-      done(err);
+    before(function() {
+        var contextResponseFile =
+            './contextResponses/contextResponse' +
+            (aggregationType === sthConfig.AGGREGATIONS.NUMERIC ? 'Numeric' : 'Textual') +
+            'WithFixedTimeInstant';
+        contextResponsesObj = require(contextResponseFile);
     });
-  });
 
-  it('should retrieve the raw data', function(done) {
-    request({
-      uri: getURL(
-        sthTestConfig.API_OPERATION.READ,
-        {
-          lastN: 0,
-          dateFrom: contextResponsesObj.contextResponses[0].contextElement.attributes[0].
-            metadatas[0].value,
-          dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].
-            metadatas[0].value
-        },
-        contextResponsesObj.contextResponses[0].contextElement.attributes[0].name
-      ),
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-      }
-    }, function (err, response, body) {
-      var bodyJSON = JSON.parse(body);
-      expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-      expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
-        contextResponsesObj.contextResponses[0].contextElement.attributes[0].value);
-      expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-      expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-      done(err);
+    it('should store the raw and aggregated data for some ' + aggregationType + ' entity attribute', function(done) {
+        request(
+            {
+                uri: getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                },
+                json: true,
+                body: {
+                    subscriptionId: '1234567890ABCDF123456789',
+                    originator: 'orion.contextBroker.instance',
+                    contextResponses: contextResponsesObj.contextResponses,
+                },
+            },
+            function(err, response, body) {
+                expect(body).to.be(undefined);
+                done(err);
+            }
+        );
     });
-  });
 
-  for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-    if (aggregationType === sthConfig.AGGREGATIONS.NUMERIC) {
-      it('should retrieve the sum updated aggregated data',
-        numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'sum',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+    it('should retrieve the raw data', function(done) {
+        request(
+            {
+                uri: getURL(
+                    sthTestConfig.API_OPERATION.READ,
+                    {
+                        lastN: 0,
+                        dateFrom:
+                            contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
+                        dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
+                    },
+                    contextResponsesObj.contextResponses[0].contextElement.attributes[0].name
+                ),
+                method: 'GET',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                },
+            },
+            function(err, response, body) {
+                var bodyJSON = JSON.parse(body);
+                expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
+                    contextResponsesObj.contextResponses[0].contextElement.attributes[0].value
+                );
+                expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                done(err);
+            }
+        );
+    });
 
-      it('should retrieve the sum2 aggregated data',
-        numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'sum2',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+        if (aggregationType === sthConfig.AGGREGATIONS.NUMERIC) {
+            it(
+                'should retrieve the sum updated aggregated data',
+                numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'sum',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
 
-      it('should retrieve the max aggregated data',
-        numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'max',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+            it(
+                'should retrieve the sum2 aggregated data',
+                numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'sum2',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
 
-      it('should retrieve the min aggregated data',
-        numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'min',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-    } else {
-      it('should retrieve the occur aggregated data',
-        textualAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseTextualWithFixedTimeInstant',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+            it(
+                'should retrieve the max aggregated data',
+                numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'max',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should retrieve the min aggregated data',
+                numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'min',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+        } else {
+            it(
+                'should retrieve the occur aggregated data',
+                textualAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseTextualWithFixedTimeInstant',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+        }
     }
-  }
 
-  it('should delete the raw and aggregated data for the same ' + aggregationType + ' entity attribute',
-    function (done) {
-    request({
-      uri: getURL(
-        sthTestConfig.API_OPERATION.DELETE,
-        removalOptions
-      ),
-      method: 'DELETE',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-      },
-      json: true,
-      body: {
-        'subscriptionId' : '1234567890ABCDF123456789',
-        'originator' : 'orion.contextBroker.instance',
-        'contextResponses' : contextResponsesObj.contextResponses
-      }
-    }, function (err, response, body) {
-      expect(body).to.be(undefined);
-      done(err);
+    it('should delete the raw and aggregated data for the same ' + aggregationType + ' entity attribute', function(
+        done
+    ) {
+        request(
+            {
+                uri: getURL(sthTestConfig.API_OPERATION.DELETE, removalOptions),
+                method: 'DELETE',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                },
+                json: true,
+                body: {
+                    subscriptionId: '1234567890ABCDF123456789',
+                    originator: 'orion.contextBroker.instance',
+                    contextResponses: contextResponsesObj.contextResponses,
+                },
+            },
+            function(err, response, body) {
+                expect(body).to.be(undefined);
+                done(err);
+            }
+        );
     });
-  });
 
-  it('should not retrieve the deleted raw data', function(done) {
-    request({
-      uri: getURL(
-        sthTestConfig.API_OPERATION.READ,
-        {
-          lastN: 0,
-          dateFrom: contextResponsesObj.contextResponses[0].contextElement.attributes[0].
-            metadatas[0].value,
-          dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].
-            metadatas[0].value
-        },
-        contextResponsesObj.contextResponses[0].contextElement.attributes[0].name
-      ),
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-      }
-    }, function (err, response, body) {
-      var bodyJSON = JSON.parse(body);
-      expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
-      expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-      expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-      done(err);
+    it('should not retrieve the deleted raw data', function(done) {
+        request(
+            {
+                uri: getURL(
+                    sthTestConfig.API_OPERATION.READ,
+                    {
+                        lastN: 0,
+                        dateFrom:
+                            contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
+                        dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
+                    },
+                    contextResponsesObj.contextResponses[0].contextElement.attributes[0].name
+                ),
+                method: 'GET',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                },
+            },
+            function(err, response, body) {
+                var bodyJSON = JSON.parse(body);
+                expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(0);
+                expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                done(err);
+            }
+        );
     });
-  });
 
-  for (var j = 0; j < sthConfig.AGGREGATION_BY.length; j++) {
-    if (aggregationType === sthConfig.AGGREGATIONS.NUMERIC) {
-      it('should not retrieve the deleted sum updated aggregated data',
-        aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'sum',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
+    for (var j = 0; j < sthConfig.AGGREGATION_BY.length; j++) {
+        if (aggregationType === sthConfig.AGGREGATIONS.NUMERIC) {
+            it(
+                'should not retrieve the deleted sum updated aggregated data',
+                aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'sum',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
 
-      it('should not retrieve the deleted sum2 aggregated data',
-        aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'sum2',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
+            it(
+                'should not retrieve the deleted sum2 aggregated data',
+                aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'sum2',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
 
-      it('should not retrieve the deleted max aggregated data',
-        aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'max',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
+            it(
+                'should not retrieve the deleted max aggregated data',
+                aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'max',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
 
-      it('should not retrieve the deleted min aggregated data',
-        aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'min',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-    } else {
-      it('should not retrieve the deleted occur aggregated data',
-        aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseTextualWithFixedTimeInstant',
-          'occur',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
+            it(
+                'should not retrieve the deleted min aggregated data',
+                aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'min',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+        } else {
+            it(
+                'should not retrieve the deleted occur aggregated data',
+                aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseTextualWithFixedTimeInstant',
+                    'occur',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+        }
     }
-  }
 }
 
 /**
@@ -1736,36 +1851,36 @@ function dataRemovalSuite(aggregationType, removalOptions) {
  * @param done The done() function
  */
 function validLogLevelChangeTest(level, done) {
-  request({
-    uri: getURL(
-      sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL,
-      {
-        level: level
-      }
-    ),
-    method: 'PUT'
-  }, function (err, response) {
-    expect(err).to.equal(null);
-    expect(response.statusCode).to.equal(200);
-    done();
-  });
+    request(
+        {
+            uri: getURL(sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL, {
+                level: level,
+            }),
+            method: 'PUT',
+        },
+        function(err, response) {
+            expect(err).to.equal(null);
+            expect(response.statusCode).to.equal(200);
+            done();
+        }
+    );
 }
 
 module.exports = {
-  getDayOfYear: getDayOfYear,
-  addEventTest: addEventTest,
-  eachEventTestSuite: eachEventTestSuite,
-  dropRawEventCollectionTest: dropRawEventCollectionTest,
-  dropAggregatedDataCollectionTest: dropAggregatedDataCollectionTest,
-  getURL: getURL,
-  rawDataRetrievalSuite: rawDataRetrievalSuite,
-  aggregatedDataRetrievalSuite: aggregatedDataRetrievalSuite,
-  cleanDatabaseSuite: cleanDatabaseSuite,
-  eventNotificationSuite: eventNotificationSuite,
-  status200Test: status200Test,
-  numericAggregatedDataUpdatedTest: numericAggregatedDataUpdatedTest,
-  textualAggregatedDataUpdatedTest: textualAggregatedDataUpdatedTest,
-  aggregatedDataNonExistentTest: aggregatedDataNonExistentTest,
-  dataRemovalSuite: dataRemovalSuite,
-  validLogLevelChangeTest: validLogLevelChangeTest
+    getDayOfYear: getDayOfYear,
+    addEventTest: addEventTest,
+    eachEventTestSuite: eachEventTestSuite,
+    dropRawEventCollectionTest: dropRawEventCollectionTest,
+    dropAggregatedDataCollectionTest: dropAggregatedDataCollectionTest,
+    getURL: getURL,
+    rawDataRetrievalSuite: rawDataRetrievalSuite,
+    aggregatedDataRetrievalSuite: aggregatedDataRetrievalSuite,
+    cleanDatabaseSuite: cleanDatabaseSuite,
+    eventNotificationSuite: eventNotificationSuite,
+    status200Test: status200Test,
+    numericAggregatedDataUpdatedTest: numericAggregatedDataUpdatedTest,
+    textualAggregatedDataUpdatedTest: textualAggregatedDataUpdatedTest,
+    aggregatedDataNonExistentTest: aggregatedDataNonExistentTest,
+    dataRemovalSuite: dataRemovalSuite,
+    validLogLevelChangeTest: validLogLevelChangeTest,
 };

--- a/test/unit/sthTestUtils.js
+++ b/test/unit/sthTestUtils.js
@@ -68,7 +68,7 @@ function createEvent(attrName, attrType, recvTime) {
                 entityType: sthTestConfig.ENTITY_TYPE,
                 attrName: attrName,
                 attrType: attrType,
-                attrValue: attrValue,
+                attrValue: attrValue
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ENTITY:
@@ -76,7 +76,7 @@ function createEvent(attrName, attrType, recvTime) {
                 recvTime: recvTime,
                 attrName: attrName,
                 attrType: attrType,
-                attrValue: attrValue,
+                attrValue: attrValue
             };
             break;
         case sthConfig.DATA_MODELS.COLLECTION_PER_ATTRIBUTE:
@@ -86,7 +86,7 @@ function createEvent(attrName, attrType, recvTime) {
                 //  It is included just to ease its recovery
                 attrName: attrName,
                 attrType: attrType,
-                attrValue: attrValue,
+                attrValue: attrValue
             };
             break;
     }
@@ -123,12 +123,12 @@ function addEventTest(anEvent, includeTimeInstantMetadata, done) {
             servicePath: sthConfig.DEFAULT_SERVICE_PATH,
             entityId: sthTestConfig.ENTITY_ID,
             entityType: sthTestConfig.ENTITY_TYPE,
-            attrName: anEvent.attrName,
+            attrName: anEvent.attrName
         },
         {
             isAggregated: false,
             shouldCreate: true,
-            shouldTruncate: true,
+            shouldTruncate: true
         },
         function(err, collection) {
             if (err) {
@@ -149,13 +149,13 @@ function addEventTest(anEvent, includeTimeInstantMetadata, done) {
                                     {
                                         name: 'TimeInstant',
                                         type: 'ISO8601',
-                                        value: anEvent.recvTime,
-                                    },
-                                ],
+                                        value: anEvent.recvTime
+                                    }
+                                ]
                             },
                             notificationInfo: {
-                                inserts: true,
-                            },
+                                inserts: true
+                            }
                         },
                         done
                     );
@@ -169,11 +169,11 @@ function addEventTest(anEvent, includeTimeInstantMetadata, done) {
                             attribute: {
                                 name: anEvent.attrName,
                                 type: anEvent.attrType,
-                                value: anEvent.attrValue,
+                                value: anEvent.attrValue
                             },
                             notificationInfo: {
-                                inserts: true,
-                            },
+                                inserts: true
+                            }
                         },
                         done
                     );
@@ -206,12 +206,12 @@ function addAggregatedDataTest(anEvent, done) {
             servicePath: sthConfig.DEFAULT_SERVICE_PATH,
             entityId: sthTestConfig.ENTITY_ID,
             entityType: sthTestConfig.ENTITY_TYPE,
-            attrName: anEvent.attrName,
+            attrName: anEvent.attrName
         },
         {
             isAggregated: true,
             shouldCreate: true,
-            shouldTruncate: true,
+            shouldTruncate: true
         },
         function(err, collection) {
             if (err) {
@@ -228,8 +228,8 @@ function addAggregatedDataTest(anEvent, done) {
                         resolution: sthConfig.RESOLUTION.SECOND,
                         timestamp: anEvent.recvTime,
                         notificationInfo: {
-                            inserts: true,
-                        },
+                            inserts: true
+                        }
                     },
                     callback
                 );
@@ -244,8 +244,8 @@ function addAggregatedDataTest(anEvent, done) {
                         resolution: sthConfig.RESOLUTION.MINUTE,
                         timestamp: anEvent.recvTime,
                         notificationInfo: {
-                            inserts: true,
-                        },
+                            inserts: true
+                        }
                     },
                     callback
                 );
@@ -260,8 +260,8 @@ function addAggregatedDataTest(anEvent, done) {
                         resolution: sthConfig.RESOLUTION.HOUR,
                         timestamp: anEvent.recvTime,
                         notificationInfo: {
-                            inserts: true,
-                        },
+                            inserts: true
+                        }
                     },
                     callback
                 );
@@ -276,8 +276,8 @@ function addAggregatedDataTest(anEvent, done) {
                         resolution: sthConfig.RESOLUTION.DAY,
                         timestamp: anEvent.recvTime,
                         notificationInfo: {
-                            inserts: true,
-                        },
+                            inserts: true
+                        }
                     },
                     callback
                 );
@@ -292,8 +292,8 @@ function addAggregatedDataTest(anEvent, done) {
                         resolution: sthConfig.RESOLUTION.MONTH,
                         timestamp: anEvent.recvTime,
                         notificationInfo: {
-                            inserts: true,
-                        },
+                            inserts: true
+                        }
                     },
                     callback
                 );
@@ -341,7 +341,7 @@ function dropRawEventCollectionTest(done) {
         servicePath: sthConfig.DEFAULT_SERVICE_PATH,
         entityId: sthTestConfig.ENTITY_ID,
         entityType: sthTestConfig.ENTITY_TYPE,
-        attrName: sthTestConfig.ATTRIBUTE_NAME,
+        attrName: sthTestConfig.ATTRIBUTE_NAME
     });
     console.log(collectionName4Events);
     sthDatabase.connection.dropCollection(collectionName4Events, function(err) {
@@ -362,7 +362,7 @@ function dropAggregatedDataCollectionTest(done) {
         servicePath: sthConfig.DEFAULT_SERVICE_PATH,
         entityId: sthTestConfig.ENTITY_ID,
         entityType: sthTestConfig.ENTITY_TYPE,
-        attrName: sthTestConfig.ATTRIBUTE_NAME,
+        attrName: sthTestConfig.ATTRIBUTE_NAME
     });
     sthDatabase.connection.dropCollection(collectionName4Aggregated, function(err) {
         if (err && err.message === 'ns not found') {
@@ -500,8 +500,8 @@ function noRawDataIfEntityCaseChange(params, done) {
             method: 'GET',
             headers: {
                 'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -543,8 +543,8 @@ function rawDataAvailableDateFilter(params, done) {
             method: 'GET',
             headers: {
                 'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -606,15 +606,15 @@ function noAggregatedDataIfEntityCaseChangeTest(params, done) {
                 {
                     aggrMethod: aggrMethod,
                     aggrPeriod: resolution,
-                    changeEntityCase: true,
+                    changeEntityCase: true
                 },
                 attrName
             ),
             method: 'GET',
             headers: {
                 'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -684,15 +684,15 @@ function noAggregatedDataSinceDateTest(params, done) {
                     aggrPeriod: resolution,
                     dateFrom: sthUtils.getISODateString(
                         sthUtils.getOrigin(new Date(events[events.length - 1].recvTime.getTime() + offset), resolution)
-                    ),
+                    )
                 },
                 attrName
             ),
             method: 'GET',
             headers: {
                 'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -741,15 +741,15 @@ function aggregatedDataAvailableSinceDateTest(params, done) {
                     aggrPeriod: resolution,
                     dateFrom: sthUtils.getISODateString(
                         sthUtils.getOrigin(events[events.length - 1].recvTime, resolution)
-                    ),
+                    )
                 },
                 attrName
             ),
             method: 'GET',
             headers: {
                 'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var theEvent = events[events.length - 1];
@@ -881,7 +881,7 @@ function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
                 servicePath: sthConfig.DEFAULT_SERVICE_PATH,
                 attrName: attrName,
                 options: optionsForCaseSensitivity,
-                checkRecvTime: checkRecvTime,
+                checkRecvTime: checkRecvTime
             })
         );
 
@@ -892,7 +892,7 @@ function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
                 servicePath: sthConfig.DEFAULT_SERVICE_PATH,
                 attrName: attrName,
                 options: optionsWithNoDates,
-                checkRecvTime: checkRecvTime,
+                checkRecvTime: checkRecvTime
             })
         );
 
@@ -903,7 +903,7 @@ function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
                 servicePath: sthConfig.DEFAULT_SERVICE_PATH,
                 attrName: attrName,
                 options: optionsWithDateFrom,
-                checkRecvTime: checkRecvTime,
+                checkRecvTime: checkRecvTime
             })
         );
 
@@ -914,7 +914,7 @@ function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
                 servicePath: sthConfig.DEFAULT_SERVICE_PATH,
                 attrName: attrName,
                 options: optionsWithDateTo,
-                checkRecvTime: checkRecvTime,
+                checkRecvTime: checkRecvTime
             })
         );
 
@@ -925,7 +925,7 @@ function rawDataRetrievalSuite(options, attrName, attrType, checkRecvTime) {
                 servicePath: sthConfig.DEFAULT_SERVICE_PATH,
                 attrName: attrName,
                 options: optionsWithFromAndToDate,
-                checkRecvTime: checkRecvTime,
+                checkRecvTime: checkRecvTime
             })
         );
     });
@@ -946,7 +946,7 @@ function aggregatedDataRetrievalTests(index, attrName, attrType, aggrMethod) {
             servicePath: sthConfig.DEFAULT_SERVICE_PATH,
             attrName: attrName,
             aggrMethod: aggrMethod,
-            resolution: sthConfig.AGGREGATION_BY[index],
+            resolution: sthConfig.AGGREGATION_BY[index]
         })
     );
 
@@ -957,7 +957,7 @@ function aggregatedDataRetrievalTests(index, attrName, attrType, aggrMethod) {
             servicePath: sthConfig.DEFAULT_SERVICE_PATH,
             attrName: attrName,
             aggrMethod: aggrMethod,
-            resolution: sthConfig.AGGREGATION_BY[index],
+            resolution: sthConfig.AGGREGATION_BY[index]
         })
     );
 
@@ -969,7 +969,7 @@ function aggregatedDataRetrievalTests(index, attrName, attrType, aggrMethod) {
             attrName: attrName,
             attrType: attrType,
             aggrMethod: aggrMethod,
-            resolution: sthConfig.AGGREGATION_BY[index],
+            resolution: sthConfig.AGGREGATION_BY[index]
         })
     );
 }
@@ -1019,7 +1019,7 @@ function noAttributesTest(service, servicePath, done) {
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
                 'Fiware-Service': service || sthConfig.SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH,
+                'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH
             },
             json: true,
             body: {
@@ -1031,39 +1031,39 @@ function noAttributesTest(service, servicePath, done) {
                             attributes: [],
                             type: sthTestConfig.ENTITY_TYPE,
                             isPattern: 'false',
-                            id: sthTestConfig.ENTITY_ID,
+                            id: sthTestConfig.ENTITY_ID
                         },
                         statusCode: {
                             code: '200',
-                            reasonPhrase: 'OK',
-                        },
+                            reasonPhrase: 'OK'
+                        }
                     },
                     {
                         contextElement: {
                             attributes: [],
                             type: sthTestConfig.ENTITY_TYPE,
                             isPattern: 'false',
-                            id: sthTestConfig.ENTITY_ID,
+                            id: sthTestConfig.ENTITY_ID
                         },
                         statusCode: {
                             code: '200',
-                            reasonPhrase: 'OK',
-                        },
+                            reasonPhrase: 'OK'
+                        }
                     },
                     {
                         contextElement: {
                             attributes: [],
                             type: sthTestConfig.ENTITY_TYPE,
                             isPattern: 'false',
-                            id: sthTestConfig.ENTITY_ID,
+                            id: sthTestConfig.ENTITY_ID
                         },
                         statusCode: {
                             code: '200',
-                            reasonPhrase: 'OK',
-                        },
-                    },
-                ],
-            },
+                            reasonPhrase: 'OK'
+                        }
+                    }
+                ]
+            }
         },
         function(err, response, body) {
             expect(err).to.equal(null);
@@ -1095,17 +1095,17 @@ function nonAggregatableAttributeValuesTest(service, servicePath, done) {
                         {
                             name: sthTestConfig.ATTRIBUTE_NAME,
                             type: sthTestConfig.ATTRIBUTE_TYPE,
-                            value: '',
-                        },
+                            value: ''
+                        }
                     ],
                     type: sthTestConfig.ENTITY_TYPE,
                     isPattern: 'false',
-                    id: sthTestConfig.ENTITY_ID,
+                    id: sthTestConfig.ENTITY_ID
                 },
                 statusCode: {
                     code: '200',
-                    reasonPhrase: 'OK',
-                },
+                    reasonPhrase: 'OK'
+                }
             },
             {
                 contextElement: {
@@ -1113,17 +1113,17 @@ function nonAggregatableAttributeValuesTest(service, servicePath, done) {
                         {
                             name: sthTestConfig.ATTRIBUTE_NAME,
                             type: sthTestConfig.ATTRIBUTE_TYPE,
-                            value: ['just', 'an', 'array'],
-                        },
+                            value: ['just', 'an', 'array']
+                        }
                     ],
                     type: sthTestConfig.ENTITY_TYPE,
                     isPattern: 'false',
-                    id: sthTestConfig.ENTITY_ID,
+                    id: sthTestConfig.ENTITY_ID
                 },
                 statusCode: {
                     code: '200',
-                    reasonPhrase: 'OK',
-                },
+                    reasonPhrase: 'OK'
+                }
             },
             {
                 contextElement: {
@@ -1132,20 +1132,20 @@ function nonAggregatableAttributeValuesTest(service, servicePath, done) {
                             name: sthTestConfig.ATTRIBUTE_NAME,
                             type: sthTestConfig.ATTRIBUTE_TYPE,
                             value: {
-                                just: 'an object',
-                            },
-                        },
+                                just: 'an object'
+                            }
+                        }
                     ],
                     type: sthTestConfig.ENTITY_TYPE,
                     isPattern: 'false',
-                    id: sthTestConfig.ENTITY_ID,
+                    id: sthTestConfig.ENTITY_ID
                 },
                 statusCode: {
                     code: '200',
-                    reasonPhrase: 'OK',
-                },
-            },
-        ],
+                    reasonPhrase: 'OK'
+                }
+            }
+        ]
     };
     if (sthConfig.IGNORE_BLANK_SPACES) {
         body.contextResponses.push(
@@ -1155,17 +1155,17 @@ function nonAggregatableAttributeValuesTest(service, servicePath, done) {
                         {
                             name: sthTestConfig.ATTRIBUTE_NAME,
                             type: sthTestConfig.ATTRIBUTE_TYPE,
-                            value: ' ', // Blank space
-                        },
+                            value: ' ' // Blank space
+                        }
                     ],
                     type: sthTestConfig.ENTITY_TYPE,
                     isPattern: 'false',
-                    id: sthTestConfig.ENTITY_ID,
+                    id: sthTestConfig.ENTITY_ID
                 },
                 statusCode: {
                     code: '200',
-                    reasonPhrase: 'OK',
-                },
+                    reasonPhrase: 'OK'
+                }
             },
             {
                 contextElement: {
@@ -1173,17 +1173,17 @@ function nonAggregatableAttributeValuesTest(service, servicePath, done) {
                         {
                             name: sthTestConfig.ATTRIBUTE_NAME,
                             type: sthTestConfig.ATTRIBUTE_TYPE,
-                            value: '   ', // Several blank space
-                        },
+                            value: '   ' // Several blank space
+                        }
                     ],
                     type: sthTestConfig.ENTITY_TYPE,
                     isPattern: 'false',
-                    id: sthTestConfig.ENTITY_ID,
+                    id: sthTestConfig.ENTITY_ID
                 },
                 statusCode: {
                     code: '200',
-                    reasonPhrase: 'OK',
-                },
+                    reasonPhrase: 'OK'
+                }
             }
         );
     }
@@ -1195,10 +1195,10 @@ function nonAggregatableAttributeValuesTest(service, servicePath, done) {
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
                 'Fiware-Service': service || sthConfig.SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH,
+                'Fiware-ServicePath': servicePath || sthConfig.SERVICE_PATH
             },
             json: true,
-            body: body,
+            body: body
         },
         function(err, response) {
             expect(err).to.equal(null);
@@ -1234,7 +1234,7 @@ function complexNotificationSuite(attrName, attrType, includeTimeInstantMetadata
                     servicePath: sthConfig.DEFAULT_SERVICE_PATH,
                     attrName: attrName,
                     attrType: attrType,
-                    includeTimeInstantMetadata: includeTimeInstantMetadata,
+                    includeTimeInstantMetadata: includeTimeInstantMetadata
                 })
             );
         });
@@ -1336,7 +1336,7 @@ complexNotificationTest = function complexNotificationTest(params, done) {
     var attribute = {
         name: anEvent.attrName,
         type: anEvent.attrType,
-        value: anEvent.attrValue,
+        value: anEvent.attrValue
     };
 
     if (includeTimeInstantMetadata) {
@@ -1344,8 +1344,8 @@ complexNotificationTest = function complexNotificationTest(params, done) {
             {
                 name: 'TimeInstant',
                 type: 'ISO8601',
-                value: now,
-            },
+                value: now
+            }
         ];
     }
 
@@ -1355,12 +1355,12 @@ complexNotificationTest = function complexNotificationTest(params, done) {
                 attributes: [attribute],
                 type: sthTestConfig.ENTITY_TYPE,
                 isPattern: 'false',
-                id: sthTestConfig.ENTITY_ID,
+                id: sthTestConfig.ENTITY_ID
             },
             statusCode: {
                 code: '200',
-                reasonPhrase: 'OK',
-            },
+                reasonPhrase: 'OK'
+            }
         });
     }
     request(
@@ -1371,14 +1371,14 @@ complexNotificationTest = function complexNotificationTest(params, done) {
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
                 'Fiware-Service': service || sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH,
+                'Fiware-ServicePath': servicePath || sthConfig.DEFAULT_SERVICE_PATH
             },
             json: true,
             body: {
                 subscriptionId: '1234567890ABCDF123456789',
                 originator: 'orion.contextBroker.instance',
-                contextResponses: contextResponses,
-            },
+                contextResponses: contextResponses
+            }
         },
         function(err, response, body) {
             for (var i = 0; i < 3; i++) {
@@ -1404,8 +1404,8 @@ function status200Test(options, done) {
             method: 'GET',
             headers: {
                 'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -1448,7 +1448,7 @@ function numericAggregatedDataUpdatedTest(contextResponseFile, aggrMethod, resol
                             .metadatas[0].value,
                     dateTo:
                         contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
-                            .metadatas[0].value,
+                            .metadatas[0].value
                 },
                 contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
             ),
@@ -1457,8 +1457,8 @@ function numericAggregatedDataUpdatedTest(contextResponseFile, aggrMethod, resol
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
                 'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -1520,7 +1520,7 @@ function textualAggregatedDataUpdatedTest(contextResponseFile, resolution, done)
                             .metadatas[0].value,
                     dateTo:
                         contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
-                            .metadatas[0].value,
+                            .metadatas[0].value
                 },
                 contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
             ),
@@ -1529,8 +1529,8 @@ function textualAggregatedDataUpdatedTest(contextResponseFile, resolution, done)
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
                 'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -1582,7 +1582,7 @@ function aggregatedDataNonExistentTest(contextResponseFile, aggrMethod, resoluti
                             .metadatas[0].value,
                     dateTo:
                         contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
-                            .metadatas[0].value,
+                            .metadatas[0].value
                 },
                 contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
             ),
@@ -1591,8 +1591,8 @@ function aggregatedDataNonExistentTest(contextResponseFile, aggrMethod, resoluti
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
                 'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-            },
+                'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+            }
         },
         function(err, response, body) {
             var bodyJSON = JSON.parse(body);
@@ -1629,14 +1629,14 @@ function dataRemovalSuite(aggregationType, removalOptions) {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
                     'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                 },
                 json: true,
                 body: {
                     subscriptionId: '1234567890ABCDF123456789',
                     originator: 'orion.contextBroker.instance',
-                    contextResponses: contextResponsesObj.contextResponses,
-                },
+                    contextResponses: contextResponsesObj.contextResponses
+                }
             },
             function(err, response, body) {
                 expect(body).to.be(undefined);
@@ -1654,7 +1654,7 @@ function dataRemovalSuite(aggregationType, removalOptions) {
                         lastN: 0,
                         dateFrom:
                             contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
-                        dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
+                        dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value
                     },
                     contextResponsesObj.contextResponses[0].contextElement.attributes[0].name
                 ),
@@ -1663,8 +1663,8 @@ function dataRemovalSuite(aggregationType, removalOptions) {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
                     'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                },
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                }
             },
             function(err, response, body) {
                 var bodyJSON = JSON.parse(body);
@@ -1743,14 +1743,14 @@ function dataRemovalSuite(aggregationType, removalOptions) {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
                     'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                 },
                 json: true,
                 body: {
                     subscriptionId: '1234567890ABCDF123456789',
                     originator: 'orion.contextBroker.instance',
-                    contextResponses: contextResponsesObj.contextResponses,
-                },
+                    contextResponses: contextResponsesObj.contextResponses
+                }
             },
             function(err, response, body) {
                 expect(body).to.be(undefined);
@@ -1768,7 +1768,7 @@ function dataRemovalSuite(aggregationType, removalOptions) {
                         lastN: 0,
                         dateFrom:
                             contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
-                        dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value,
+                        dateTo: contextResponsesObj.contextResponses[0].contextElement.attributes[0].metadatas[0].value
                     },
                     contextResponsesObj.contextResponses[0].contextElement.attributes[0].name
                 ),
@@ -1777,8 +1777,8 @@ function dataRemovalSuite(aggregationType, removalOptions) {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
                     'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                },
+                    'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                }
             },
             function(err, response, body) {
                 var bodyJSON = JSON.parse(body);
@@ -1854,9 +1854,9 @@ function validLogLevelChangeTest(level, done) {
     request(
         {
             uri: getURL(sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL, {
-                level: level,
+                level: level
             }),
-            method: 'PUT',
+            method: 'PUT'
         },
         function(err, response) {
             expect(err).to.equal(null);
@@ -1882,5 +1882,5 @@ module.exports = {
     textualAggregatedDataUpdatedTest: textualAggregatedDataUpdatedTest,
     aggregatedDataNonExistentTest: aggregatedDataNonExistentTest,
     dataRemovalSuite: dataRemovalSuite,
-    validLogLevelChangeTest: validLogLevelChangeTest,
+    validLogLevelChangeTest: validLogLevelChangeTest
 };

--- a/test/unit/sth_test.js
+++ b/test/unit/sth_test.js
@@ -48,7 +48,7 @@ describe('sth tests', function() {
                     dbURI: sthConfig.DB_URI,
                     replicaSet: sthConfig.REPLICA_SET,
                     database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-                    poolSize: sthConfig.POOL_SIZE,
+                    poolSize: sthConfig.POOL_SIZE
                 },
                 function(err) {
                     done(err);
@@ -74,7 +74,7 @@ describe('sth tests', function() {
             request(
                 {
                     uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
-                    method: 'PUT',
+                    method: 'PUT'
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -91,9 +91,9 @@ describe('sth tests', function() {
             request(
                 {
                     uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ, {
-                        invalidPath: true,
+                        invalidPath: true
                     }),
-                    method: 'GET',
+                    method: 'GET'
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -110,7 +110,7 @@ describe('sth tests', function() {
             request(
                 {
                     uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
-                    method: 'GET',
+                    method: 'GET'
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -129,8 +129,8 @@ describe('sth tests', function() {
                     uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
                     method: 'GET',
                     headers: {
-                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                    },
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -153,8 +153,8 @@ describe('sth tests', function() {
                         method: 'GET',
                         headers: {
                             'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                            'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                        },
+                            'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                        }
                     },
                     function(err, response, body) {
                         var bodyJSON = JSON.parse(body);
@@ -186,7 +186,7 @@ describe('sth tests', function() {
             'should respond with 200 - OK if hLimit and hOffset query params',
             sthTestUtils.status200Test.bind(null, {
                 hLimit: 1,
-                hOffset: 1,
+                hOffset: 1
             })
         );
 
@@ -194,7 +194,7 @@ describe('sth tests', function() {
             'should respond with 200 - OK if aggrMethod and aggrPeriod query params',
             sthTestUtils.status200Test.bind(null, {
                 aggrMethod: 'min',
-                aggrPeriod: 'second',
+                aggrPeriod: 'second'
             })
         );
     });
@@ -313,14 +313,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseNumericWithFixedTimeInstant.contextResponses,
-                    },
+                        contextResponses: contextResponseNumericWithFixedTimeInstant.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -338,14 +338,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseNumericWithFixedTimeInstant.contextResponses,
-                    },
+                        contextResponses: contextResponseNumericWithFixedTimeInstant.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -366,7 +366,7 @@ describe('sth tests', function() {
                                     .attributes[0].metadatas[0].value,
                             dateTo:
                                 contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement
-                                    .attributes[0].metadatas[0].value,
+                                    .attributes[0].metadatas[0].value
                         },
                         contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
                     ),
@@ -375,8 +375,8 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                    },
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -451,14 +451,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseTextualWithFixedTimeInstant.contextResponses,
-                    },
+                        contextResponses: contextResponseTextualWithFixedTimeInstant.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -476,14 +476,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseTextualWithFixedTimeInstant.contextResponses,
-                    },
+                        contextResponses: contextResponseTextualWithFixedTimeInstant.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -504,7 +504,7 @@ describe('sth tests', function() {
                                     .attributes[0].metadatas[0].value,
                             dateTo:
                                 contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement
-                                    .attributes[0].metadatas[0].value,
+                                    .attributes[0].metadatas[0].value
                         },
                         contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
                     ),
@@ -513,8 +513,8 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                    },
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -558,14 +558,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses,
-                    },
+                        contextResponses: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -583,14 +583,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses,
-                    },
+                        contextResponses: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -611,7 +611,7 @@ describe('sth tests', function() {
                                     .attributes[0].metadatas[0].value,
                             dateTo:
                                 contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement
-                                    .attributes[0].metadatas[0].value,
+                                    .attributes[0].metadatas[0].value
                         },
                         contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement
                             .attributes[0].name
@@ -621,8 +621,8 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                    },
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -697,14 +697,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses,
-                    },
+                        contextResponses: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -722,14 +722,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses,
-                    },
+                        contextResponses: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -750,7 +750,7 @@ describe('sth tests', function() {
                                     .attributes[0].metadatas[0].value,
                             dateTo:
                                 contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement
-                                    .attributes[0].metadatas[0].value,
+                                    .attributes[0].metadatas[0].value
                         },
                         contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement
                             .attributes[0].name
@@ -760,8 +760,8 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                    },
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -805,14 +805,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseArrayWithFixedTimeInstant.contextResponses,
-                    },
+                        contextResponses: contextResponseArrayWithFixedTimeInstant.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -833,7 +833,7 @@ describe('sth tests', function() {
                                     .attributes[0].metadatas[0].value,
                             dateTo:
                                 contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement
-                                    .attributes[0].metadatas[0].value,
+                                    .attributes[0].metadatas[0].value
                         },
                         contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
                     ),
@@ -842,8 +842,8 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                    },
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -927,14 +927,14 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                     },
                     json: true,
                     body: {
                         subscriptionId: '1234567890ABCDF123456789',
                         originator: 'orion.contextBroker.instance',
-                        contextResponses: contextResponseObjectWithFixedTimeInstant.contextResponses,
-                    },
+                        contextResponses: contextResponseObjectWithFixedTimeInstant.contextResponses
+                    }
                 },
                 function(err, response, body) {
                     expect(body).to.be(undefined);
@@ -955,7 +955,7 @@ describe('sth tests', function() {
                                     .attributes[0].metadatas[0].value,
                             dateTo:
                                 contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement
-                                    .attributes[0].metadatas[0].value,
+                                    .attributes[0].metadatas[0].value
                         },
                         contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
                     ),
@@ -964,8 +964,8 @@ describe('sth tests', function() {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                         'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
-                    },
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+                    }
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);
@@ -1044,7 +1044,7 @@ describe('sth tests', function() {
                 entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
                 attrName:
                     contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0]
-                        .name,
+                        .name
             })
         );
 
@@ -1052,7 +1052,7 @@ describe('sth tests', function() {
             'Removal of concrete entities including numeric data',
             sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.NUMERIC, {
                 entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
-                entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
+                entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type
             })
         );
 
@@ -1068,7 +1068,7 @@ describe('sth tests', function() {
                 entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
                 attrName:
                     contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0]
-                        .name,
+                        .name
             })
         );
 
@@ -1076,7 +1076,7 @@ describe('sth tests', function() {
             'Removal of concrete entities including textual data',
             sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.TEXTUAL, {
                 entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
-                entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
+                entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type
             })
         );
 
@@ -1104,9 +1104,9 @@ describe('sth tests', function() {
             request(
                 {
                     uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL, {
-                        level: 'deBug',
+                        level: 'deBug'
                     }),
-                    method: 'PUT',
+                    method: 'PUT'
                 },
                 function(err, response) {
                     expect(err).to.equal(null);
@@ -1122,7 +1122,7 @@ describe('sth tests', function() {
             request(
                 {
                     uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.VERSION),
-                    method: 'GET',
+                    method: 'GET'
                 },
                 function(err, response, body) {
                     var bodyJSON = JSON.parse(body);

--- a/test/unit/sth_test.js
+++ b/test/unit/sth_test.js
@@ -40,994 +40,1105 @@ console.log('\n***** Unit tests environment variables:');
 console.log(sthTestConfig);
 
 describe('sth tests', function() {
-  describe('database connection', function () {
-    it('should be a database available', function (done) {
-      sth.sthDatabase.connect(
-        {
-          authentication: sthConfig.DB_AUTHENTICATION,
-          dbURI: sthConfig.DB_URI,
-          replicaSet: sthConfig.REPLICA_SET,
-          database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-          poolSize: sthConfig.POOL_SIZE
-        },
-        function (err) {
-          done(err);
-        }
-      );
-    });
-  });
-
-  describe('database clean up', sthTestUtils.cleanDatabaseSuite);
-
-  describe('server start', function () {
-    it('should start gracefully', function (done) {
-      sth.sthServer.startServer(
-        sthConfig.STH_HOST,
-        sthConfig.STH_PORT,
-        function (err, server) {
-          expect(err).to.equal(null);
-          expect(server).to.be.a(hapi.Server);
-          done();
+    describe('database connection', function() {
+        it('should be a database available', function(done) {
+            sth.sthDatabase.connect(
+                {
+                    authentication: sthConfig.DB_AUTHENTICATION,
+                    dbURI: sthConfig.DB_URI,
+                    replicaSet: sthConfig.REPLICA_SET,
+                    database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+                    poolSize: sthConfig.POOL_SIZE,
+                },
+                function(err) {
+                    done(err);
+                }
+            );
         });
     });
-  });
 
-  describe('invalid routes', function () {
-    it('should respond with 404 - Not Found if invalid HTTP method', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
-        method: 'PUT'
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(err).to.equal(null);
-        expect(response.statusCode).to.equal(404);
-        expect(bodyJSON.statusCode).to.equal(404);
-        expect(bodyJSON.error).to.equal('Not Found');
-        done();
-      });
-    });
+    describe('database clean up', sthTestUtils.cleanDatabaseSuite);
 
-    it('should respond with 404 - Not Found if invalid path', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ, {
-          invalidPath: true
-        }),
-        method: 'GET'
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(err).to.equal(null);
-        expect(response.statusCode).to.equal(404);
-        expect(bodyJSON.statusCode).to.equal(404);
-        expect(bodyJSON.error).to.equal('Not Found');
-        done();
-      });
-    });
-
-    it('should respond with 400 - Bad Request if missing Fiware-Service header', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
-        method: 'GET'
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(err).to.equal(null);
-        expect(response.statusCode).to.equal(400);
-        expect(bodyJSON.statusCode).to.equal(400);
-        expect(bodyJSON.error).to.equal('Bad Request');
-        done();
-      });
-    });
-
-    it('should respond with 400 - Bad Request if missing Fiware-ServicePath header', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
-        method: 'GET',
-        headers: {
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(err).to.equal(null);
-        expect(response.statusCode).to.equal(400);
-        expect(bodyJSON.statusCode).to.equal(400);
-        expect(bodyJSON.error).to.equal('Bad Request');
-        done();
-      });
-    });
-
-    it('should respond with 400 - Bad Request if missing lastN, hLimit and hOffset or aggrMethod and aggrPeriod ' +
-      'query params',
-      function (done) {
-        request({
-          uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
-          method: 'GET',
-          headers: {
-            'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-            'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-          }
-        }, function (err, response, body) {
-          var bodyJSON = JSON.parse(body);
-          expect(err).to.equal(null);
-          expect(response.statusCode).to.equal(400);
-          expect(bodyJSON.statusCode).to.equal(400);
-          expect(bodyJSON.error).to.equal('Bad Request');
-          expect(bodyJSON.validation.source).to.equal('query');
-          expect(bodyJSON.validation.keys).to.be.an(Array);
-          expect(bodyJSON.validation.keys.indexOf('lastN')).to.not.equal(-1);
-          expect(bodyJSON.validation.keys.indexOf('hLimit')).to.not.equal(-1);
-          expect(bodyJSON.validation.keys.indexOf('hOffset')).to.not.equal(-1);
-          expect(bodyJSON.validation.keys.indexOf('aggrMethod')).to.not.equal(-1);
-          expect(bodyJSON.validation.keys.indexOf('aggrPeriod')).to.not.equal(-1);
-          done();
+    describe('server start', function() {
+        it('should start gracefully', function(done) {
+            sth.sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(err, server) {
+                expect(err).to.equal(null);
+                expect(server).to.be.a(hapi.Server);
+                done();
+            });
         });
-      });
-
-    it('should respond with 200 - OK if lastN query param', sthTestUtils.status200Test.bind(null, {lastN: 1}));
-
-    it('should respond with 200 - OK if lastN and count query params',
-       sthTestUtils.status200Test.bind(null, {lastN: 1, count: true}));
-
-    it('should respond with 200 - OK if hLimit and hOffset query params',
-      sthTestUtils.status200Test.bind(
-        null,
-        {
-          hLimit: 1,
-          hOffset: 1
-        }
-      )
-    );
-
-    it('should respond with 200 - OK if aggrMethod and aggrPeriod query params',
-      sthTestUtils.status200Test.bind(
-        null,
-        {
-          aggrMethod: 'min',
-          aggrPeriod: 'second'
-        }
-      )
-    );
-  });
-
-  function eachEventTestSuiteContainer(attrName, attrType, includeTimeInstantMetadata) {
-    describe('for each new event with attribute of type ' + attrType,
-      sthTestUtils.eachEventTestSuite.bind(null, attrName, attrType, includeTimeInstantMetadata));
-  }
-
-  for (var i = 0; i < sthTestConfig.SAMPLES; i++) {
-    describe('data storage', eachEventTestSuiteContainer.bind(
-      null, 'attribute-float', 'float', i % 2));
-
-    describe('raw data retrieval',
-      sthTestUtils.rawDataRetrievalSuite.bind(null, {lastN: i + 1}, 'attribute-float', 'float', true));
-
-    describe('raw data retrieval',
-      sthTestUtils.rawDataRetrievalSuite.bind(null, {hLimit: 1, hOffset: i}, 'attribute-float', 'float', true));
-
-    describe('raw data retrieval',
-      // FIXME: As discussed @fgalan and @AlvaroVega F2F, it would be great to have a unit test that checks not 
-      // only existence of fiware-total-count header, but also that is actually working. I mean, for instance, 
-      // having 4 items in the raw collection, set count=true in the request and check not only that 
-      // fiware-total-count is in the response, but also that its value is 4.
-      //
-      // However, it is not clear if the cost of developing such unit test would be high, given the current "style" 
-      // in the unit tests in this componente. This FIXME is a remark about this future improvement.
-      sthTestUtils.rawDataRetrievalSuite.bind(null, {hLimit: 1, hOffset: i, count: true},
-          'attribute-float', 'float', false));
-
-    describe('aggregated data retrieval',
-      sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'min'));
-
-    describe('aggregated data retrieval',
-      sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'max'));
-
-    describe('aggregated data retrieval',
-      sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'sum'));
-
-    describe('aggregated data retrieval',
-      sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'sum2'));
-  }
-
-  for (var j = 0; j < sthTestConfig.SAMPLES; j++) {
-    describe('data storage', eachEventTestSuiteContainer.bind(
-      null, 'attribute-string', 'string', j % 2));
-
-    describe('raw data retrieval',
-      sthTestUtils.rawDataRetrievalSuite.bind(null, {lastN: j + 1}, 'attribute-string', 'string', true));
-
-    describe('raw data retrieval',
-      sthTestUtils.rawDataRetrievalSuite.bind(null, {hLimit: 1, hOffset: j}, 'attribute-string', 'string', true));
-
-    describe('aggregated data retrieval',
-      sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-string', 'string', 'occur'));
-  }
-
-  describe('notification of numeric data without TimeInstant metadata by the Orion Context Broker of',
-    sthTestUtils.eventNotificationSuite.bind(null, 'attribute-float-1', 'float', false));
-
-  describe('notification of textual data without TimeInstant metadata by the Orion Context Broker of',
-    sthTestUtils.eventNotificationSuite.bind(null, 'attribute-string-1', 'string', false));
-
-  describe('notification of numeric data with TimeInstant metadata by the Orion Context Broker of',
-    sthTestUtils.eventNotificationSuite.bind(null, 'attribute-float-2', 'float', true));
-
-  describe('notification of numeric data with TimeInstant metadata by the Orion Context Broker of',
-    sthTestUtils.eventNotificationSuite.bind(null, 'attribute-string-2', 'string', true));
-
-  describe('notification of already existent numeric data should register it only once', function() {
-    var contextResponseNumericWithFixedTimeInstant;
-
-    before(function() {
-     contextResponseNumericWithFixedTimeInstant =
-        require('./contextResponses/contextResponseNumericWithFixedTimeInstant');
     });
 
-    it('should store the raw and aggregated data for the first time', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseNumericWithFixedTimeInstant.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
+    describe('invalid routes', function() {
+        it('should respond with 404 - Not Found if invalid HTTP method', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
+                    method: 'PUT',
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(err).to.equal(null);
+                    expect(response.statusCode).to.equal(404);
+                    expect(bodyJSON.statusCode).to.equal(404);
+                    expect(bodyJSON.error).to.equal('Not Found');
+                    done();
+                }
+            );
+        });
+
+        it('should respond with 404 - Not Found if invalid path', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ, {
+                        invalidPath: true,
+                    }),
+                    method: 'GET',
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(err).to.equal(null);
+                    expect(response.statusCode).to.equal(404);
+                    expect(bodyJSON.statusCode).to.equal(404);
+                    expect(bodyJSON.error).to.equal('Not Found');
+                    done();
+                }
+            );
+        });
+
+        it('should respond with 400 - Bad Request if missing Fiware-Service header', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
+                    method: 'GET',
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(err).to.equal(null);
+                    expect(response.statusCode).to.equal(400);
+                    expect(bodyJSON.statusCode).to.equal(400);
+                    expect(bodyJSON.error).to.equal('Bad Request');
+                    done();
+                }
+            );
+        });
+
+        it('should respond with 400 - Bad Request if missing Fiware-ServicePath header', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
+                    method: 'GET',
+                    headers: {
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(err).to.equal(null);
+                    expect(response.statusCode).to.equal(400);
+                    expect(bodyJSON.statusCode).to.equal(400);
+                    expect(bodyJSON.error).to.equal('Bad Request');
+                    done();
+                }
+            );
+        });
+
+        it(
+            'should respond with 400 - Bad Request if missing lastN, hLimit and hOffset or aggrMethod and aggrPeriod ' +
+                'query params',
+            function(done) {
+                request(
+                    {
+                        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
+                        method: 'GET',
+                        headers: {
+                            'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                            'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                        },
+                    },
+                    function(err, response, body) {
+                        var bodyJSON = JSON.parse(body);
+                        expect(err).to.equal(null);
+                        expect(response.statusCode).to.equal(400);
+                        expect(bodyJSON.statusCode).to.equal(400);
+                        expect(bodyJSON.error).to.equal('Bad Request');
+                        expect(bodyJSON.validation.source).to.equal('query');
+                        expect(bodyJSON.validation.keys).to.be.an(Array);
+                        expect(bodyJSON.validation.keys.indexOf('lastN')).to.not.equal(-1);
+                        expect(bodyJSON.validation.keys.indexOf('hLimit')).to.not.equal(-1);
+                        expect(bodyJSON.validation.keys.indexOf('hOffset')).to.not.equal(-1);
+                        expect(bodyJSON.validation.keys.indexOf('aggrMethod')).to.not.equal(-1);
+                        expect(bodyJSON.validation.keys.indexOf('aggrPeriod')).to.not.equal(-1);
+                        done();
+                    }
+                );
+            }
+        );
+
+        it('should respond with 200 - OK if lastN query param', sthTestUtils.status200Test.bind(null, { lastN: 1 }));
+
+        it(
+            'should respond with 200 - OK if lastN and count query params',
+            sthTestUtils.status200Test.bind(null, { lastN: 1, count: true })
+        );
+
+        it(
+            'should respond with 200 - OK if hLimit and hOffset query params',
+            sthTestUtils.status200Test.bind(null, {
+                hLimit: 1,
+                hOffset: 1,
+            })
+        );
+
+        it(
+            'should respond with 200 - OK if aggrMethod and aggrPeriod query params',
+            sthTestUtils.status200Test.bind(null, {
+                aggrMethod: 'min',
+                aggrPeriod: 'second',
+            })
+        );
     });
 
-    it('should try to store the raw and aggregated data for second time', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseNumericWithFixedTimeInstant.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
-
-    it('should only retrieve the raw data as stored once', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.READ,
-          {
-            lastN: 0,
-            dateFrom: contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value,
-            dateTo: contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value
-          },
-          contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-        ),
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
-          contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value);
-        expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-        expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-        done(err);
-      });
-    });
-
-    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-      it('should have only accumulated the sum aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'sum',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-
-      it('should have only accumulated the sum2 aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'sum2',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-
-      it('should have only accumulated the max aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'max',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-
-      it('should have only accumulated the min aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstant',
-          'min',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+    function eachEventTestSuiteContainer(attrName, attrType, includeTimeInstantMetadata) {
+        describe(
+            'for each new event with attribute of type ' + attrType,
+            sthTestUtils.eachEventTestSuite.bind(null, attrName, attrType, includeTimeInstantMetadata)
+        );
     }
-  });
 
-  describe('notification of already existent textual data should register it only once', function() {
-    var contextResponseTextualWithFixedTimeInstant;
+    for (var i = 0; i < sthTestConfig.SAMPLES; i++) {
+        describe('data storage', eachEventTestSuiteContainer.bind(null, 'attribute-float', 'float', i % 2));
 
-    before(function() {
-      contextResponseTextualWithFixedTimeInstant =
-        require('./contextResponses/contextResponseTextualWithFixedTimeInstant');
-    });
+        describe(
+            'raw data retrieval',
+            sthTestUtils.rawDataRetrievalSuite.bind(null, { lastN: i + 1 }, 'attribute-float', 'float', true)
+        );
 
-    it('should store the raw and aggregated data for the first time', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseTextualWithFixedTimeInstant.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
+        describe(
+            'raw data retrieval',
+            sthTestUtils.rawDataRetrievalSuite.bind(null, { hLimit: 1, hOffset: i }, 'attribute-float', 'float', true)
+        );
 
-    it('should try to store the raw and aggregated data for second time', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseTextualWithFixedTimeInstant.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
+        describe(
+            'raw data retrieval',
+            // FIXME: As discussed @fgalan and @AlvaroVega F2F, it would be great to have a unit test that checks not
+            // only existence of fiware-total-count header, but also that is actually working. I mean, for instance,
+            // having 4 items in the raw collection, set count=true in the request and check not only that
+            // fiware-total-count is in the response, but also that its value is 4.
+            //
+            // However, it is not clear if the cost of developing such unit test would be high, given the current "style"
+            // in the unit tests in this componente. This FIXME is a remark about this future improvement.
+            sthTestUtils.rawDataRetrievalSuite.bind(
+                null,
+                { hLimit: 1, hOffset: i, count: true },
+                'attribute-float',
+                'float',
+                false
+            )
+        );
 
-    it('should only retrieve the raw data as stored once', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.READ,
-          {
-            lastN: 0,
-            dateFrom: contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value,
-            dateTo: contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value
-          },
-          contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-        ),
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
-          contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value);
-        expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-        expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-        done(err);
-      });
-    });
+        describe(
+            'aggregated data retrieval',
+            sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'min')
+        );
 
-    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-      it('should have only accumulated the aggregated data once',
-        sthTestUtils.textualAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseTextualWithFixedTimeInstant',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+        describe(
+            'aggregated data retrieval',
+            sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'max')
+        );
+
+        describe(
+            'aggregated data retrieval',
+            sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'sum')
+        );
+
+        describe(
+            'aggregated data retrieval',
+            sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-float', 'float', 'sum2')
+        );
     }
-  });
 
-  describe('notification of an update to already existent numeric data should update the original value', function() {
-    var contextResponseNumericWithFixedTimeInstantUpdate;
+    for (var j = 0; j < sthTestConfig.SAMPLES; j++) {
+        describe('data storage', eachEventTestSuiteContainer.bind(null, 'attribute-string', 'string', j % 2));
 
-    before(function() {
-      contextResponseNumericWithFixedTimeInstantUpdate =
-        require('./contextResponses/contextResponseNumericWithFixedTimeInstantUpdate');
-    });
+        describe(
+            'raw data retrieval',
+            sthTestUtils.rawDataRetrievalSuite.bind(null, { lastN: j + 1 }, 'attribute-string', 'string', true)
+        );
 
-    it('should store the raw and aggregated data for the first time', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseNumericWithFixedTimeInstantUpdate.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
+        describe(
+            'raw data retrieval',
+            sthTestUtils.rawDataRetrievalSuite.bind(null, { hLimit: 1, hOffset: j }, 'attribute-string', 'string', true)
+        );
 
-    it('should update the already existent data', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseNumericWithFixedTimeInstantUpdate.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
-
-    it('should retrieve the updated raw data', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.READ,
-          {
-            lastN: 0,
-            dateFrom: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value,
-            dateTo: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value
-          },
-          contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].name
-        ),
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
-          contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].value);
-        expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-        expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-        done(err);
-      });
-    });
-
-    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-      it('should have only accumulated the sum updated aggregated data',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstantUpdate',
-          'sum',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-
-      it('should have only accumulated the sum2 aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstantUpdate',
-          'sum2',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-
-      it('should have only accumulated the max aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstantUpdate',
-          'max',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-
-      it('should have only accumulated the min aggregated data once',
-        sthTestUtils.numericAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseNumericWithFixedTimeInstantUpdate',
-          'min',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
+        describe(
+            'aggregated data retrieval',
+            sthTestUtils.aggregatedDataRetrievalSuite.bind(null, 'attribute-string', 'string', 'occur')
+        );
     }
-  });
 
-  describe('notification of already existent textual data should update the original value', function() {
-    var contextResponseTextualWithFixedTimeInstantUpdate;
-
-    before(function() {
-      contextResponseTextualWithFixedTimeInstantUpdate =
-        require('./contextResponses/contextResponseTextualWithFixedTimeInstantUpdate');
-    });
-
-    it('should store the raw and aggregated data for the first time', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseTextualWithFixedTimeInstantUpdate.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
-
-    it('should update the stored raw and aggregated data', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseTextualWithFixedTimeInstantUpdate.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
-
-    it('should retrieve the updated raw data', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.READ,
-          {
-            lastN: 0,
-            dateFrom: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value,
-            dateTo: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value
-          },
-          contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].name
-        ),
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
-          contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0].value);
-        expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-        expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-        done(err);
-      });
-    });
-
-    for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
-      it('should retrieve the updated aggregated data',
-        sthTestUtils.textualAggregatedDataUpdatedTest.bind(
-          null,
-          'contextResponseTextualWithFixedTimeInstantUpdate',
-          sthConfig.AGGREGATION_BY[i]
-        )
-      );
-    }
-  });
-
-  describe('notification of an array attribute value should register it only as raw data', function() {
-    var contextResponseArrayWithFixedTimeInstant;
-
-    before(function() {
-      contextResponseArrayWithFixedTimeInstant =
-        require('./contextResponses/contextResponseArrayWithFixedTimeInstant');
-    });
-
-    it('should store the raw data but not the aggregated data', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseArrayWithFixedTimeInstant.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
-
-    it('should retrieve the raw data', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.READ,
-          {
-            lastN: 0,
-            dateFrom: contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value,
-            dateTo: contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value
-          },
-          contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-        ),
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.eql(
-          contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value);
-        expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-        expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-        done(err);
-      });
-    });
-
-    for (var j = 0; j < sthConfig.AGGREGATION_BY.length; j++) {
-      it('should not retrieve the non-registered aggregated data if sum is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseArrayWithFixedTimeInstant',
-          'sum',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if sum2 is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseArrayWithFixedTimeInstant',
-          'sum2',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if max is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseArrayWithFixedTimeInstant',
-          'max',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if min is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseArrayWithFixedTimeInstant',
-          'min',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if occur is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseArrayWithFixedTimeInstant',
-          'occur',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-    }
-  });
-
-  describe('notification of an object attribute value should register it only as raw data', function() {
-    var contextResponseObjectWithFixedTimeInstant;
-
-    before(function() {
-      contextResponseObjectWithFixedTimeInstant =
-        require('./contextResponses/contextResponseObjectWithFixedTimeInstant');
-    });
-
-    it('should store the raw data but not the aggregated data', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        },
-        json: true,
-        body: {
-          'subscriptionId' : '1234567890ABCDF123456789',
-          'originator' : 'orion.contextBroker.instance',
-          'contextResponses' : contextResponseObjectWithFixedTimeInstant.contextResponses
-        }
-      }, function (err, response, body) {
-        expect(body).to.be(undefined);
-        done(err);
-      });
-    });
-
-    it('should retrieve the raw data', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.READ,
-          {
-            lastN: 0,
-            dateFrom: contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value,
-            dateTo: contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].
-              metadatas[0].value
-          },
-          contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
-        ),
-        method: 'GET',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'Fiware-Service': sthConfig.DEFAULT_SERVICE,
-          'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
-        }
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
-        expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.eql(
-          contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value);
-        expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
-        expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
-        done(err);
-      });
-    });
-
-    for (var j = 0; j < sthConfig.AGGREGATION_BY.length; j++) {
-      it('should not retrieve the non-registered aggregated data if sum is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseObjectWithFixedTimeInstant',
-          'sum',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if sum2 is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseObjectWithFixedTimeInstant',
-          'sum2',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if max is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseObjectWithFixedTimeInstant',
-          'max',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if min is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseObjectWithFixedTimeInstant',
-          'min',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-
-      it('should not retrieve the non-registered aggregated data if occur is requested',
-        sthTestUtils.aggregatedDataNonExistentTest.bind(
-          null,
-          'contextResponseObjectWithFixedTimeInstant',
-          'occur',
-          sthConfig.AGGREGATION_BY[j]
-        )
-      );
-    }
-  });
-
-  var contextResponseNumericWithFixedTimeInstantUpdate =
-    require('./contextResponses/contextResponseNumericWithFixedTimeInstantUpdate');
-  var contextResponseTextualWithFixedTimeInstantUpdate =
-    require('./contextResponses/contextResponseTextualWithFixedTimeInstantUpdate');
-
-  describe('Data removal', function() {
-    describe('Removal of concrete attributes of entities including numeric data',
-      sthTestUtils.dataRemovalSuite.bind(
-        null,
-        sthConfig.AGGREGATIONS.NUMERIC,
-        {
-          entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
-          entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
-          attrName: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.
-            attributes[0].name
-        }
-      )
+    describe(
+        'notification of numeric data without TimeInstant metadata by the Orion Context Broker of',
+        sthTestUtils.eventNotificationSuite.bind(null, 'attribute-float-1', 'float', false)
     );
 
-    describe('Removal of concrete entities including numeric data',
-      sthTestUtils.dataRemovalSuite.bind(
-        null,
-        sthConfig.AGGREGATIONS.NUMERIC,
-        {
-          entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
-          entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type
+    describe(
+        'notification of textual data without TimeInstant metadata by the Orion Context Broker of',
+        sthTestUtils.eventNotificationSuite.bind(null, 'attribute-string-1', 'string', false)
+    );
+
+    describe(
+        'notification of numeric data with TimeInstant metadata by the Orion Context Broker of',
+        sthTestUtils.eventNotificationSuite.bind(null, 'attribute-float-2', 'float', true)
+    );
+
+    describe(
+        'notification of numeric data with TimeInstant metadata by the Orion Context Broker of',
+        sthTestUtils.eventNotificationSuite.bind(null, 'attribute-string-2', 'string', true)
+    );
+
+    describe('notification of already existent numeric data should register it only once', function() {
+        var contextResponseNumericWithFixedTimeInstant;
+
+        before(function() {
+            contextResponseNumericWithFixedTimeInstant = require('./contextResponses/contextResponseNumericWithFixedTimeInstant');
+        });
+
+        it('should store the raw and aggregated data for the first time', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseNumericWithFixedTimeInstant.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should try to store the raw and aggregated data for second time', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseNumericWithFixedTimeInstant.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should only retrieve the raw data as stored once', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(
+                        sthTestConfig.API_OPERATION.READ,
+                        {
+                            lastN: 0,
+                            dateFrom:
+                                contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                            dateTo:
+                                contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                        },
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+                    ),
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
+                        contextResponseNumericWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .value
+                    );
+                    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                    done(err);
+                }
+            );
+        });
+
+        for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+            it(
+                'should have only accumulated the sum aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'sum',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should have only accumulated the sum2 aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'sum2',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should have only accumulated the max aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'max',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should have only accumulated the min aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstant',
+                    'min',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
         }
-      )
-    );
+    });
 
-    describe('Removal of all the entities for certain service and service path including numeric data',
-      sthTestUtils.dataRemovalSuite.bind(
-        null,
-        sthConfig.AGGREGATIONS.NUMERIC
-      )
-    );
+    describe('notification of already existent textual data should register it only once', function() {
+        var contextResponseTextualWithFixedTimeInstant;
 
-    describe('Removal of concrete attributes of entities including textual data',
-      sthTestUtils.dataRemovalSuite.bind(
-        null,
-        sthConfig.AGGREGATIONS.TEXTUAL,
-        {
-          entityId: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
-          entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
-          attrName: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.
-            attributes[0].name
+        before(function() {
+            contextResponseTextualWithFixedTimeInstant = require('./contextResponses/contextResponseTextualWithFixedTimeInstant');
+        });
+
+        it('should store the raw and aggregated data for the first time', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseTextualWithFixedTimeInstant.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should try to store the raw and aggregated data for second time', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseTextualWithFixedTimeInstant.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should only retrieve the raw data as stored once', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(
+                        sthTestConfig.API_OPERATION.READ,
+                        {
+                            lastN: 0,
+                            dateFrom:
+                                contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                            dateTo:
+                                contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                        },
+                        contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+                    ),
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
+                        contextResponseTextualWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0]
+                            .value
+                    );
+                    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                    done(err);
+                }
+            );
+        });
+
+        for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+            it(
+                'should have only accumulated the aggregated data once',
+                sthTestUtils.textualAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseTextualWithFixedTimeInstant',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
         }
-      )
-    );
+    });
 
-    describe('Removal of concrete entities including textual data',
-      sthTestUtils.dataRemovalSuite.bind(
-        null,
-        sthConfig.AGGREGATIONS.TEXTUAL,
-        {
-          entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
-          entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type
+    describe('notification of an update to already existent numeric data should update the original value', function() {
+        var contextResponseNumericWithFixedTimeInstantUpdate;
+
+        before(function() {
+            contextResponseNumericWithFixedTimeInstantUpdate = require('./contextResponses/contextResponseNumericWithFixedTimeInstantUpdate');
+        });
+
+        it('should store the raw and aggregated data for the first time', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should update the already existent data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should retrieve the updated raw data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(
+                        sthTestConfig.API_OPERATION.READ,
+                        {
+                            lastN: 0,
+                            dateFrom:
+                                contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                            dateTo:
+                                contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                        },
+                        contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                            .attributes[0].name
+                    ),
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
+                        contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                            .attributes[0].value
+                    );
+                    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                    done(err);
+                }
+            );
+        });
+
+        for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+            it(
+                'should have only accumulated the sum updated aggregated data',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstantUpdate',
+                    'sum',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should have only accumulated the sum2 aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstantUpdate',
+                    'sum2',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should have only accumulated the max aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstantUpdate',
+                    'max',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+
+            it(
+                'should have only accumulated the min aggregated data once',
+                sthTestUtils.numericAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseNumericWithFixedTimeInstantUpdate',
+                    'min',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
         }
-      )
-    );
-
-    describe('Removal of all the entities for certain service and service path including textual data',
-      sthTestUtils.dataRemovalSuite.bind(
-        null,
-        sthConfig.AGGREGATIONS.TEXTUAL
-      )
-    );
-  });
-
-  describe('PUT /admin/log', function() {
-    it('should accept FATAL as a valid logging level',
-      sthTestUtils.validLogLevelChangeTest.bind(null, 'FATAL')
-    );
-
-    it('should accept ERROR as a valid logging level',
-      sthTestUtils.validLogLevelChangeTest.bind(null, 'ERROR')
-    );
-
-    it('should accept WARNING as a valid logging level',
-      sthTestUtils.validLogLevelChangeTest.bind(null, 'WARNING')
-    );
-
-    it('should accept INFO as a valid logging level',
-      sthTestUtils.validLogLevelChangeTest.bind(null, 'INFO')
-    );
-
-    it('should accept DEBUG as a valid logging level',
-      sthTestUtils.validLogLevelChangeTest.bind(null, 'DEBUG')
-    );
-
-    it('should ignore case sensitivity in the logging levels', function(done) {
-      request({
-        uri: sthTestUtils.getURL(
-          sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL,
-          {
-            level: 'deBug'
-          }
-        ),
-        method: 'PUT'
-      }, function (err, response) {
-        expect(err).to.equal(null);
-        expect(response.statusCode).to.equal(200);
-        done();
-      });
     });
-  });
 
-  describe('GET /version', function () {
-    it('should provide version information', function (done) {
-      request({
-        uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.VERSION),
-        method: 'GET'
-      }, function (err, response, body) {
-        var bodyJSON = JSON.parse(body);
-        expect(err).to.equal(null);
-        expect(bodyJSON.version).not.to.be(undefined);
-        done();
-      });
+    describe('notification of already existent textual data should update the original value', function() {
+        var contextResponseTextualWithFixedTimeInstantUpdate;
+
+        before(function() {
+            contextResponseTextualWithFixedTimeInstantUpdate = require('./contextResponses/contextResponseTextualWithFixedTimeInstantUpdate');
+        });
+
+        it('should store the raw and aggregated data for the first time', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should update the stored raw and aggregated data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should retrieve the updated raw data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(
+                        sthTestConfig.API_OPERATION.READ,
+                        {
+                            lastN: 0,
+                            dateFrom:
+                                contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                            dateTo:
+                                contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                        },
+                        contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                            .attributes[0].name
+                    ),
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.equal(
+                        contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement
+                            .attributes[0].value
+                    );
+                    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                    done(err);
+                }
+            );
+        });
+
+        for (var i = 0; i < sthConfig.AGGREGATION_BY.length; i++) {
+            it(
+                'should retrieve the updated aggregated data',
+                sthTestUtils.textualAggregatedDataUpdatedTest.bind(
+                    null,
+                    'contextResponseTextualWithFixedTimeInstantUpdate',
+                    sthConfig.AGGREGATION_BY[i]
+                )
+            );
+        }
     });
-  });
 
-  describe('should clean the data if requested', sthTestUtils.cleanDatabaseSuite);
+    describe('notification of an array attribute value should register it only as raw data', function() {
+        var contextResponseArrayWithFixedTimeInstant;
 
-  describe('server stop', function () {
-    it('should stop gracefully', function (done) {
-      sth.exitGracefully(null, done);
+        before(function() {
+            contextResponseArrayWithFixedTimeInstant = require('./contextResponses/contextResponseArrayWithFixedTimeInstant');
+        });
+
+        it('should store the raw data but not the aggregated data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseArrayWithFixedTimeInstant.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should retrieve the raw data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(
+                        sthTestConfig.API_OPERATION.READ,
+                        {
+                            lastN: 0,
+                            dateFrom:
+                                contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                            dateTo:
+                                contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                        },
+                        contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+                    ),
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.eql(
+                        contextResponseArrayWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value
+                    );
+                    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                    done(err);
+                }
+            );
+        });
+
+        for (var j = 0; j < sthConfig.AGGREGATION_BY.length; j++) {
+            it(
+                'should not retrieve the non-registered aggregated data if sum is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseArrayWithFixedTimeInstant',
+                    'sum',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if sum2 is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseArrayWithFixedTimeInstant',
+                    'sum2',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if max is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseArrayWithFixedTimeInstant',
+                    'max',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if min is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseArrayWithFixedTimeInstant',
+                    'min',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if occur is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseArrayWithFixedTimeInstant',
+                    'occur',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+        }
     });
-  });
+
+    describe('notification of an object attribute value should register it only as raw data', function() {
+        var contextResponseObjectWithFixedTimeInstant;
+
+        before(function() {
+            contextResponseObjectWithFixedTimeInstant = require('./contextResponses/contextResponseObjectWithFixedTimeInstant');
+        });
+
+        it('should store the raw data but not the aggregated data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.NOTIFY),
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                    json: true,
+                    body: {
+                        subscriptionId: '1234567890ABCDF123456789',
+                        originator: 'orion.contextBroker.instance',
+                        contextResponses: contextResponseObjectWithFixedTimeInstant.contextResponses,
+                    },
+                },
+                function(err, response, body) {
+                    expect(body).to.be(undefined);
+                    done(err);
+                }
+            );
+        });
+
+        it('should retrieve the raw data', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(
+                        sthTestConfig.API_OPERATION.READ,
+                        {
+                            lastN: 0,
+                            dateFrom:
+                                contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                            dateTo:
+                                contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement
+                                    .attributes[0].metadatas[0].value,
+                        },
+                        contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].name
+                    ),
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+                        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH,
+                    },
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values.length).to.equal(1);
+                    expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0].attrValue).to.eql(
+                        contextResponseObjectWithFixedTimeInstant.contextResponses[0].contextElement.attributes[0].value
+                    );
+                    expect(bodyJSON.contextResponses[0].statusCode.code).to.equal('200');
+                    expect(bodyJSON.contextResponses[0].statusCode.reasonPhrase).to.equal('OK');
+                    done(err);
+                }
+            );
+        });
+
+        for (var j = 0; j < sthConfig.AGGREGATION_BY.length; j++) {
+            it(
+                'should not retrieve the non-registered aggregated data if sum is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseObjectWithFixedTimeInstant',
+                    'sum',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if sum2 is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseObjectWithFixedTimeInstant',
+                    'sum2',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if max is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseObjectWithFixedTimeInstant',
+                    'max',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if min is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseObjectWithFixedTimeInstant',
+                    'min',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+
+            it(
+                'should not retrieve the non-registered aggregated data if occur is requested',
+                sthTestUtils.aggregatedDataNonExistentTest.bind(
+                    null,
+                    'contextResponseObjectWithFixedTimeInstant',
+                    'occur',
+                    sthConfig.AGGREGATION_BY[j]
+                )
+            );
+        }
+    });
+
+    var contextResponseNumericWithFixedTimeInstantUpdate = require('./contextResponses/contextResponseNumericWithFixedTimeInstantUpdate');
+    var contextResponseTextualWithFixedTimeInstantUpdate = require('./contextResponses/contextResponseTextualWithFixedTimeInstantUpdate');
+
+    describe('Data removal', function() {
+        describe(
+            'Removal of concrete attributes of entities including numeric data',
+            sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.NUMERIC, {
+                entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
+                entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
+                attrName:
+                    contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0]
+                        .name,
+            })
+        );
+
+        describe(
+            'Removal of concrete entities including numeric data',
+            sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.NUMERIC, {
+                entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
+                entityType: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
+            })
+        );
+
+        describe(
+            'Removal of all the entities for certain service and service path including numeric data',
+            sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.NUMERIC)
+        );
+
+        describe(
+            'Removal of concrete attributes of entities including textual data',
+            sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.TEXTUAL, {
+                entityId: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
+                entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
+                attrName:
+                    contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.attributes[0]
+                        .name,
+            })
+        );
+
+        describe(
+            'Removal of concrete entities including textual data',
+            sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.TEXTUAL, {
+                entityId: contextResponseNumericWithFixedTimeInstantUpdate.contextResponses[0].contextElement.id,
+                entityType: contextResponseTextualWithFixedTimeInstantUpdate.contextResponses[0].contextElement.type,
+            })
+        );
+
+        describe(
+            'Removal of all the entities for certain service and service path including textual data',
+            sthTestUtils.dataRemovalSuite.bind(null, sthConfig.AGGREGATIONS.TEXTUAL)
+        );
+    });
+
+    describe('PUT /admin/log', function() {
+        it('should accept FATAL as a valid logging level', sthTestUtils.validLogLevelChangeTest.bind(null, 'FATAL'));
+
+        it('should accept ERROR as a valid logging level', sthTestUtils.validLogLevelChangeTest.bind(null, 'ERROR'));
+
+        it(
+            'should accept WARNING as a valid logging level',
+            sthTestUtils.validLogLevelChangeTest.bind(null, 'WARNING')
+        );
+
+        it('should accept INFO as a valid logging level', sthTestUtils.validLogLevelChangeTest.bind(null, 'INFO'));
+
+        it('should accept DEBUG as a valid logging level', sthTestUtils.validLogLevelChangeTest.bind(null, 'DEBUG'));
+
+        it('should ignore case sensitivity in the logging levels', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.ADMIN.SET_LOG_LEVEL, {
+                        level: 'deBug',
+                    }),
+                    method: 'PUT',
+                },
+                function(err, response) {
+                    expect(err).to.equal(null);
+                    expect(response.statusCode).to.equal(200);
+                    done();
+                }
+            );
+        });
+    });
+
+    describe('GET /version', function() {
+        it('should provide version information', function(done) {
+            request(
+                {
+                    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.VERSION),
+                    method: 'GET',
+                },
+                function(err, response, body) {
+                    var bodyJSON = JSON.parse(body);
+                    expect(err).to.equal(null);
+                    expect(bodyJSON.version).not.to.be(undefined);
+                    done();
+                }
+            );
+        });
+    });
+
+    describe('should clean the data if requested', sthTestUtils.cleanDatabaseSuite);
+
+    describe('server stop', function() {
+        it('should stop gracefully', function(done) {
+            sth.exitGracefully(null, done);
+        });
+    });
 });


### PR DESCRIPTION
Adds [prettier](https://prettier.io) and  [husky](https://github.com/typicode/husky). All JavaScript files are autoformated on commit using the Git Hooks hook. 

running `npm run prettier` will format all files with standardized whitespace.