### PR TITLE
[IMPROVE] Decrease log level of trace Everything OK 0 requests from INFO to DEBUG #310

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,3 @@
 Upgrade NodeJS version from 8.12.0 to 8.16.0 in Dockerfile due to security issues
 Fix: race condition causes erroneous count to 0 in some cases (#493)
 Add logging feature to count number of requests attended and number of requests processed with error (#310)
-

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 Upgrade NodeJS version from 8.12.0 to 8.16.0 in Dockerfile due to security issues
-Adding logging feature to count number of requests attended and number of processed requests
+Add logging feature to count number of requests attended and number of requests processed with error

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 Upgrade NodeJS version from 8.12.0 to 8.16.0 in Dockerfile due to security issues
-Adding logging feature to count number of requests atttended and number of processed requests
+Adding logging feature to count number of requests attended and number of processed requests

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 Upgrade NodeJS version from 8.12.0 to 8.16.0 in Dockerfile due to security issues
 Fix: race condition causes erroneous count to 0 in some cases (#493)
-Add logging feature to count number of requests attended and number of requests processed with error
+Add logging feature to count number of requests attended and number of requests processed with error (#310)
 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 Upgrade NodeJS version from 8.12.0 to 8.16.0 in Dockerfile due to security issues
+Adding logging feature to count number of requests atttended and number of processed requests

--- a/config.js
+++ b/config.js
@@ -147,9 +147,9 @@ config.logging = {
     // The time in seconds between proof of life logging messages informing that the server is up and running normally.
     // Default value: "60"
     proofOfLifeInterval: '60',
-    // The time in seconds between proof of performance logging messages informing that the server is up and running normally.
+    // The time in seconds between processed requests statistics appear in the logs
     // Default value: "60"
-    proofOfPerformanceInterval: '60'
+    processedRequestLogStatisticsInterval: '60'
 };
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -146,7 +146,10 @@ config.logging = {
     format: 'pipe',
     // The time in seconds between proof of life logging messages informing that the server is up and running normally.
     // Default value: "60"
-    proofOfLifeInterval: '60'
+    proofOfLifeInterval: '60',
+    // The time in seconds between proof of performance logging messages informing that the server is up and running normally.
+    // Default value: "60"
+    proofOfPerformanceInterval: '60'
 };
 
 module.exports = config;

--- a/doc/manuals/running.md
+++ b/doc/manuals/running.md
@@ -96,7 +96,8 @@ The environment variables accepted by the script (for which there exists counter
     logging, for further information please check out the [logops](https://www.npmjs.com/package/logops) npm package
     information online. Default value: "json".
 -   `PROOF_OF_LIFE_INTERVAL`: The time in seconds between proof of life logging messages informing that the server is up
-    and running normally. Default value: "60".
+    and running normally. Default value: "60". `PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL`: The time in seconds between
+    processed requests statistics appear in the logs
 
 For example, to start the STH server listening on port 7777, connecting to a MongoDB instance listening on
 mymongo.com:27777 and without filtering out the empty results, use:

--- a/doc/manuals/running.md
+++ b/doc/manuals/running.md
@@ -96,8 +96,9 @@ The environment variables accepted by the script (for which there exists counter
     logging, for further information please check out the [logops](https://www.npmjs.com/package/logops) npm package
     information online. Default value: "json".
 -   `PROOF_OF_LIFE_INTERVAL`: The time in seconds between proof of life logging messages informing that the server is up
-    and running normally. Default value: "60". `PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL`: The time in seconds between
-    processed requests statistics appear in the logs
+    and running normally. Default value: "60".
+    `PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL`: The time in seconds between
+    processed requests statistics appear in the logs. Default value: "60".  
 
 For example, to start the STH server listening on port 7777, connecting to a MongoDB instance listening on
 mymongo.com:27777 and without filtering out the empty results, use:

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -740,28 +740,36 @@ if (ENV.PROOF_OF_LIFE_INTERVAL && !isNaN(ENV.PROOF_OF_LIFE_INTERVAL)) {
             module.exports.PROOF_OF_LIFE_INTERVAL
     );
 }
-if (ENV.PROOF_OF_PERFORMANCE_INTERVAL && !isNaN(ENV.PROOF_OF_PERFORMANCE_INTERVAL)) {
-    module.exports.PROOF_OF_PERFORMANCE_INTERVAL = parseInt(ENV.PROOF_OF_PERFORMANCE_INTERVAL, 10);
+if (ENV.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL && !isNaN(ENV.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL)) {
+    module.exports.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL = parseInt(
+        ENV.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL,
+        10
+    );
     sthLogger.info(
         module.exports.LOGGING_CONTEXT.STARTUP,
-        'Proof of performance interval set to value: ' + module.exports.PROOF_OF_PERFORMANCE_INTERVAL
+        'Processed Request Log Statistics Interval set to value: ' +
+            module.exports.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL
     );
 } else if (
     // prettier-ignore
-    config && config.logging && config.logging.proofOfPerformanceInterval && 
-        !isNaN(config.logging.proofOfPerformanceInterval)
+    config && config.logging && config.logging.processedRequestLogStatisticsInterval && 
+        !isNaN(config.logging.processedRequestLogStatisticsInterval)
 ) {
-    module.exports.PROOF_OF_PERFORMANCE_INTERVAL = parseInt(config.logging.proofOfPerformanceInterval, 10);
+    module.exports.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL = parseInt(
+        config.logging.processedRequestLogStatisticsInterval,
+        10
+    );
     sthLogger.info(
         module.exports.LOGGING_CONTEXT.STARTUP,
-        'Proof of performance interval set to value: ' + module.exports.PROOF_OF_PERFORMANCE_INTERVAL
+        'Processed request log statistics interval set to value: ' +
+            module.exports.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL
     );
 } else {
-    module.exports.PROOF_OF_PERFORMANCE_INTERVAL = 60;
+    module.exports.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL = 60;
     sthLogger.warn(
         module.exports.LOGGING_CONTEXT.STARTUP,
-        'Invalid or not configured proof of performance interval, setting to default value: ' +
-            module.exports.PROOF_OF_PERFORMANCE_INTERVAL
+        'Invalid or not configured processed request log statistics interval, setting to default value: ' +
+            module.exports.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL
     );
 }
 

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -740,5 +740,28 @@ if (ENV.PROOF_OF_LIFE_INTERVAL && !isNaN(ENV.PROOF_OF_LIFE_INTERVAL)) {
             module.exports.PROOF_OF_LIFE_INTERVAL
     );
 }
+if (ENV.PROOF_OF_PERFORMANCE_INTERVAL && !isNaN(ENV.PROOF_OF_PERFORMANCE_INTERVAL)) {
+    module.exports.PROOF_OF_PERFORMANCE_INTERVAL = parseInt(ENV.PROOF_OF_PERFORMANCE_INTERVAL, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Proof of performance interval set to value: ' + module.exports.PROOF_OF_PERFORMANCE_INTERVAL
+    );
+} else if (
+    // prettier-ignore
+    config && config.logging && config.logging.proofOfPerformanceInterval && !isNaN(config.logging.proofOfPerformanceInterval)
+) {
+    module.exports.PROOF_OF_PERFORMANCE_INTERVAL = parseInt(config.logging.proofOfPerformanceInterval, 10);
+    sthLogger.info(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Proof of performance interval set to value: ' + module.exports.PROOF_OF_PERFORMANCE_INTERVAL
+    );
+} else {
+    module.exports.PROOF_OF_PERFORMANCE_INTERVAL = 60;
+    sthLogger.warn(
+        module.exports.LOGGING_CONTEXT.STARTUP,
+        'Invalid or not configured proof of performance interval, setting to default value: ' +
+            module.exports.PROOF_OF_PERFORMANCE_INTERVAL
+    );
+}
 
 sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'STH component configuration successfully completed');

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -748,7 +748,8 @@ if (ENV.PROOF_OF_PERFORMANCE_INTERVAL && !isNaN(ENV.PROOF_OF_PERFORMANCE_INTERVA
     );
 } else if (
     // prettier-ignore
-    config && config.logging && config.logging.proofOfPerformanceInterval && !isNaN(config.logging.proofOfPerformanceInterval)
+    config && config.logging && config.logging.proofOfPerformanceInterval && 
+        !isNaN(config.logging.proofOfPerformanceInterval)
 ) {
     module.exports.PROOF_OF_PERFORMANCE_INTERVAL = parseInt(config.logging.proofOfPerformanceInterval, 10);
     sthLogger.info(

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -26,245 +26,149 @@
 var ROOT_PATH = require('app-root-path');
 var sthLogger = require('logops');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
-var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils');
-var sthHeaderValidator = require(ROOT_PATH + '/lib/server/validators/sthHeaderValidator');
-var sthGetDataHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetDataHandler');
-var sthGetVersionHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetVersionHandler');
-var sthNotificationHandler = require(ROOT_PATH + '/lib/server/handlers/sthNotificationHandler');
-var sthRemoveDataHandler = require(ROOT_PATH + '/lib/server/handlers/sthRemoveDataHandler');
-var sthGetLogLevelHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetLogLevelHandler');
-var sthSetLogLevelHandler = require(ROOT_PATH + '/lib/server/handlers/sthSetLogLevelHandler');
-var sthNotFoundHandler = require(ROOT_PATH + '/lib/server/handlers/sthNotFoundHandler');
-var hapi = require('hapi');
-var joi = require('joi');
+var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils.js');
+var sthDatabaseNaming = require(ROOT_PATH + '/lib/database/model/sthDatabaseNaming');
+var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
+var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
 
-var server;
+var isStarted = false,
+    proofOfLifeInterval,
+    processedRequestLogStatisticsInterval;
 
-var attendedRequests = 0;
-
-var processedRequestsWithError = 0;
 /**
- * Effectively starts and configures the hapi server
- * @param  {String}   host     The host
- * @param  {Number}   port     The port
- * @param  {Function} callback The callback
+ * Stops the application stopping the server after completing all the
+ *  pending requests and closing the server afterwards
+ * @param {Error} err The error provoking the exit if any
  */
-function doStartServer(host, port, callback) {
-    server = new hapi.Server();
-
-    server.on('log', function(event, tags) {
-        if (tags.load) {
-            sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'event=' + JSON.stringify(event));
+function exitGracefully(err, callback) {
+    function onStopped() {
+        isStarted = false;
+        var exitCode = 0;
+        if (err) {
+            exitCode = 1;
+        } else {
+            sthLogger.info(sthConfig.LOGGING_CONTEXT.SHUTDOWN, 'Application exited successfully');
         }
-    });
-
-    server.on('request-internal', function(request, event, tags) {
-        if (tags.error) {
-            processedRequestsWithError++;
-            if (tags.auth || tags.handler || tags.state || tags.payload || tags.validation) {
-                sthLogger.warn(
-                    sthServerUtils.getContext(request),
-                    request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
-                );
-            } else {
-                sthLogger.error(
-                    sthServerUtils.getContext(request),
-                    request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
-                );
-            }
+        if (callback) {
+            callback(err);
         }
-        else if (tags.error === undefined && request._isReplied) {
-            attendedRequests++;
+        // TODO:
+        // Due to https://github.com/winstonjs/winston/issues/228 we use the
+        //  setTimeout() hack. Once the issue is solved, we will fix it.
+        setTimeout(process.exit.bind(null, exitCode), 500);
+    }
+
+    if (err) {
+        var message = err.toString();
+        if (message.indexOf('listen EADDRINUSE') !== -1) {
+            message += ' (another STH instance maybe already listening on the same port)';
         }
-    });
+        sthLogger.error(sthConfig.LOGGING_CONTEXT.SHUTDOWN, message);
+    }
 
-    server.connection({
-        host: host,
-        port: port
-    });
+    if (proofOfLifeInterval) {
+        clearInterval(proofOfLifeInterval);
+    }
+    if (processedRequestLogStatisticsInterval) {
+        clearInterval(processedRequestLogStatisticsInterval);
+    }
+    sthServer.stopServer(sthDatabase.closeConnection.bind(null, onStopped));
+}
 
-    server.route([
+/**
+ * Convenience method to startup the Node.js STH application in case the module
+ *  has not been loaded via require
+ * @param {Function} callback Callback function to notify when startup process
+ *  has concluded
+ * @return {*}
+ */
+function startup(callback) {
+    if (isStarted) {
+        if (callback) {
+            return process.nextTick(callback);
+        }
+        return;
+    }
+
+    var version = sthUtils.getVersion();
+    sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_START, 'Starting up the STH server version %s...', version.version);
+
+    // Connect to the MongoDB database
+    sthDatabase.connect(
         {
-            method: 'GET',
-            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
-            handler: sthGetDataHandler,
-            config: {
-                validate: {
-                    headers: sthHeaderValidator,
-                    query: {
+            authentication: sthConfig.DB_AUTHENTICATION,
+            dbURI: sthConfig.DB_URI,
+            replicaSet: sthConfig.REPLICA_SET,
+            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+            poolSize: sthConfig.POOL_SIZE
+        },
+        function(err) {
+            if (err) {
+                // Error when connecting to the MongoDB database
+                return exitGracefully(err, callback);
+            }
+
+            // Start the hapi server
+            sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(err) {
+                if (err) {
+                    sthLogger.error(sthConfig.LOGGING_CONTEXT.SERVER_START, err.toString());
+                    // Error when starting the server
+                    return exitGracefully(err, callback);
+                } else {
+                    isStarted = true;
+                    sthLogger.info(
+                        sthConfig.LOGGING_CONTEXT.SERVER_START,
+                        'Server started at',
+                        sthServer.server.info.uri
+                    );
+                    proofOfLifeInterval = setInterval(function() {
                         // prettier-ignore
-                        lastN: joi.number().integer().greater(-1).optional(),
+                        sthLogger.debug(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'Everything OK, ' + 
+                            sthServer.getKPIs().attendedRequests + ' requests attended in the last ' + 
+                            sthConfig.PROOF_OF_LIFE_INTERVAL + 's interval'
+                        );
+                        sthServer.resetKPIs();
+                    }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
+                    processedRequestLogStatisticsInterval = setInterval(function() {
                         // prettier-ignore
-                        hLimit: joi.number().integer().greater(-1).optional(),
-                        // prettier-ignore
-                        hOffset: joi.number().integer().greater(-1).optional(),
-                        // prettier-ignore
-                        aggrMethod: joi.string().valid(
-                            'max', 'min', 'sum', 'sum2', 'occur').optional(),
-                        // prettier-ignore
-                        aggrPeriod: joi.string().required().valid(
-                            'month', 'day', 'hour', 'minute', 'second').optional(),
-                        dateFrom: joi.date().optional(),
-                        dateTo: joi.date().optional(),
-                        filetype: joi.string().optional(),
-                        count: joi.boolean().optional()
+                        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'We have processed ' + 
+                            sthServer.getProcessedRequestsWithErrorCount().processedRequestsWithError + ' requests with ERROR in the last ' + 
+                            sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL + 's interval'
+                        );
+                        sthServer.resetProcessedRequestsWithErrorCount();
+                    }, sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL * 1000);
+                    if (callback) {
+                        return callback();
                     }
                 }
-            }
-        },
-        {
-            method: 'GET',
-            path: '/version',
-            handler: sthGetVersionHandler
-        },
-        {
-            method: 'POST',
-            path: '/notify',
-            handler: sthNotificationHandler,
-            config: {
-                validate: {
-                    headers: sthHeaderValidator
-                }
-            }
-        },
-        {
-            method: 'DELETE',
-            path: '/STH/v1/contextEntities',
-            handler: sthRemoveDataHandler,
-            config: {
-                validate: {
-                    headers: sthHeaderValidator
-                }
-            }
-        },
-        {
-            method: 'DELETE',
-            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}',
-            handler: sthRemoveDataHandler,
-            config: {
-                validate: {
-                    headers: sthHeaderValidator
-                }
-            }
-        },
-        {
-            method: 'DELETE',
-            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
-            handler: sthRemoveDataHandler,
-            config: {
-                validate: {
-                    headers: sthHeaderValidator
-                }
-            }
-        },
-        {
-            method: 'PUT',
-            path: '/admin/log',
-            handler: sthSetLogLevelHandler,
-            config: {
-                validate: {
-                    query: {
-                        // prettier-ignore
-                        level: joi.string().insensitive().valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG').required()
-                    }
-                }
-            }
-        },
-        {
-            method: 'GET',
-            path: '/admin/log',
-            handler: sthGetLogLevelHandler
-        },
-        {
-            method: '*',
-            path: '/{p*}',
-            handler: sthNotFoundHandler
+            });
         }
-    ]);
-
-    // Start the server
-    server.start(function(err) {
-        return callback(err, server);
-    });
+    );
 }
 
-/**
- * Starts the server asynchronously
- * @param {String} host The STH server host
- * @param {String} port The STH server port
- * @param {Function} callback Callback function to notify the result of the operation
- */
-function startServer(host, port, callback) {
-    if (server && server.info && server.info.started) {
-        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'STH server already started');
-        return process.nextTick(callback.bind(null, null, server));
-    } else {
-        doStartServer(host, port, callback);
-    }
+// Starts the STH application up in case this file has not been 'require'd,
+//  such as, for example, for testing
+if (!module.parent) {
+    startup();
 }
 
-/**
- * Stops the server asynchronously
- * @param {Function} callback Callback function to notify the result
- *  of the operation
- */
-function stopServer(callback) {
-    sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'Stopping the STH server...');
-    if (server && server.info && server.info.started) {
-        server.stop(function(err) {
-            // Server successfully stopped
-            sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'hapi server successfully stopped');
-            return callback(err);
-        });
-    } else {
-        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'No hapi server running');
-        return process.nextTick(callback);
-    }
-}
+// In case Control+C is clicked, exit gracefully
+process.on('SIGINT', function() {
+    return exitGracefully(null);
+});
 
-/**
- * Returns the server KPIs
- * @return {{attendedRequests: number}}
- */
-function getKPIs() {
-    return {
-        attendedRequests: attendedRequests
-    };
-}
-
-/**
- * Returns the server PIs
- * @return {{processedRequestsWithError: number}}
- */
-function getPIs() {
-    return {
-        processedRequestsWithError: processedRequestsWithError
-    };
-}
-
-/**
- * Resets the server KPIs
- */
-function resetKPIs() {
-    attendedRequests = 0;
-}
-
-/**
- * Resets the server PIs
- */
-function resetPIs() {
-    processedRequestsWithError = 0;
-}
-
+// In case of an uncaught exception exists gracefully
+process.on('uncaughtException', function(exception) {
+    return exitGracefully(exception);
+});
 
 module.exports = {
-    get server() {
-        return server;
+    startup: startup,
+    get sthServer() {
+        return sthServer;
     },
-    startServer: startServer,
-    stopServer: stopServer,
-    getKPIs: getKPIs,
-    getPIs: getPIs,
-    resetKPIs: resetKPIs,
-    resetPIs: resetPIs
+    get sthDatabase() {
+        return sthDatabase;
+    },
+    exitGracefully: exitGracefully
 };

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -42,6 +42,7 @@ var server;
 
 var attendedRequests = 0;
 
+var processedRequestsWithError = 0;
 /**
  * Effectively starts and configures the hapi server
  * @param  {String}   host     The host
@@ -59,6 +60,7 @@ function doStartServer(host, port, callback) {
 
     server.on('request-internal', function(request, event, tags) {
         if (tags.error) {
+            processedRequestsWithError++;
             if (tags.auth || tags.handler || tags.state || tags.payload || tags.validation) {
                 sthLogger.warn(
                     sthServerUtils.getContext(request),
@@ -70,6 +72,9 @@ function doStartServer(host, port, callback) {
                     request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
                 );
             }
+        }
+        else if (tags.error === undefined && request._isReplied) {
+            attendedRequests++;
         }
     });
 
@@ -228,11 +233,29 @@ function getKPIs() {
 }
 
 /**
+ * Returns the server PIs
+ * @return {{processedRequestsWithError: number}}
+ */
+function getPIs() {
+    return {
+        processedRequestsWithError: processedRequestsWithError
+    };
+}
+
+/**
  * Resets the server KPIs
  */
 function resetKPIs() {
     attendedRequests = 0;
 }
+
+/**
+ * Resets the server PIs
+ */
+function resetPIs() {
+    processedRequestsWithError = 0;
+}
+
 
 module.exports = {
     get server() {
@@ -241,5 +264,7 @@ module.exports = {
     startServer: startServer,
     stopServer: stopServer,
     getKPIs: getKPIs,
-    resetKPIs: resetKPIs
+    getPIs: getPIs,
+    resetKPIs: resetKPIs,
+    resetPIs: resetPIs
 };

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -61,7 +61,7 @@ function doStartServer(host, port, callback) {
 
     server.on('request-internal', function(request, event, tags) {
         if (tags.error) {
-        	processedRequestsWithError++;
+            processedRequestsWithError++;
             if (tags.auth || tags.handler || tags.state || tags.payload || tags.validation) {
                 sthLogger.warn(
                     sthServerUtils.getContext(request),

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -26,149 +26,245 @@
 var ROOT_PATH = require('app-root-path');
 var sthLogger = require('logops');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
-var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils.js');
-var sthDatabaseNaming = require(ROOT_PATH + '/lib/database/model/sthDatabaseNaming');
-var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
-var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
+var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils');
+var sthHeaderValidator = require(ROOT_PATH + '/lib/server/validators/sthHeaderValidator');
+var sthGetDataHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetDataHandler');
+var sthGetVersionHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetVersionHandler');
+var sthNotificationHandler = require(ROOT_PATH + '/lib/server/handlers/sthNotificationHandler');
+var sthRemoveDataHandler = require(ROOT_PATH + '/lib/server/handlers/sthRemoveDataHandler');
+var sthGetLogLevelHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetLogLevelHandler');
+var sthSetLogLevelHandler = require(ROOT_PATH + '/lib/server/handlers/sthSetLogLevelHandler');
+var sthNotFoundHandler = require(ROOT_PATH + '/lib/server/handlers/sthNotFoundHandler');
+var hapi = require('hapi');
+var joi = require('joi');
 
-var isStarted = false,
-    proofOfLifeInterval,
-    processedRequestLogStatisticsInterval;
+var server;
 
-/**
- * Stops the application stopping the server after completing all the
- *  pending requests and closing the server afterwards
- * @param {Error} err The error provoking the exit if any
- */
-function exitGracefully(err, callback) {
-    function onStopped() {
-        isStarted = false;
-        var exitCode = 0;
-        if (err) {
-            exitCode = 1;
-        } else {
-            sthLogger.info(sthConfig.LOGGING_CONTEXT.SHUTDOWN, 'Application exited successfully');
-        }
-        if (callback) {
-            callback(err);
-        }
-        // TODO:
-        // Due to https://github.com/winstonjs/winston/issues/228 we use the
-        //  setTimeout() hack. Once the issue is solved, we will fix it.
-        setTimeout(process.exit.bind(null, exitCode), 500);
-    }
+var attendedRequests = 0;
 
-    if (err) {
-        var message = err.toString();
-        if (message.indexOf('listen EADDRINUSE') !== -1) {
-            message += ' (another STH instance maybe already listening on the same port)';
-        }
-        sthLogger.error(sthConfig.LOGGING_CONTEXT.SHUTDOWN, message);
-    }
-
-    if (proofOfLifeInterval) {
-        clearInterval(proofOfLifeInterval);
-    }
-    if (processedRequestLogStatisticsInterval) {
-        clearInterval(processedRequestLogStatisticsInterval);
-    }
-    sthServer.stopServer(sthDatabase.closeConnection.bind(null, onStopped));
-}
+var processedRequestsWithError = 0;
 
 /**
- * Convenience method to startup the Node.js STH application in case the module
- *  has not been loaded via require
- * @param {Function} callback Callback function to notify when startup process
- *  has concluded
- * @return {*}
+ * Effectively starts and configures the hapi server
+ * @param  {String}   host     The host
+ * @param  {Number}   port     The port
+ * @param  {Function} callback The callback
  */
-function startup(callback) {
-    if (isStarted) {
-        if (callback) {
-            return process.nextTick(callback);
+function doStartServer(host, port, callback) {
+    server = new hapi.Server();
+
+    server.on('log', function(event, tags) {
+        if (tags.load) {
+            sthLogger.warn(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'event=' + JSON.stringify(event));
         }
-        return;
-    }
+    });
 
-    var version = sthUtils.getVersion();
-    sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_START, 'Starting up the STH server version %s...', version.version);
-
-    // Connect to the MongoDB database
-    sthDatabase.connect(
-        {
-            authentication: sthConfig.DB_AUTHENTICATION,
-            dbURI: sthConfig.DB_URI,
-            replicaSet: sthConfig.REPLICA_SET,
-            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-            poolSize: sthConfig.POOL_SIZE
-        },
-        function(err) {
-            if (err) {
-                // Error when connecting to the MongoDB database
-                return exitGracefully(err, callback);
+    server.on('request-internal', function(request, event, tags) {
+        if (tags.error) {
+        	processedRequestsWithError++;
+            if (tags.auth || tags.handler || tags.state || tags.payload || tags.validation) {
+                sthLogger.warn(
+                    sthServerUtils.getContext(request),
+                    request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
+                );
+            } else {
+                sthLogger.error(
+                    sthServerUtils.getContext(request),
+                    request.method.toUpperCase() + ' ' + request.url.path + ', event=' + JSON.stringify(event)
+                );
             }
+        }
+        else if (tags.error === undefined && request._isReplied) {
+            attendedRequests++;
+        }
+    });
 
-            // Start the hapi server
-            sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(err) {
-                if (err) {
-                    sthLogger.error(sthConfig.LOGGING_CONTEXT.SERVER_START, err.toString());
-                    // Error when starting the server
-                    return exitGracefully(err, callback);
-                } else {
-                    isStarted = true;
-                    sthLogger.info(
-                        sthConfig.LOGGING_CONTEXT.SERVER_START,
-                        'Server started at',
-                        sthServer.server.info.uri
-                    );
-                    proofOfLifeInterval = setInterval(function() {
+    server.connection({
+        host: host,
+        port: port
+    });
+
+    server.route([
+        {
+            method: 'GET',
+            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
+            handler: sthGetDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator,
+                    query: {
                         // prettier-ignore
-                        sthLogger.debug(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'Everything OK, ' + 
-                            sthServer.getKPIs().attendedRequests + ' requests attended in the last ' + 
-                            sthConfig.PROOF_OF_LIFE_INTERVAL + 's interval'
-                        );
-                        sthServer.resetKPIs();
-                    }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
-                    processedRequestLogStatisticsInterval = setInterval(function() {
+                        lastN: joi.number().integer().greater(-1).optional(),
                         // prettier-ignore
-                        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'We have processed ' + 
-                            sthServer.getProcessedRequestsWithErrorCount().processedRequestsWithError + ' requests with ERROR in the last ' + 
-                            sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL + 's interval'
-                        );
-                        sthServer.resetProcessedRequestsWithErrorCount();
-                    }, sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL * 1000);
-                    if (callback) {
-                        return callback();
+                        hLimit: joi.number().integer().greater(-1).optional(),
+                        // prettier-ignore
+                        hOffset: joi.number().integer().greater(-1).optional(),
+                        // prettier-ignore
+                        aggrMethod: joi.string().valid(
+                            'max', 'min', 'sum', 'sum2', 'occur').optional(),
+                        // prettier-ignore
+                        aggrPeriod: joi.string().required().valid(
+                            'month', 'day', 'hour', 'minute', 'second').optional(),
+                        dateFrom: joi.date().optional(),
+                        dateTo: joi.date().optional(),
+                        filetype: joi.string().optional(),
+                        count: joi.boolean().optional()
                     }
                 }
-            });
+            }
+        },
+        {
+            method: 'GET',
+            path: '/version',
+            handler: sthGetVersionHandler
+        },
+        {
+            method: 'POST',
+            path: '/notify',
+            handler: sthNotificationHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator
+                }
+            }
+        },
+        {
+            method: 'DELETE',
+            path: '/STH/v1/contextEntities',
+            handler: sthRemoveDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator
+                }
+            }
+        },
+        {
+            method: 'DELETE',
+            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}',
+            handler: sthRemoveDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator
+                }
+            }
+        },
+        {
+            method: 'DELETE',
+            path: '/STH/v1/contextEntities/type/{entityType}/id/{entityId}/attributes/{attrName}',
+            handler: sthRemoveDataHandler,
+            config: {
+                validate: {
+                    headers: sthHeaderValidator
+                }
+            }
+        },
+        {
+            method: 'PUT',
+            path: '/admin/log',
+            handler: sthSetLogLevelHandler,
+            config: {
+                validate: {
+                    query: {
+                        // prettier-ignore
+                        level: joi.string().insensitive().valid('FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG').required()
+                    }
+                }
+            }
+        },
+        {
+            method: 'GET',
+            path: '/admin/log',
+            handler: sthGetLogLevelHandler
+        },
+        {
+            method: '*',
+            path: '/{p*}',
+            handler: sthNotFoundHandler
         }
-    );
+    ]);
+
+    // Start the server
+    server.start(function(err) {
+        return callback(err, server);
+    });
 }
 
-// Starts the STH application up in case this file has not been 'require'd,
-//  such as, for example, for testing
-if (!module.parent) {
-    startup();
+/**
+ * Starts the server asynchronously
+ * @param {String} host The STH server host
+ * @param {String} port The STH server port
+ * @param {Function} callback Callback function to notify the result of the operation
+ */
+function startServer(host, port, callback) {
+    if (server && server.info && server.info.started) {
+        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'STH server already started');
+        return process.nextTick(callback.bind(null, null, server));
+    } else {
+        doStartServer(host, port, callback);
+    }
 }
 
-// In case Control+C is clicked, exit gracefully
-process.on('SIGINT', function() {
-    return exitGracefully(null);
-});
+/**
+ * Stops the server asynchronously
+ * @param {Function} callback Callback function to notify the result
+ *  of the operation
+ */
+function stopServer(callback) {
+    sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'Stopping the STH server...');
+    if (server && server.info && server.info.started) {
+        server.stop(function(err) {
+            // Server successfully stopped
+            sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'hapi server successfully stopped');
+            return callback(err);
+        });
+    } else {
+        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_STOP, 'No hapi server running');
+        return process.nextTick(callback);
+    }
+}
 
-// In case of an uncaught exception exists gracefully
-process.on('uncaughtException', function(exception) {
-    return exitGracefully(exception);
-});
+/**
+ * Returns the server KPIs
+ * @return {{attendedRequests: number}}
+ */
+function getKPIs() {
+    return {
+        attendedRequests: attendedRequests
+    };
+}
+
+/**
+ * Returns the counter for processed requests with error
+ * @return {{processedRequestsWithError: number}}
+ */
+function getProcessedRequestsWithErrorCount() {
+    return {
+        processedRequestsWithError: processedRequestsWithError
+    };
+}
+
+/**
+ * Resets the server KPIs
+ */
+function resetKPIs() {
+    attendedRequests = 0;
+}
+
+/**
+ * Resets the counter for processed requests with error
+ */
+function resetProcessedRequestsWithErrorCount() {
+    processedRequestsWithError = 0;
+}
 
 module.exports = {
-    startup: startup,
-    get sthServer() {
-        return sthServer;
+    get server() {
+        return server;
     },
-    get sthDatabase() {
-        return sthDatabase;
-    },
-    exitGracefully: exitGracefully
+    startServer: startServer,
+    stopServer: stopServer,
+    getKPIs: getKPIs,
+    getProcessedRequestsWithErrorCount: getProcessedRequestsWithErrorCount,
+    resetKPIs: resetKPIs,
+    resetProcessedRequestsWithErrorCount: resetProcessedRequestsWithErrorCount
 };

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -69,6 +69,9 @@ function exitGracefully(err, callback) {
     if (proofOfLifeInterval) {
         clearInterval(proofOfLifeInterval);
     }
+    if (proofOfPerformanceInterval) {
+        clearInterval(proofOfPerformanceInterval);
+    }
     sthServer.stopServer(sthDatabase.closeConnection.bind(null, onStopped));
 }
 

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -33,7 +33,7 @@ var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
 
 var isStarted = false,
     proofOfLifeInterval,
-    proofOfPerformanceInterval;
+    processedRequestLogStatisticsInterval;
 
 /**
  * Stops the application stopping the server after completing all the
@@ -69,8 +69,8 @@ function exitGracefully(err, callback) {
     if (proofOfLifeInterval) {
         clearInterval(proofOfLifeInterval);
     }
-    if (proofOfPerformanceInterval) {
-        clearInterval(proofOfPerformanceInterval);
+    if (processedRequestLogStatisticsInterval) {
+        clearInterval(processedRequestLogStatisticsInterval);
     }
     sthServer.stopServer(sthDatabase.closeConnection.bind(null, onStopped));
 }
@@ -129,14 +129,14 @@ function startup(callback) {
                         );
                         sthServer.resetKPIs();
                     }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
-                    proofOfPerformanceInterval = setInterval(function() {
+                    processedRequestLogStatisticsInterval = setInterval(function() {
                         // prettier-ignore
                         sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'We have processed ' + 
                             sthServer.getPIs().processedRequestsWithError + ' requests with ERROR in the last ' + 
-                            sthConfig.PROOF_OF_PERFORMANCE_INTERVAL + 's interval'
+                            sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL + 's interval'
                         );
                         sthServer.resetPIs();
-                    }, sthConfig.PROOF_OF_PERFORMANCE_INTERVAL * 1000);
+                    }, sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL * 1000);
                     if (callback) {
                         return callback();
                     }

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -132,10 +132,10 @@ function startup(callback) {
                     processedRequestLogStatisticsInterval = setInterval(function() {
                         // prettier-ignore
                         sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'We have processed ' + 
-                            sthServer.getPIs().processedRequestsWithError + ' requests with ERROR in the last ' + 
+                            sthServer.getProcessedRequestsWithErrorCount().processedRequestsWithError + ' requests with ERROR in the last ' + 
                             sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL + 's interval'
                         );
-                        sthServer.resetPIs();
+                        sthServer.resetProcessedRequestsWithErrorCount();
                     }, sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL * 1000);
                     if (callback) {
                         return callback();

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -32,7 +32,8 @@ var sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
 var sthServer = require(ROOT_PATH + '/lib/server/sthServer');
 
 var isStarted = false,
-    proofOfLifeInterval;
+    proofOfLifeInterval,
+    proofOfPerformanceInterval;
 
 /**
  * Stops the application stopping the server after completing all the
@@ -119,12 +120,20 @@ function startup(callback) {
                     );
                     proofOfLifeInterval = setInterval(function() {
                         // prettier-ignore
-                        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'Everything OK, ' + 
+                        sthLogger.debug(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'Everything OK, ' + 
                             sthServer.getKPIs().attendedRequests + ' requests attended in the last ' + 
                             sthConfig.PROOF_OF_LIFE_INTERVAL + 's interval'
                         );
                         sthServer.resetKPIs();
                     }, sthConfig.PROOF_OF_LIFE_INTERVAL * 1000);
+                    proofOfPerformanceInterval = setInterval(function() {
+                        // prettier-ignore
+                        sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'We have processed ' + 
+                            sthServer.getPIs().processedRequestsWithError + ' requests with ERROR in the last ' + 
+                            sthConfig.PROOF_OF_PERFORMANCE_INTERVAL + 's interval'
+                        );
+                        sthServer.resetPIs();
+                    }, sthConfig.PROOF_OF_PERFORMANCE_INTERVAL * 1000);
                     if (callback) {
                         return callback();
                     }

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -132,7 +132,8 @@ function startup(callback) {
                     processedRequestLogStatisticsInterval = setInterval(function() {
                         // prettier-ignore
                         sthLogger.info(sthConfig.LOGGING_CONTEXT.SERVER_LOG, 'We have processed ' + 
-                            sthServer.getProcessedRequestsWithErrorCount().processedRequestsWithError + ' requests with ERROR in the last ' + 
+                            sthServer.getProcessedRequestsWithErrorCount().processedRequestsWithError + 
+                                       ' requests with ERROR in the last ' + 
                             sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL + 's interval'
                         );
                         sthServer.resetProcessedRequestsWithErrorCount();

--- a/rpm/EXAMPLES/sth_default.conf
+++ b/rpm/EXAMPLES/sth_default.conf
@@ -152,7 +152,6 @@ export LOGOPS_FORMAT="pipe"
 # Default value: "60".
 export PROOF_OF_LIFE_INTERVAL="60"
 
-# The time in seconds between proof of performance logging messages informing that
-# the server is up and running normally.
+# The time in seconds between processed requests statistics appear in the logs
 # Default value: "60".
-export PROOF_OF_PERFORMANCE_INTERVAL="60"
+export PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL="60"

--- a/rpm/EXAMPLES/sth_default.conf
+++ b/rpm/EXAMPLES/sth_default.conf
@@ -151,3 +151,8 @@ export LOGOPS_FORMAT="pipe"
 # the server is up and running normally.
 # Default value: "60".
 export PROOF_OF_LIFE_INTERVAL="60"
+
+# The time in seconds between proof of performance logging messages informing that
+# the server is up and running normally.
+# Default value: "60".
+export PROOF_OF_PERFORMANCE_INTERVAL="60"

--- a/test/unit/sthConfiguration_test.js
+++ b/test/unit/sthConfiguration_test.js
@@ -55,7 +55,7 @@ var DEFAULT_VALUES = {
     IGNORE_BLANK_SPACES: true,
     NAME_ENCODING: false,
     PROOF_OF_LIFE_INTERVAL: 60,
-    PROOF_OF_PERFORMANCE_INTERVAL: 60
+    PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL: 60
 };
 
 describe('sthConfiguration tests', function() {
@@ -712,30 +712,34 @@ describe('sthConfiguration tests', function() {
                 expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
             }
         );
-        
-        it("should set the proof of performance interval configuration parameter to '120'", function() {
-            process.env.PROOF_OF_PERFORMANCE_INTERVAL = '120';
+
+        it("should set the processed request log statistics interval configuration parameter to '120'", function() {
+            process.env.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL = '120';
             sthConfig = require(STH_CONFIGURATION_PATH);
-            expect(sthConfig.PROOF_OF_PERFORMANCE_INTERVAL).to.equal(120);
+            expect(sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL).to.equal(120);
         });
 
         it(
-            'should set the proof of performance interval configuration parameter to the default value if not set via ' +
-                'PROOF_OF_PERFORMANCE_INTERVAL',
+            'should set the processed request log statistics interval configuration parameter to the default value if not set via ' +
+                'PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL',
             function() {
-                delete process.env.PROOF_OF_PERFORMANCE_INTERVAL;
+                delete process.env.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL;
                 sthConfig = require(STH_CONFIGURATION_PATH);
-                expect(sthConfig.PROOF_OF_PERFORMANCE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_PERFORMANCE_INTERVAL);
+                expect(sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL).to.equal(
+                    DEFAULT_VALUES.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL
+                );
             }
         );
 
         it(
-            'should set the proof of performance interval configuration parameter to the default value if not set to a valid ' +
+            'should set the processed request log statistics interval configuration parameter to the default value if not set to a valid ' +
                 'number',
             function() {
-                process.env.PROOF_OF_PERFORMANCE_INTERVAL = 'ABC';
+                process.env.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL = 'ABC';
                 sthConfig = require(STH_CONFIGURATION_PATH);
-                expect(sthConfig.PROOF_OF_PERFORMANCE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_PERFORMANCE_INTERVAL);
+                expect(sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL).to.equal(
+                    DEFAULT_VALUES.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL
+                );
             }
         );
     });

--- a/test/unit/sthConfiguration_test.js
+++ b/test/unit/sthConfiguration_test.js
@@ -213,6 +213,7 @@ describe('sthConfiguration tests', function() {
                 expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
             });
         }
+
         if (Object.keys(process.env).indexOf('PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL') === -1) {
             it('should set the processed request log statistics interval configuration parameter to its default value', function() {
                 expect(sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL).to.equal(

--- a/test/unit/sthConfiguration_test.js
+++ b/test/unit/sthConfiguration_test.js
@@ -54,7 +54,8 @@ var DEFAULT_VALUES = {
     TRUNCATION_MAX: 0,
     IGNORE_BLANK_SPACES: true,
     NAME_ENCODING: false,
-    PROOF_OF_LIFE_INTERVAL: 60
+    PROOF_OF_LIFE_INTERVAL: 60,
+    PROOF_OF_PERFORMANCE_INTERVAL: 60
 };
 
 describe('sthConfiguration tests', function() {
@@ -709,6 +710,32 @@ describe('sthConfiguration tests', function() {
                 process.env.PROOF_OF_LIFE_INTERVAL = 'ABC';
                 sthConfig = require(STH_CONFIGURATION_PATH);
                 expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
+            }
+        );
+        
+        it("should set the proof of performance interval configuration parameter to '120'", function() {
+            process.env.PROOF_OF_PERFORMANCE_INTERVAL = '120';
+            sthConfig = require(STH_CONFIGURATION_PATH);
+            expect(sthConfig.PROOF_OF_PERFORMANCE_INTERVAL).to.equal(120);
+        });
+
+        it(
+            'should set the proof of performance interval configuration parameter to the default value if not set via ' +
+                'PROOF_OF_PERFORMANCE_INTERVAL',
+            function() {
+                delete process.env.PROOF_OF_PERFORMANCE_INTERVAL;
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.PROOF_OF_PERFORMANCE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_PERFORMANCE_INTERVAL);
+            }
+        );
+
+        it(
+            'should set the proof of performance interval configuration parameter to the default value if not set to a valid ' +
+                'number',
+            function() {
+                process.env.PROOF_OF_PERFORMANCE_INTERVAL = 'ABC';
+                sthConfig = require(STH_CONFIGURATION_PATH);
+                expect(sthConfig.PROOF_OF_PERFORMANCE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_PERFORMANCE_INTERVAL);
             }
         );
     });

--- a/test/unit/sthConfiguration_test.js
+++ b/test/unit/sthConfiguration_test.js
@@ -213,6 +213,13 @@ describe('sthConfiguration tests', function() {
                 expect(sthConfig.PROOF_OF_LIFE_INTERVAL).to.equal(DEFAULT_VALUES.PROOF_OF_LIFE_INTERVAL);
             });
         }
+        if (Object.keys(process.env).indexOf('PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL') === -1) {
+            it('should set the processed request log statistics interval configuration parameter to its default value', function() {
+                expect(sthConfig.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL).to.equal(
+                    DEFAULT_VALUES.PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL
+                );
+            });
+        }
     });
 
     describe('setting values via environment variables', function() {


### PR DESCRIPTION
1. The trace {"op":"OPER_STH_SERVER_LOG","time":"2016-04-07T02:11:55.606Z","lvl":"INFO","msg":"Everything OK, 0 requests attended in the last 60s interval"} is changed from log level INFO to DEBUG.

2. A new trace is added to count the number of requests processed with error:
"msg"="We have processed 0 requests with ERROR in the last 60s interval"

This pull request is created for the following issue:
[IMPROVE] Decrease log level of trace Everything OK 0 requests from INFO to DEBUG #310 