### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/telefonicaid/fiware-sth-comet.git
 site_description: STH (Short Time Historic) - Comet Documentation
 docs_dir: doc/manuals
 site_dir: html
+edit_uri: edit/master/doc/manuals/
 markdown_extensions: [toc, fenced_code]
 use_directory_urls: false
 theme: readthedocs


### PR DESCRIPTION
Adding the right config parameter, according to mkdocs instructions will fix documentation broken links:
https://www.mkdocs.org/user-guide/configuration/#edit_uri
The same fix has been applied successfully in other similar repositories:
https://github.com/telefonicaid/fiware-orion/pull/3491