### PR TITLE
Return 500 when DB is not connected (fix for issue 570)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -9,3 +9,4 @@
     -  Add esLint using standard tamia presets
     -  Replace var with let/const
     -  Fix or disable eslint errors
+    -  Return 500 when DB is not connected

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,4 +10,4 @@
     -  Replace var with let/const
     -  Fix or disable eslint errors
 - Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption
-- Return 500 when DB is not connected
+- Return 500 when DB is not connected (#570)

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -328,7 +328,7 @@ function getCollection(params, options, callback) {
  */
 function isConnectionAlive() {
     let dbConnected = true;
-    if (db === null || !client.isConnected()) {
+    if (db === null || (client && !client.isConnected())) {
         dbConnected = false;
     }
     return dbConnected;

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -328,7 +328,7 @@ function getCollection(params, options, callback) {
  */
 function isConnectionAlive() {
     let dbConnected = true;
-    if (db === null || !db.serverConfig.isConnected()) {
+    if (db === null || !client.isConnected()) {
         dbConnected = false;
     }
     return dbConnected;

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -328,7 +328,7 @@ function getCollection(params, options, callback) {
  */
 function isConnectionAlive() {
     let dbConnected = true;
-    if (db == null || !db.serverConfig.isConnected()) {
+    if (db === null || !db.serverConfig.isConnected()) {
         dbConnected = false;
     }
     return dbConnected;

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -313,6 +313,60 @@ function getCollection(params, options, callback) {
         return process.nextTick(callback.bind(null, error));
     }
 
+    //Call fetchCollection after creating database connection if connection was not restored after database restarted
+    if (isConnectionAlive()) {
+        fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback);
+    } else {
+        reconnectDB(callback, function() {
+            fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback);
+        });
+    }
+}
+
+/**
+ * Check whether database is connected or not
+ */
+function isConnectionAlive() {
+    let dbConnected = true;
+    if (db == null || !db.serverConfig.isConnected()) {
+        dbConnected = false;
+    }
+    return dbConnected;
+}
+
+/**
+ * Reconnect to database
+ * @param {function} callback The Callback
+ * @param {function} callbackConnection The Callback
+ */
+function reconnectDB(callback, callbackConnection) {
+    connect({
+            authentication: sthConfig.DB_AUTHENTICATION,
+            dbURI: sthConfig.DB_URI,
+            replicaSet: sthConfig.REPLICA_SET,
+            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
+            poolSize: sthConfig.POOL_SIZE,
+            authSource: sthConfig.DB_AUTH_SOURCE
+        },
+        function(err) {
+            if (err) {
+                return callback(err, null);
+            }
+            callbackConnection();
+        });
+}
+ 
+/**
+ * Returns asynchronously a reference to a collection of the database
+ * @param {string} databaseName The name of the database
+ * @param {boolean} isAggregated Flag indicating if the aggregated collection is desired
+ * @param {boolean} shouldTruncate Flag indicating if the collection should be trucate in time or size
+ * @param {boolean} shouldCreate Flag indicating if the collection should be created if it does not exist
+ * @param {string} collectionName The name of the collection
+ * @param {function} callback THe callback
+ */
+function fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback){
+    
     // Switch to the right database
     const connection = client.db(databaseName);
 

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -313,7 +313,7 @@ function getCollection(params, options, callback) {
         return process.nextTick(callback.bind(null, error));
     }
 
-    //Check DB connection status 
+    //Call fetchCollection if DB is connected else raise error 500 DB is not connected
     if (isConnectionAlive()) {
         fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback);
     } else {

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -317,8 +317,10 @@ function getCollection(params, options, callback) {
     if (isConnectionAlive()) {
         fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback);
     } else {
-        reconnectDB(callback, function() {
-            fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback);
+        client.connect(function(err) {
+            if(err) {
+                return callback(err,null);
+            }
         });
     }
 }
@@ -332,28 +334,6 @@ function isConnectionAlive() {
         dbConnected = false;
     }
     return dbConnected;
-}
-
-/**
- * Reconnect to database
- * @param {function} callback The Callback
- * @param {function} callbackConnection The Callback
- */
-function reconnectDB(callback, callbackConnection) {
-    connect({
-            authentication: sthConfig.DB_AUTHENTICATION,
-            dbURI: sthConfig.DB_URI,
-            replicaSet: sthConfig.REPLICA_SET,
-            database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
-            poolSize: sthConfig.POOL_SIZE,
-            authSource: sthConfig.DB_AUTH_SOURCE
-        },
-        function(err) {
-            if (err) {
-                return callback(err, null);
-            }
-            callbackConnection();
-        });
 }
  
 /**

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -313,7 +313,7 @@ function getCollection(params, options, callback) {
         return process.nextTick(callback.bind(null, error));
     }
 
-    //Call fetchCollection after creating database connection if connection was not restored after database restarted
+    //Check DB connection status 
     if (isConnectionAlive()) {
         fetchCollection(databaseName, isAggregated, shouldTruncate, shouldCreate, collectionName, callback);
     } else {

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -89,6 +89,7 @@ function getRawData(request, reply) {
             if (request.query.count) {
                 sthServerUtils.addFiwareTotalCount(0, response);
             }
+            }
         } else {
             var rawQuery = {
                 entityId: request.params.entityId,
@@ -232,6 +233,7 @@ function getAggregatedData(request, reply) {
             );
             response = reply(ngsiPayload);
             sthServerUtils.addFiwareCorrelator(request, response);
+            }
         } else {
             var aggregatedQuery = {
                 entityId: request.params.entityId,

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -65,7 +65,7 @@ function getRawData(request, reply) {
             if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
                 sthLogger.error(request.sth.context, 'DataBase is not connected');
                 sthLogger.debug(request.sth.context, 'Responding with 500- Internal error');
-                response = reply(err);
+                response = reply(err, {statusCode:500});
             } else {
                 // The collection does not exist, reply with en empty response
                 sthLogger.warn(
@@ -209,7 +209,7 @@ function getAggregatedData(request, reply) {
             if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
                 sthLogger.error(request.sth.context, 'DataBase is not connected');
                 sthLogger.debug(request.sth.context, 'Responding with 500- Internal error');
-                response = reply(err);
+                response = reply(err, {statusCode:500});
             } else {
                 // The collection does not exist, reply with en empty response
                 sthLogger.warn(

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -62,8 +62,13 @@ function getRawData(request, reply) {
     );
     sthDatabase.getCollection(query, sthOptions, function(err, collection) {
         if (err) {
-            // The collection does not exist, reply with en empty response
-            sthLogger.warn(
+            if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
+                sthLogger.error(request.sth.context, 'DataBase is not connected');
+                sthLogger.debug(request.sth.context, 'Responding with 500- Internal error');
+                response = reply(err);
+            } else {
+                // The collection does not exist, reply with en empty response
+                sthLogger.warn(
                 request.sth.context,
                 'Error %j when getting the raw data collection for retrieval using query %j and sthOptions %j',
                 err,
@@ -200,16 +205,21 @@ function getAggregatedData(request, reply) {
     );
     sthDatabase.getCollection(query, sthOptions, function(err, collection) {
         if (err) {
-            // The collection does not exist, reply with en empty response
-            sthLogger.warn(
-                request.sth.context,
-                'Error %j when getting the aggregated data collection for retrieval' +
-                    // Overly long line.
-                    ' using query %j and options %j',
-                err,
-                query,
-                sthOptions
-            );
+            if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
+                sthLogger.error(request.sth.context, 'DataBase is not connected');
+                sthLogger.debug(request.sth.context, 'Responding with 500- Internal error');
+                response = reply(err);
+            } else {
+                // The collection does not exist, reply with en empty response
+                sthLogger.warn(
+                    request.sth.context,
+                    'Error %j when getting the aggregated data collection for retrieval' +
+                        // Overly long line.
+                        ' using query %j and options %j',
+                    err,
+                    query,
+                    sthOptions
+                );
 
             sthLogger.debug(request.sth.context, 'Responding with no points');
             const emptyResponse = sthServerUtils.getEmptyResponse();

--- a/lib/server/handlers/sthRemoveDataHandler.js
+++ b/lib/server/handlers/sthRemoveDataHandler.js
@@ -67,7 +67,7 @@ function removeDataHandler(request, reply) {
                 if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
                     sthLogger.error(request.sth.context,'Database is not connected');
                     response =  reply(err);
-                } else if (err.name === 'MongoNetworkError' && err.message.includes('does not exist. Currently in strict mode')) {
+                } else if (err.name === 'MongoError' && err.message.includes('does not exist. Currently in strict mode')) {
                     // There is no associated data for the provided service, service path and entity
                     sthLogger.debug(
                         request.sth.context,

--- a/lib/server/handlers/sthRemoveDataHandler.js
+++ b/lib/server/handlers/sthRemoveDataHandler.js
@@ -66,7 +66,7 @@ function removeDataHandler(request, reply) {
             if (err) {
                 if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
                     sthLogger.error(request.sth.context,'Database is not connected');
-                    response =  reply(err);
+                    response =  reply(err, {statusCode:500});
                 } else if (err.name === 'MongoError' && err.message.includes('does not exist. Currently in strict mode')) {
                     // There is no associated data for the provided service, service path and entity
                     sthLogger.debug(

--- a/lib/server/handlers/sthRemoveDataHandler.js
+++ b/lib/server/handlers/sthRemoveDataHandler.js
@@ -64,7 +64,10 @@ function removeDataHandler(request, reply) {
         },
         function(err) {
             if (err) {
-                if (err.name === 'MongoError' && err.message.indexOf('does not exist. Currently in strict mode')) {
+                if(err.name === 'MongoNetworkError' && err.message.includes('failed to connect to server')){
+                    sthLogger.error(request.sth.context,'Database is not connected');
+                    response =  reply(err);
+                } else if (err.name === 'MongoNetworkError' && err.message.includes('does not exist. Currently in strict mode')) {
                     // There is no associated data for the provided service, service path and entity
                     sthLogger.debug(
                         request.sth.context,

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -273,6 +273,50 @@ function collectionAccessTests() {
 }
 
 /**
+ * Tests to check that the access to the collections works as expected after reconnect with DB
+ */
+function collectionAccessReconnectTests() {
+    const ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
+    const dataTypes = Object.keys(sthTestConfig.DATA_TYPES);
+    const dataModels = Object.keys(sthConfig.DATA_MODELS);
+
+    dataModels.forEach(function(dataModel) {
+        describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
+            before(function() {
+                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
+            });
+
+            dataTypes.forEach(function(dataType) {
+                //prettier-ignore
+                it('should notify as error a non-existent ' + sthTestConfig.DATA_TYPES[dataType] + 
+                    ' data collection if it should not be created',
+                    function(done) {
+                        sthDatabase.getCollection(
+                            COLLECTION_NAME_PARAMS,
+                            {
+                                shouldCreate: true,
+                                isAggregated:
+                                    sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
+                                shouldTruncate: false
+                            },
+                            function(err, collection) {
+                                expect(err).to.be(null);
+                                expect(collection).to.be.ok();
+                                return done();
+                            }
+                        );
+                    }
+                );
+            });
+
+            after(function() {
+                sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
+            });
+        });
+    });
+}
+
+/**
  * Returns the aggregated entry or point for certain offset
  * @param {Array} points The array of points
  * @param {Number} offset The offset
@@ -1191,6 +1235,14 @@ describe('sthDatabase tests', function() {
             });
 
             describe('access', collectionAccessTests);
+        });
+        
+        describe('collection access reconnect', function() {
+            before(function(done) {
+                sthDatabase.closeConnection(done);
+            });
+
+            describe('access', collectionAccessReconnectTests);
         });
     });
 

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -123,7 +123,7 @@ function connectToDatabase(callback) {
  */
 function CheckDatabaseStatus() {
     let client;
-    if (!client.isConnected())) {
+    if (!client.isConnected()) {
         client.connect(function(err) { 
             expect(err).to.have.status(500);
             expect(err.message).to.include('DataBase is not connected');
@@ -1212,7 +1212,7 @@ describe('sthDatabase tests', function() {
             });
         });
     });
-    
+
     describe('storage and retrieval', function() {
         before(function(done) {
             connectToDatabase(done);

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -123,7 +123,7 @@ function connectToDatabase(callback) {
  */
 function CheckDatabaseStatus() {
     let client;
-    if (db===null || (client && !client.isConnected())) {
+    if (!client.isConnected())) {
         client.connect(function(err) { 
             expect(err).to.have.status(500);
             expect(err.message).to.include('DataBase is not connected');

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -1196,7 +1196,7 @@ describe('sthDatabase tests', function() {
         });
         describe('When the database is not connected', function() {
             before(function(done) {
-                sth.sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function(err, server) {
+                sth.sthServer.startServer(sthConfig.STH_HOST, sthConfig.STH_PORT, function() {
                     sthDatabase.closeConnection(function() {
                         done();
                     });
@@ -1218,11 +1218,9 @@ describe('sthDatabase tests', function() {
                             'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
                         }
                     },
-                    function(err, response, body) {
-                        console.log(body);
-                        console.log('statusCode:', response && response.statusCode);
-                        //console.log(err);
-                        expect(response.statusCode).to.equal(500);
+                    function(err) {
+                        expect(err).to.have.status(500);
+                        expect(err.message).to.include('DataBase is not connected');
                         done();
                     }
                 );

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -1205,9 +1205,8 @@ describe('sthDatabase tests', function() {
 
             describe('access', collectionAccessTests);
         });
-    });
- 
-    describe('collection access', function() {
+        
+        describe('collection access', function() {
             before(function(done) {
                 CheckDatabaseStatus(done);
             });

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -119,6 +119,18 @@ function connectToDatabase(callback) {
 }
 
 /**
+ * Check DB status and return error 500 if DB is not connected
+ */
+function CheckDatabaseStatus(callback) {
+    if (!client.isConnected()) {
+        client.connect(function(err) { 
+            expect(err).to.have.status(500);
+            expect(err.message).to.include('DataBase is not connected');
+        });
+    }
+}
+
+/**
  * Drops a database collection for the provided data type and model asynchronously
  * @param  {object}   collectionNameParams The collection name params
  * @param  {string}   dataType             The data type
@@ -258,50 +270,6 @@ function collectionAccessTests() {
                             function(err, collection) {
                                 expect(err).to.be(null);
                                 expect(collection).to.be.ok();
-                                return done();
-                            }
-                        );
-                    }
-                );
-            });
-
-            after(function() {
-                sthConfig.DATA_MODEL = ORIGINAL_DATA_MODEL;
-            });
-        });
-    });
-}
-
-/**
- * Tests to check that the access to the collections works as expected after reconnect with DB
- */
-function collectionAccessReconnectTests() {
-    const ORIGINAL_DATA_MODEL = sthConfig.DATA_MODEL;
-    const dataTypes = Object.keys(sthTestConfig.DATA_TYPES);
-    const dataModels = Object.keys(sthConfig.DATA_MODELS);
-
-    dataModels.forEach(function(dataModel) {
-        describe(sthConfig.DATA_MODELS[dataModel] + ' data model', function() {
-            before(function() {
-                sthConfig.DATA_MODEL = sthConfig.DATA_MODELS[dataModel];
-            });
-
-            dataTypes.forEach(function(dataType) {
-                //prettier-ignore
-                it('should notify as error a non-existent ' + sthTestConfig.DATA_TYPES[dataType] + 
-                    ' data collection if it should not be created',
-                    function(done) {
-                        !sthDatabase.connect(
-                            COLLECTION_NAME_PARAMS,
-                            {
-                                shouldCreate: true,
-                                isAggregated:
-                                    sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
-                                shouldTruncate: false
-                            },
-                            function(err) {
-                                expect(err).to.have.status(500);
-                                expect(err).to.include('DataBase is not connected');
                                 return done();
                             }
                         );
@@ -1235,14 +1203,6 @@ describe('sthDatabase tests', function() {
             });
 
             describe('access', collectionAccessTests);
-        });
-        
-        describe('collection access reconnect', function() {
-            before(function(done) {
-                sthDatabase.closeConnection(done);
-            });
-
-            describe('access', collectionAccessReconnectTests);
         });
     });
 

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -299,9 +299,9 @@ function collectionAccessReconnectTests() {
                                     sthTestConfig.DATA_TYPES[dataType] === sthTestConfig.DATA_TYPES.AGGREGATED,
                                 shouldTruncate: false
                             },
-                            function(err, collection) {
+                            function(err) {
                                 expect(err).to.have.status(500);
-                                expect(collection).to.include('DataBase is not connected');
+                                expect(err).to.include('DataBase is not connected');
                                 return done();
                             }
                         );

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -300,8 +300,8 @@ function collectionAccessReconnectTests() {
                                 shouldTruncate: false
                             },
                             function(err, collection) {
-                                expect(err).to.be(null);
-                                expect(collection).to.be.ok();
+                                expect(err).to.have.status(500);
+                                expect(collection).to.include('DataBase is not connected');
                                 return done();
                             }
                         );

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -123,7 +123,7 @@ function connectToDatabase(callback) {
  */
 function CheckDatabaseStatus() {
     let client;
-    if (db===null || (client && !client.isConnected()) {
+    if (db===null || (client && !client.isConnected())) {
         client.connect(function(err) { 
             expect(err).to.have.status(500);
             expect(err.message).to.include('DataBase is not connected');

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -1143,7 +1143,7 @@ describe('return 500 test', function() {
                     isAggregated: false,
                     shouldCreate: true,
                     shouldTruncate: true
-                }  
+                },  
                 function(err, response) {
                 expect(err.name).to.equal('MongoNetworkError');
                 expect(response.statusCode).to.equal(500);
@@ -1233,7 +1233,7 @@ describe('sthDatabase tests', function() {
             describe('access', collectionAccessTests);
          });
     });
-    
+
     describe('storage and retrieval', function() {
         before(function(done) {
             connectToDatabase(done);

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -121,14 +121,15 @@ function connectToDatabase(callback) {
 /**
  * Check DB status and return error 500 if DB is not connected
  */
-function CheckDatabaseStatus() {
+function checkDatabaseStatus() {
     let client;
-    if (!client.isConnected()) {
-        client.connect(function(err) { 
-            expect(err).to.have.status(500);
-            expect(err.message).to.include('DataBase is not connected');
-        });
+    if (client.isConnected()) {
+        client.close()
     }
+    client.connect(function(err) { 
+        expect(err).to.have.status(500);
+        expect(err.message).to.include('DataBase is not connected');
+    });
 }
 
 /**
@@ -1206,9 +1207,9 @@ describe('sthDatabase tests', function() {
             describe('access', collectionAccessTests);
         });
         
-        describe('collection access', function() {
+        describe('database not connected', function() {
             before(function(done) {
-                CheckDatabaseStatus(done);
+                checkDatabaseStatus(done);
             });
         });
     });

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -33,7 +33,6 @@ const sthTestConfig = require(ROOT_PATH + '/test/unit/sthTestConfiguration');
 const expect = require('expect.js');
 const _ = require('lodash');
 const request = require('request');
-const sthTestHelper = require(ROOT_PATH + '/test/unit/sthTestUtils.js');
 const sth = require(ROOT_PATH + '/lib/sth');
 
 const DATABASE_NAME = sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE);
@@ -1204,7 +1203,7 @@ describe('sthDatabase tests', function() {
                 });
             });
             it('should return 500', function(done) {
-                let url_sth =
+                let urlSth =
                     'http://' +
                     sthConfig.STH_HOST +
                     ':' +
@@ -1212,7 +1211,7 @@ describe('sthDatabase tests', function() {
                     '/STH/v2/entities/entityId/attrs/attrName?type=entityType&lastN=1';
                 request(
                     {
-                        uri: url_sth,
+                        uri: urlSth,
                         method: 'GET',
                         headers: {
                             'Fiware-Service': sthConfig.DEFAULT_SERVICE,

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -26,12 +26,16 @@
 const ROOT_PATH = require('app-root-path');
 const sthDatabase = require(ROOT_PATH + '/lib/database/sthDatabase');
 const sthDatabaseNameCodec = require(ROOT_PATH + '/lib/database/model/sthDatabaseNameCodec');
+const sthGetDataHandler = require(ROOT_PATH + '/lib/server/handlers/sthGetDataHandler');
+const sthRemoveDataHandler = require(ROOT_PATH + '/lib/server/handlers/sthRemoveDataHandler');
+const sthTestUtils = require(ROOT_PATH + '/test/unit/sthTestUtils.js');
 const sthDatabaseNaming = require(ROOT_PATH + '/lib/database/model/sthDatabaseNaming');
 const sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
 const sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils');
 const sthTestConfig = require(ROOT_PATH + '/test/unit/sthTestConfiguration');
 const expect = require('expect.js');
 const _ = require('lodash');
+const INVALID_HOST = 'localhosttest';
 
 const DATABASE_NAME = sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE);
 const DATABASE_CONNECTION_PARAMS = {
@@ -79,6 +83,22 @@ const VERY_LONG_COLLECTION_NAME_PARAMS = {
     entityType: sthTestConfig.ENTITY_TYPE,
     attrName: sthTestConfig.ATTRIBUTE_NAME,
     attrType: sthTestConfig.ATTRIBUTE_TYPE
+};
+const GET_AND_REMOVE_HANDLER_QUERY = {
+    lastN: sthTestConfig.MIN_VALUE,
+    hLimit: sthTestConfig.MIN_VALUE,
+    hOffset: sthTestConfig.MIN_VALUE,
+    filetype: 'csv'
+};
+const GET_AND_REMOVE_HANDLER_REQUEST = {
+    uri: sthTestUtils.getURL(sthTestConfig.API_OPERATION.READ),
+    method: 'GET',
+    query: GET_AND_REMOVE_HANDLER_QUERY,
+    params: COLLECTION_NAME_PARAMS,
+    headers: {
+        'Fiware-Service': sthConfig.DEFAULT_SERVICE,
+        'Fiware-ServicePath': sthConfig.DEFAULT_SERVICE_PATH
+    }
 };
 const DATE = new Date(Date.UTC(1970, 1, 3, 4, 5, 6, 777));
 const DELAY = 100;
@@ -1135,21 +1155,29 @@ describe('return 500 test', function() {
                 done();
             });
         });
-        
-        it('should return error 500', function(done) {
-            sthDatabase.getCollection(
-                COLLECTION_NAME_PARAMS,
-                {
-                    isAggregated: false,
-                    shouldCreate: true,
-                    shouldTruncate: true
-                },  
-                function(err, response) {
+
+        it('should return error 500 from get request', function(done) {
+            const url = { url: { path: sthConfig.DEFAULT_SERVICE_PATH } };
+            const req = { ...GET_AND_REMOVE_HANDLER_REQUEST, ...url };
+            sthDatabase.client.s.options.servers[0].host = INVALID_HOST;
+
+            sthGetDataHandler(req, function(err, response) {
                 expect(err.name).to.equal('MongoNetworkError');
                 expect(response.statusCode).to.equal(500);
-                done(err);
-                }
-            );
+                done();
+            });
+        });
+
+        it('should return error 500 from remove request', function(done) {
+            const url = { url: { path: sthConfig.DEFAULT_SERVICE_PATH } };
+            const req = { ...GET_AND_REMOVE_HANDLER_REQUEST, ...url };
+            sthDatabase.client.s.options.servers[0].host = INVALID_HOST;
+
+            sthRemoveDataHandler(req, function(err, response) {
+                expect(err.name).to.equal('MongoNetworkError');
+                expect(response.statusCode).to.equal(500);
+                done();
+            });
         });
     });
 });

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -291,7 +291,7 @@ function collectionAccessReconnectTests() {
                 it('should notify as error a non-existent ' + sthTestConfig.DATA_TYPES[dataType] + 
                     ' data collection if it should not be created',
                     function(done) {
-                        sthDatabase.getCollection(
+                        !sthDatabase.connect(
                             COLLECTION_NAME_PARAMS,
                             {
                                 shouldCreate: true,

--- a/test/unit/sthDatabase_test.js
+++ b/test/unit/sthDatabase_test.js
@@ -121,8 +121,9 @@ function connectToDatabase(callback) {
 /**
  * Check DB status and return error 500 if DB is not connected
  */
-function CheckDatabaseStatus(callback) {
-    if (!client.isConnected()) {
+function CheckDatabaseStatus() {
+    let client;
+    if (db===null || (client && !client.isConnected()) {
         client.connect(function(err) { 
             expect(err).to.have.status(500);
             expect(err.message).to.include('DataBase is not connected');
@@ -1205,7 +1206,14 @@ describe('sthDatabase tests', function() {
             describe('access', collectionAccessTests);
         });
     });
-
+ 
+    describe('collection access', function() {
+            before(function(done) {
+                CheckDatabaseStatus(done);
+            });
+        });
+    });
+    
     describe('storage and retrieval', function() {
         before(function(done) {
             connectToDatabase(done);


### PR DESCRIPTION
This PR fixes the issue : https://github.com/telefonicaid/fiware-sth-comet/issues/570

If database is not connected and any API will be requested then it will return "500 internal server error" and in logs it will display "database is not connected"