### PR TITLE
FIX add node v14 to GitActions utests and remove node v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
         node-version:
           - 12.x
           - 14.x
-          - 16.x
+          # FIXME: it seems problems with mongodb driver version preclude using Node 16+
+          # see details at https://github.com/telefonicaid/fiware-sth-comet/pull/580#issuecomment-1160353123
+          #- 16.x
+          #- 18.x 
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
+          - 14.x
+          - 16.x
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Some previous things need to be done before merging:

- [x] Release a new version
- [x] Step Dockerfile to a node version >10
- [x] Analyze the problems in Node v16 test execution - the problem could be related with mongodb driver. By the moment we comment the entry and leave a FIXME comment
