### PR TITLE
Fix/ensure nameOnly mongo db flag is  boolean

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: ensure nameOnly flag of mongoDB is boolean
+- Fix: the way in which list collection is done at MongoDB (ensure¡ing nameOnly flag is boolean) so STH can support MongoDB 5.0+ versions
 - Fix: TRUNCATION_EXPIRE_AFTER_SECONDS functionality (#606)
 - Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
 - Add: CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image (#608)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: ensure nameOnly flag of mongoDB is boolean
 - Fix: TRUNCATION_EXPIRE_AFTER_SECONDS functionality (#606)
 - Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)
 - Add: CORS_ENABLED env var (boolean) to enable the cors configuration (of config.js file) in your docker image (#608)

--- a/lib/database/model/sthDatabaseNameCodecTool.js
+++ b/lib/database/model/sthDatabaseNameCodecTool.js
@@ -389,7 +389,7 @@ function copyDatabase(options, databaseName, callback) {
     const adminDB = sthDatabase.connection.admin();
     const listCommand = {
         listCollections: 1,
-        nameOnly: 1
+        nameOnly: true
     };
     var sourceDB = databaseName;
     var targetDB = options.encode

--- a/lib/database/model/sthDatabaseNameMapperTool.js
+++ b/lib/database/model/sthDatabaseNameMapperTool.js
@@ -392,7 +392,7 @@ function copyDatabase(options, databaseName, callback) {
     const adminDB = sthDatabase.connection.admin();
     const listCommand = {
         listCollections: 1,
-        nameOnly: 1
+        nameOnly: true
     };
     var sourceDB = databaseName;
     var targetDB = options.encode


### PR DESCRIPTION
MongoDB 5.0 tests and upper are failing due to nameOnly is of type Integer instead of boolean


https://www.mongodb.com/docs/manual/reference/command/listCollections/


This PR enables https://github.com/telefonicaid/fiware-sth-comet/pull/615