### PR TITLE
Hardering/fix copydb (solving #551)

### DIFF
--- a/doc/manuals/contribution-guidelines.md
+++ b/doc/manuals/contribution-guidelines.md
@@ -7,15 +7,15 @@ planning to contribute to the code you should read this document and get familia
 
 Before we get started, here are a few things we expect from you (and that you should expect from others):
 
-* Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and
-  projects, which means we likely have different perspectives on "how open source is done." Try to listen to others
-  rather than convince them that your way is correct.
-* Please ensure that your contribution passes all tests. If there are test failures, you will need to address them
-  before we can merge your contribution.
-* When adding content, please consider if it is widely valuable. Please don't add references or links to things you or
-  your employer have created as others will do so if they appreciate it.
-* When reporting a vulnerability on the software, please, put in contact with STH Comet repo maintainers in order to discuss it 
-  in a private way.
+*   Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and
+    projects, which means we likely have different perspectives on "how open source is done." Try to listen to others
+    rather than convince them that your way is correct.
+*   Please ensure that your contribution passes all tests. If there are test failures, you will need to address them
+    before we can merge your contribution.
+*   When adding content, please consider if it is widely valuable. Please don't add references or links to things you or
+    your employer have created as others will do so if they appreciate it.
+*   When reporting a vulnerability on the software, please, put in contact with STH Comet repository maintainers in order to discuss it 
+    in a private way.
 
 ## Overview
 

--- a/lib/database/model/sthDatabaseNameCodecTool.js
+++ b/lib/database/model/sthDatabaseNameCodecTool.js
@@ -438,35 +438,6 @@ function copyDatabase(options, databaseName, callback) {
 }
 
 /**
- *  Move collections from one Database to another, deleting previous DB
- * 
- * @param {Mongo database}  db 
- * @param {string}          sourceDB 
- * @param {string}          targetDB 
- * @param {boolean}         dropSource 
- * @param {callback}        callback 
- 
-var cloneDatabse = function (db, sourceDB, targetDB, dropSource, callback) {
-    listCollections(db.db(sourceDB), function(results){
-        results.forEach(collection => {
-            var source = sourceDB + "." + collection.name;
-            var destination = targetDB + "." + collection.name;
-            db.command({'renameCollection': source, 
-                        'to': destination, 
-                        'dropTarget': true
-                        },
-                        function(err, results) {
-                        });
-            // No needed to drop DB
-                        
-        });
-        callback();
-    });
-
-};
-*/
-
-/**
  * Encodes or decodes the name of certain database and its collections
  * @param {Object}    options      An object including the following properties:
  *                                 - {Boolean} encode     Flag indicating if the request is about a codification process

--- a/lib/database/model/sthDatabaseNameCodecTool.js
+++ b/lib/database/model/sthDatabaseNameCodecTool.js
@@ -383,33 +383,88 @@ function encodeOrDecodeCollection(options, databaseName, collectionName, callbac
  * @param  {String}   databaseName The database name
  * @param  {Function} callback     The callback
  */
+
+// Alternative function without copydb command
 function copyDatabase(options, databaseName, callback) {
     const adminDB = sthDatabase.connection.admin();
-    const copyCommand = {
-        copydb: 1,
-        fromdb: databaseName,
-        todb: options.encode
-            ? sthDatabaseNameCodec.encodeDatabaseName(databaseName)
-            : sthDatabaseNameCodec.decodeDatabaseName(databaseName)
+    const listCommand = {
+        listCollections: 1,
+        nameOnly: 1
     };
-    adminDB.command(copyCommand, function onCopyDatabase(err) {
+    var sourceDB = databaseName;
+    var targetDB = options.encode
+        ? sthDatabaseNameCodec.encodeDatabaseName(databaseName)
+        : sthDatabaseNameCodec.decodeDatabaseName(databaseName);
+
+    const db = sthDatabase.connection.db(databaseName);
+    db.command(listCommand, function onListCollections(err, results) {
         if (err) {
             return process.nextTick(callback.bind(null, err));
         }
-        sthDatabase.connection.db(databaseName).dropDatabase(function onDropDatabase(err) {
-            if (err) {
-                return process.nextTick(callback.bind(null, err));
-            }
-            sthLogger.info(
-                sthConfig.LOGGING_CONTEXT.DB_LOG,
-                // prettier-ignore
-                (options.encode ? 'Codification' : 'Decodification') + " of database '" + databaseName +
-                    ' successfully completed.'
-            );
-            process.nextTick(callback);
+
+        var arrayCollectionRenames = [];
+        results.cursor.firstBatch.forEach((collection) => {
+            var source = sourceDB + '.' + collection.name;
+            var destination = targetDB + '.' + collection.name;
+
+            let collectionData = { source: source, destination: destination, db: adminDB };
+            arrayCollectionRenames.push(collectionData);
         });
+
+        async.map(
+            arrayCollectionRenames,
+            function(element, callback) {
+                element.db.command(
+                    { renameCollection: element.source, to: element.destination, dropTarget: true },
+                    function(err) {
+                        callback(err);
+                    }
+                );
+            },
+            function(err) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                sthLogger.info(
+                    sthConfig.LOGGING_CONTEXT.DB_LOG,
+                    // prettier-ignore
+                    (options.encode ? 'Codification' : 'Decodification') + " of database '" + databaseName +
+                        ' successfully completed.'
+                );
+                process.nextTick(callback);
+            }
+        );
     });
 }
+
+/**
+ *  Move collections from one Database to another, deleting previous DB
+ * 
+ * @param {Mongo database}  db 
+ * @param {string}          sourceDB 
+ * @param {string}          targetDB 
+ * @param {boolean}         dropSource 
+ * @param {callback}        callback 
+ 
+var cloneDatabse = function (db, sourceDB, targetDB, dropSource, callback) {
+    listCollections(db.db(sourceDB), function(results){
+        results.forEach(collection => {
+            var source = sourceDB + "." + collection.name;
+            var destination = targetDB + "." + collection.name;
+            db.command({'renameCollection': source, 
+                        'to': destination, 
+                        'dropTarget': true
+                        },
+                        function(err, results) {
+                        });
+            // No needed to drop DB
+                        
+        });
+        callback();
+    });
+
+};
+*/
 
 /**
  * Encodes or decodes the name of certain database and its collections

--- a/lib/database/model/sthDatabaseNameMapperTool.js
+++ b/lib/database/model/sthDatabaseNameMapperTool.js
@@ -387,6 +387,7 @@ function mapOrUnmapCollection(options, databaseName, collectionName, callback) {
  * @param  {String}   databaseName The database name
  * @param  {Function} callback     The callback
  */
+// Alternative function without copydb command
 function copyDatabase(options, databaseName, callback) {
     const adminDB = sthDatabase.connection.admin();
     const listCommand = {

--- a/lib/database/model/sthDatabaseNameMapperTool.js
+++ b/lib/database/model/sthDatabaseNameMapperTool.js
@@ -389,27 +389,54 @@ function mapOrUnmapCollection(options, databaseName, collectionName, callback) {
  */
 function copyDatabase(options, databaseName, callback) {
     const adminDB = sthDatabase.connection.admin();
-    const copyCommand = {
-        copydb: 1,
-        fromdb: databaseName,
-        todb: options.map
-            ? sthDatabaseNameMapper.mapDatabaseName(databaseName)
-            : sthDatabaseNameMapper.unmapDatabaseName(databaseName)
+    const listCommand = {
+        listCollections: 1,
+        nameOnly: 1
     };
-    adminDB.command(copyCommand, function onCopyDatabase(err) {
+    var sourceDB = databaseName;
+    var targetDB = options.encode
+        ? sthDatabaseNameMapper.mapDatabaseName(databaseName)
+        : sthDatabaseNameMapper.unmapDatabaseName(databaseName);
+
+    const db = sthDatabase.connection.db(databaseName);
+    db.command(listCommand, function onListCollections(err, results) {
         if (err) {
             return process.nextTick(callback.bind(null, err));
         }
-        sthDatabase.connection.db(databaseName).dropDatabase(function onDropDatabase(err) {
-            if (err) {
-                return process.nextTick(callback.bind(null, err));
-            }
-            sthLogger.info(
-                sthConfig.LOGGING_CONTEXT.DB_LOG,
-                (options.map ? 'Mapping' : 'Unmapping') + " of database '" + databaseName + "' successfully completed."
-            );
-            process.nextTick(callback);
+
+        var arrayCollectionRenames = [];
+        results.cursor.firstBatch.forEach((collection) => {
+            var source = sourceDB + '.' + collection.name;
+            var destination = targetDB + '.' + collection.name;
+
+            let collectionData = { source: source, destination: destination, db: adminDB };
+            arrayCollectionRenames.push(collectionData);
         });
+
+        async.map(
+            arrayCollectionRenames,
+            function(element, callback) {
+                element.db.command(
+                    { renameCollection: element.source, to: element.destination, dropTarget: true },
+                    function(err) {
+                        callback(err);
+                    }
+                );
+            },
+            function(err) {
+                if (err) {
+                    return process.nextTick(callback.bind(null, err));
+                }
+                sthLogger.info(
+                    sthConfig.LOGGING_CONTEXT.DB_LOG,
+                    (options.map ? 'Mapping' : 'Unmapping') +
+                        " of database '" +
+                        databaseName +
+                        "' successfully completed."
+                );
+                process.nextTick(callback);
+            }
+        );
     });
 }
 


### PR DESCRIPTION
Changed methods that use MongoBD copyDB which is deprecated in MongoDB 4.2 version. The coded was completing successfully the unit tests using MongoDB 4.2.

This PR solve Issue https://github.com/telefonicaid/fiware-sth-comet/pull/551

Additionally, some changes were done in `contribution-guidelines.md` to fix markdown linter after PR https://github.com/telefonicaid/fiware-sth-comet/pull/553