### PR TITLE
Bump to Node 10

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,4 +3,4 @@
 - Check header response before use it (CSV response has no header)
 - Fix handler for reply a CSV: use new Hapi API (#513)
 - Ensure permissions over temp directory (used by CSV generation) in docker container (#514)
-- Upgrade NodeJS version from 8.16.0 to 8.16.1 in Dockerfile due to security issues
+- Upgrade NodeJS version from 8.16.1 to 10.17.0 in Dockerfile due to Node 8 End-of-Life 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # For those usages not covered by the GNU Affero General Public License
 # please contact with: [german.torodelvalle@telefonica.com]
 
-ARG NODE_VERSION=8.16.1-slim
+ARG NODE_VERSION=10.17.0-slim
 FROM node:${NODE_VERSION}
 
 MAINTAINER FIWARE STH Team. Telefónica I+D


### PR DESCRIPTION
Node 8 leaves LTS at the end of the year. The default node version should be switched to Node Dubnium for the upcoming December FIWARE 7.8.1 Patch release.