### PR TITLE
Fixed to use truncation expire

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+- Fix: Updated isAggregated() to fix truncation expire (#606)
 - Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
 - Add: CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image (#608)

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -220,7 +220,7 @@ function isAggregated(collectionName) {
 function setTTLPolicy(collection) {
     // Set the TTL policy if required
     if (sthConfig.TRUNCATION_EXPIRE_AFTER_SECONDS > 0) {
-        if (!isAggregated(collection)) {
+        if (!isAggregated(collection.collectionName)) {
             if (sthConfig.TRUNCATION_SIZE === 0) {
                 collection.ensureIndex(
                     {


### PR DESCRIPTION
Fixes #606 .
isAggregated() function needs collectionName as it's argument [here](https://github.com/telefonicaid/fiware-sth-comet/blob/master/lib/database/sthDatabase.js#L206). But collection is provided to isAggregated() inside setTTLPolicy() function. Hence, isAggregated() function is not working properly. 