### PR TITLE
Add webhook bash script

### DIFF
--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -13,6 +13,7 @@ function clone {
    echo 'cloning from '"$1 $2"' to '"$3"
    docker pull -q "$1":"$2"
    docker tag "$1":"$2" "$3":"$2"
+   docker push -q "$3":"$2"
    
    if ! [ -z "$4" ]; then
         echo 'pushing '"$1 $2"' to latest'

--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -31,3 +31,9 @@ for i in "$@" ; do
     fi
     echo ""
 done
+
+for i in "$@" ; do
+    if [[ $i == "clean" ]]; then
+        docker rmi -f $(docker images -a -q) | true
+    fi
+done

--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -1,0 +1,32 @@
+set -e
+
+SOURCE="telefonicaiot/fiware-sth-comet"
+DOCKER_TARGET="fiware/sth-comet"
+QUAY_TARGET="quay.io/fiware/sth-comet"
+
+# DOCKER_TARGET="fiware/$(basename $(git rev-parse --show-toplevel))"
+# QUAY_TARGET="quay.io/fiware/$(basename $(git rev-parse --show-toplevel))"
+
+VERSION=$(git describe --exclude 'FIWARE*' --tags $(git rev-list --tags --max-count=1))
+
+function clone {
+   echo 'cloning from '"$1 $2"' to '"$3"
+   docker pull -q "$1":"$2"
+   docker tag "$1":"$2" "$3":"$2"
+   
+   if ! [ -z "$4" ]; then
+        echo 'pushing '"$1 $2"' to latest'
+        docker tag "$1":"$2" "$3":latest
+        docker push -q "$3":latest
+   fi
+}
+
+for i in "$@" ; do
+    if [[ $i == "docker" ]]; then
+        clone "$SOURCE" "$VERSION" "$DOCKER_TARGET" true
+    fi
+    if [[ $i == "quay" ]]; then
+        clone "$SOURCE" "$VERSION" "$QUAY_TARGET" true
+    fi
+    echo ""
+done


### PR DESCRIPTION
As discussed within the TSC, FIWARE Foundation need to be able to create clones of the container image on both Docker Hub and quay.io - this PR allows us to continue to track your latest container images, a functionality which has been removed from the free tier on Docker Hub.