### PR TITLE
Add CORS_ENABLED env var for docker-compose

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-- Add CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image
+- Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
+- Add: CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image (#608)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
+- Add CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-- Add CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image
+- Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
+- Add: CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image

--- a/doc/manuals/running.md
+++ b/doc/manuals/running.md
@@ -101,6 +101,7 @@ The environment variables accepted by the script (for which there exists counter
 -   `PROOF_OF_LIFE_INTERVAL`: The time in seconds between proof of life logging messages informing that the server is up
     and running normally. Default value: "60". `PROCESSED_REQUEST_LOG_STATISTICS_INTERVAL`: The time in seconds between
     processed requests statistics appear in the logs. Default value: "60".
+-   `CORS_ENABLED`: Boolean attribute (`true`|`false`) to enable cors configuration. Optional. Default value: "false".
 
 For example, to start the STH server listening on port 7777, connecting to a MongoDB instance listening on
 mymongo.com:27777 and without filtering out the empty results, use:

--- a/lib/configuration/sthConfiguration.js
+++ b/lib/configuration/sthConfiguration.js
@@ -223,7 +223,10 @@ if (ENV.STH_PORT && !isNaN(ENV.STH_PORT)) {
     );
 }
 
-if (config && config.cors && config.cors.enabled) {
+if (ENV.CORS_ENABLED && !isNull(ENV.CORS_ENABLED)) {
+    module.exports.corsEnabled = JSON.parse(ENV.CORS_ENABLED);
+    sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'CORS value set to: ' + module.exports.corsEnabled);
+} else if (config && config.cors && config.cors.enabled) {
     module.exports.corsEnabled = JSON.parse(config.cors.enabled);
     sthLogger.info(module.exports.LOGGING_CONTEXT.STARTUP, 'CORS value set to: ' + module.exports.corsEnabled);
 } else {


### PR DESCRIPTION
Added the CORS_ENABLED environment variable as described in the issue [608](https://github.com/telefonicaid/fiware-sth-comet/issues/608).
Please, check where it is necessary to update the doc (i.e. https://github.com/telefonicaid/fiware-sth-comet/blob/master/doc/manuals/running.md) to add this new env var. 
A usage can be:
```
  sth-comet:
    image: fiware/sth-comet:${STH_COMET_VERSION}
    hostname: sth-comet
    container_name: fiware-sth-comet
    restart: always
    depends_on:
      - database-mongo
    networks:
      - monitoring-net
    ports:
      - ${STH_COMET_PORT}:${STH_COMET_PORT}
    environment:
      - STH_HOST=0.0.0.0
      - STH_PORT=${STH_COMET_PORT}
      - DB_PREFIX=sth_
      - DB_URI=database-mongo:${MONGO_DB_PORT}
      - LOGOPS_LEVEL=INFO
      - CORS_ENABLED=true
```
I don't know if it can be included in the test scripts, I only changed the [sthConfiguration.js](https://github.com/telefonicaid/fiware-sth-comet/blob/master/lib/configuration/sthConfiguration.js#L226) file in the lib/configuration folder.