### PR TITLE
FIX CHANGES_NEXT_RELEASE

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- Fix: Updated isAggregated() to fix truncation expire (#606)
+- Fix: TRUNCATION_EXPIRE_AFTER_SECONDS functionality (#606)
 - Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
 - Add: CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image (#608)


### PR DESCRIPTION
I think this is a better alternative to CNR entry than the one used in PR https://github.com/telefonicaid/fiware-sth-comet/pull/626 as it is more "user centric".