### PR TITLE
Fixed undefined value of reconnectTries and reconnectInterval

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,4 +11,3 @@
     -  Fix or disable eslint errors
 - Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption
 - Add: graceful shutdown listening to SIGTERM and SIGHUP signals (#576)
-- Add config (reconnectTries, reconnectInterval) to allow mongo driver reconnect (#559)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,4 +11,4 @@
     -  Fix or disable eslint errors
 - Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption
 - Add: graceful shutdown listening to SIGTERM and SIGHUP signals (#576)
-- Fixed undefined value of reconnectTries and reconnectInterval
+- Add config (reconnectTries, reconnectInterval) to allow mongo driver reconnect (#559)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -9,3 +9,4 @@
     -  Add esLint using standard tamia presets
     -  Replace var with let/const
     -  Fix or disable eslint errors
+- Fixed undefined value of reconnectTries and reconnectInterval

--- a/lib/sth.js
+++ b/lib/sth.js
@@ -101,7 +101,9 @@ function startup(callback) {
             replicaSet: sthConfig.REPLICA_SET,
             database: sthDatabaseNaming.getDatabaseName(sthConfig.DEFAULT_SERVICE),
             poolSize: sthConfig.POOL_SIZE,
-            authSource: sthConfig.DB_AUTH_SOURCE
+            authSource: sthConfig.DB_AUTH_SOURCE,
+            reconnectTries: sthConfig.RECONNECT_TRIES,
+            reconnectInterval: sthConfig.RECONNECT_INTERVAL
         },
         function(err) {
             if (err) {


### PR DESCRIPTION
This PR is related to PR:https://github.com/telefonicaid/fiware-sth-comet/pull/565. While debugging it is found that the values of `reconnectTries` and `reconnectInterval` is "undefined" in MongoClient.connect( ) (https://github.com/telefonicaid/fiware-sth-comet/blob/master/lib/database/sthDatabase.js#L110-L111).

The `reconnectTries` and `reconnectInterval` parameters where missed here: https://github.com/telefonicaid/fiware-sth-comet/blob/master/lib/sth.js#L97-L105.