### PR TITLE
[WIP] Update ci.yml to mongo 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:4.4
+        image: mongo:5.0
         ports:
         - 27017:27017
     strategy:


### PR DESCRIPTION


https://www.mongodb.com/docs/drivers/node/current/compatibility/

it seems that 3.6 mongo driver for nodejs is not compatible with new features for mongo 5.0 and 6.0, but it will work.
WIth mongo 7.0 driver 3.6 has not been tested, but seeing this PR it seems that not works!
