### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -9,3 +9,4 @@
     -  Add esLint using standard tamia presets
     -  Replace var with let/const
     -  Fix or disable eslint errors
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "joi": "14.0.6",
     "json-csv": "1.5.0",
     "lodash": "~4.17.5",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "mkdirp": "~0.5.1",
     "mongodb": "~3.6.12",
     "object-assign": "~4.1.0",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/
